### PR TITLE
Fix some UB bugs, causing crashes

### DIFF
--- a/ZAP2/Main.cpp
+++ b/ZAP2/Main.cpp
@@ -107,6 +107,8 @@ int NewMain(int argc, char* argv[])
 		string source = overlay->GetSourceOutputCode("");
 		File::WriteAllText(Globals::Instance->outputPath, source);
 	}
+
+	return 0;
 }
 
 int OldMain(int argc, char* argv[])
@@ -207,6 +209,7 @@ bool Parse(string xmlFilePath, string basePath, string outPath, ZFileMode fileMo
 	if (element == nullptr)
 		return false;
 
+	return true;
 }
 
 void BuildAssetTexture(string pngFilePath, TextureType texType, string outPath)

--- a/ZAP2/ZFile.cpp
+++ b/ZAP2/ZFile.cpp
@@ -151,8 +151,6 @@ void ZFile::ExtractResources(string outputDir)
 
 void ZFile::GenerateSourceFiles(string outputDir)
 {
-	char* buffer = new char[1024 * 1024];
-
 	sourceOutput = "";
 
 	sourceOutput += "#include <ultra64.h>\n";
@@ -177,6 +175,4 @@ void ZFile::GenerateSourceFiles(string outputDir)
 	}
 
 	File::WriteAllText(outputDir + "/" + Path::GetFileNameWithoutExtension(name) + ".h", sourceOutput);
-
-	delete buffer;
 }


### PR DESCRIPTION
Fixes
```python3 extract_assets.py
tools/ZAP2/ZAP2.out e assets/textures/xml/icon_item_24_static.xml baserom/ assets/textures/icon_item_24_static 1
double free or corruption (fasttop)
Aborted (core dumped)
tools/ZAP2/ZAP2.out e assets/textures/xml/icon_item_dungeon_static.xml baserom/ assets/textures/icon_item_dungeon_static 1
double free or corruption (fasttop)
Aborted (core dumped)```