### PR TITLE
Added Makefile machinery for ccache support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,4 @@ ASALocalRun/
 
 *.out
 *.o
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
 CC := g++
+
+ifneq (, $(shell which ccache))
+CC := ccache $(CC)
+endif
+
 CFLAGS := -g -std=c++17 -I ZAP2 -O2 -rdynamic
 
 SRC_DIRS := ZAP2 ZAP2/ZRoom ZAP2/ZRoom/Commands ZAP2/Overlays ZAP2/HighLevel ZAP2/OpenFBX


### PR DESCRIPTION
This PR changes the Makefile so that ccache will be used if it's available. This will greatly improve compilation time of ZAP2 on systems which repeatedly need to build it (Jenkins) since results for identical files are cached and re-used.