### PR TITLE
ZAP project files now use correct relative paths to include headers.

### DIFF
--- a/ZAP2/ZAP2.vcxproj
+++ b/ZAP2/ZAP2.vcxproj
@@ -70,7 +70,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>C:\Users\Jack\Documents\GitHub\ZAP2\ZAP2\sqlite;C:\Users\Jack\Documents\GitHub\ZAP2\ZAP2\;$(IncludePath)</IncludePath>
+    <IncludePath>$(ProjectDir)/sqlite;$(ProjectDir);$(IncludePath)</IncludePath>
     <LibraryPath>$(ProjectDir)Libs;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -257,6 +257,11 @@
     <Text Include="..\SymbolMap_OoTMqDbg.txt">
       <DeploymentContent>true</DeploymentContent>
     </Text>
+  </ItemGroup>
+  <ItemGroup>
+    <CopyFileToFolders Include="Libs\assimp-vc142-mt.dll">
+      <FileType>Document</FileType>
+    </CopyFileToFolders>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/ZAP2/ZAP2.vcxproj.filters
+++ b/ZAP2/ZAP2.vcxproj.filters
@@ -416,4 +416,9 @@
       <Filter>Resource Files</Filter>
     </Text>
   </ItemGroup>
+  <ItemGroup>
+    <CopyFileToFolders Include="Libs\assimp-vc142-mt.dll">
+      <Filter>Resource Files</Filter>
+    </CopyFileToFolders>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Additionally, ASSIMP DLL file should now copy to the build directory.