### PR TITLE
Many fixes to sync generated files with the oot codebase style

### DIFF
--- a/ZAPD/HighLevel/HLModelIntermediette.cpp
+++ b/ZAPD/HighLevel/HLModelIntermediette.cpp
@@ -472,7 +472,7 @@ string HLVerticesIntermediette::OutputCode(HLModelIntermediette* parent)
 {
 	string output = "";
 
-	output += StringHelper::Sprintf("Vtx_t %s_verts[] = \n{\n", name.c_str());
+	output += StringHelper::Sprintf("Vtx %s_verts[] = \n{\n", name.c_str());
 
 	for (Vertex v : vertices)
 	{

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -79,13 +79,13 @@ string ZAnimation::GetSourceOutputCode(string prefix)
 {
 	if (parent != nullptr)
 	{
-		string headerStr = StringHelper::Sprintf("%i, %s_values, %s_indices, %i",
+		string headerStr = StringHelper::Sprintf("%i, %sFrameData, %sJointIndicies, %i",
 			frameCount, name.c_str(), name.c_str(), limit);
 		parent->declarations[rawDataIndex] = new Declaration(DeclarationAlignment::None, 16, "AnimationHeader", StringHelper::Sprintf("%s", name.c_str()), false, headerStr);
 
 		string indicesStr = "";
-		string valuesStr = "\t";
-		const int lineLength = 15;
+		string valuesStr = "    ";
+		const int lineLength = 14;
 		const int offset = 0;
 
 		for (int i = 0; i < rotationValues.size(); i++)
@@ -93,17 +93,22 @@ string ZAnimation::GetSourceOutputCode(string prefix)
 			valuesStr += StringHelper::Sprintf("0x%04X, ", rotationValues[i]);
 
 			if ((i - offset + 1) % lineLength == 0)
-				valuesStr += "\n\t";
+				valuesStr += "\n    ";
 		}
 
 		for (int i = 0; i < rotationIndices.size(); i++)
-			indicesStr += StringHelper::Sprintf("\t{ 0x%04X, 0x%04X, 0x%04X },\n", rotationIndices[i].x, rotationIndices[i].y, rotationIndices[i].z);
+		{
+			indicesStr += StringHelper::Sprintf("    { 0x%04X, 0x%04X, 0x%04X },", rotationIndices[i].x, rotationIndices[i].y, rotationIndices[i].z);
+
+			if (i != (rotationIndices.size() - 1))
+				indicesStr += "\n";
+		}
 
 		parent->AddDeclarationArray(rotationValuesSeg, DeclarationAlignment::Align16, (int)rotationValues.size() * 2, "s16",
-			StringHelper::Sprintf("%s_values", name.c_str()), rotationValues.size(), valuesStr);
+			StringHelper::Sprintf("%sFrameData", name.c_str()), rotationValues.size(), valuesStr);
 
 		parent->AddDeclarationArray(rotationIndicesSeg, DeclarationAlignment::Align16, (int)rotationIndices.size() * 6, "JointIndex",
-			StringHelper::Sprintf("%s_indices", name.c_str()), rotationIndices.size(), indicesStr);
+			StringHelper::Sprintf("%sJointIndicies", name.c_str()), rotationIndices.size(), indicesStr);
 	}
 
 	return "";

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -122,13 +122,13 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, std::string prefix, std::vecto
 
 		for (int i = 0; i < vertices.size(); i++)
 		{
-			sprintf(line, "\t{ %i, %i, %i }, // 0x%08X\n", vertices[i]->x, vertices[i]->y, vertices[i]->z, vtxSegmentOffset + (i * 6));
+			sprintf(line, "{ %i, %i, %i }, // 0x%08X\n", vertices[i]->x, vertices[i]->y, vertices[i]->z, vtxSegmentOffset + (i * 6));
 			declaration += line;
 		}
 
 		if (vtxSegmentOffset != 0)
 			parent->declarations[vtxSegmentOffset] = new Declaration(DeclarationAlignment::None, vertices.size() * 6,
-				"Vec3s", StringHelper::Sprintf("%s_vertices_%08X", prefix.c_str(), vtxSegmentOffset), true, declaration);
+				"Vec3s", StringHelper::Sprintf("%s_vtx_%08X", prefix.c_str(), vtxSegmentOffset), true, declaration);
 
 		declaration = "";
 	}
@@ -141,7 +141,7 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, std::string prefix, std::vecto
 	else
 		sprintf(waterBoxStr, "0");
 
-	declaration += StringHelper::Sprintf("%i, %i, %i, %i, %i, %i, %i, %s_vertices_%08X, %i, %s_polygons_%08X, %s_polygonTypes_%08X, &%s_camDataList_%08X, %i, %s",
+	declaration += StringHelper::Sprintf("%i, %i, %i, %i, %i, %i, %i, %s_vtx_%08X, %i, %s_polygons_%08X, %s_polygonTypes_%08X, &%s_camDataList_%08X, %i, %s",
 		absMinX, absMinY, absMinZ,
 		absMaxX, absMaxY, absMaxZ,
 		numVerts, prefix.c_str(), vtxSegmentOffset, numPolygons,

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -331,7 +331,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 	{
 		F3DZEXOpcode opcode = (F3DZEXOpcode)(instructions[i] >> 56);
 		uint64_t data = instructions[i];
-		sourceOutput += "\t";
+		sourceOutput += "    ";
 
 		auto start = chrono::steady_clock::now();
 
@@ -460,7 +460,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 				if (GETSEGNUM(data) == 0x80) // Are these vertices defined in code?
 					vtxAddr -= SEG2FILESPACE(parent->baseAddress);
 
-				sprintf(line, "gsSPVertex(%s_vertices_%08X, %i, %i),", prefix.c_str(), vtxAddr, nn, ((aa >> 1) - nn));
+				sprintf(line, "gsSPVertex(%s_vtx_%08X, %i, %i),", prefix.c_str(), vtxAddr, nn, ((aa >> 1) - nn));
 
 				{
 					uint32_t currentPtr = data & 0x00FFFFFF;
@@ -973,7 +973,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 
 				string modes2[] = { "COMBINED", "TEXEL0", "TEXEL1", "PRIMITIVE", "SHADE", "ENVIRONMENT", "1", "0" };
 
-				sprintf(line, "gsDPSetCombineLERP(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s),",
+				sprintf(line, "gsDPSetCombineLERP(%s, %s, %s, %s, %s, %s, %s, %s,\n                       %s, %s, %s, %s, %s, %s, %s, %s),",
 					modes[a0].c_str(), modes[b0].c_str(), modes[c0].c_str(), modes[d0].c_str(),
 					modes2[aa0].c_str(), modes2[ab0].c_str(), modes2[ac0].c_str(), modes2[ad0].c_str(),
 					modes[a1].c_str(), modes[b1].c_str(), modes[c1].c_str(), modes[d1].c_str(),
@@ -1060,9 +1060,6 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 #endif
 
 		sourceOutput += line;
-
-		if (optimizationResult != -1)
-			sourceOutput += StringHelper::Sprintf(" // 0x%08X", rawDataIndex + (i * 8));
 		
 		if (i < instructions.size() - 1)
 			sourceOutput += "\n";
@@ -1093,7 +1090,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 					vertices[verticesSorted[i].first].push_back(verticesSorted[i + 1].second[j]);
 				}
 
-				defines += StringHelper::Sprintf("#define %s_vertices_%08X ((u32)%s_vertices_%08X + 0x%08X)\n", prefix.c_str(), verticesSorted[i + 1].first, prefix.c_str(), verticesSorted[i].first, verticesSorted[i + 1].first - verticesSorted[i].first);
+				defines += StringHelper::Sprintf("#define %s_vtx_%08X ((u32)%s_vtx_%08X + 0x%08X)\n", prefix.c_str(), verticesSorted[i + 1].first, prefix.c_str(), verticesSorted[i].first, verticesSorted[i + 1].first - verticesSorted[i].first);
 				
 				int nSize = (int)vertices[verticesSorted[i].first].size();
 
@@ -1116,8 +1113,8 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 
 			for (Vertex vtx : item.second)
 			{
-				declaration += StringHelper::Sprintf("\t { %i, %i, %i, %i, %i, %i, %i, %i, %i, %i }, // 0x%08X\n",
-					vtx.x, vtx.y, vtx.z, vtx.flag, vtx.s, vtx.t, vtx.r, vtx.g, vtx.b, vtx.a, curAddr);
+				declaration += StringHelper::Sprintf("    VTX(%i, %i, %i, %i, %i, %i, %i, %i, %i),\n",
+					vtx.x, vtx.y, vtx.z, vtx.s, vtx.t, vtx.r, vtx.g, vtx.b, vtx.a);
 
 				curAddr += 16;
 			}
@@ -1126,8 +1123,8 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 
 			if (parent != nullptr)
 			{
-				parent->AddDeclarationArray(item.first, DeclarationAlignment::None, item.second.size() * 16, "Vtx_t", 
-					StringHelper::Sprintf("%s_vertices_%08X", prefix.c_str(), item.first, item.second.size()), 0, declaration);
+				parent->AddDeclarationArray(item.first, DeclarationAlignment::None, item.second.size() * 16, "Vtx", 
+					StringHelper::Sprintf("%s_vtx_%08X", prefix.c_str(), item.first, item.second.size()), 0, declaration);
 			}
 		}
 

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -486,8 +486,9 @@ void ZFile::GenerateSourceFiles(string outputDir)
 {
 	sourceOutput = "";
 
-	sourceOutput += "#include <ultra64.h>\n";
-	sourceOutput += "#include <z64.h>\n";
+	sourceOutput += "#include \"ultra64.h\"\n";
+	sourceOutput += "#include \"z64.h\"\n";
+	sourceOutput += "#include \"macros.h\"\n";
 	sourceOutput += GetHeaderInclude();
 
 	GeneratePlaceholderDeclarations();
@@ -724,7 +725,7 @@ string ZFile::ProcessDeclarations()
 				{
 					if (diff > 0)
 					{
-						AddDeclarationArray(lastAddr + declarations[lastAddr]->size, DeclarationAlignment::None, diff, "static u8", StringHelper::Sprintf("unaccounted%04X", lastAddr + declarations[lastAddr]->size),
+						AddDeclarationArray(lastAddr + declarations[lastAddr]->size, DeclarationAlignment::None, diff, "static u8", StringHelper::Sprintf("unaccounted_%04X", lastAddr + declarations[lastAddr]->size),
 							diff, src);
 					}
 				}
@@ -739,21 +740,21 @@ string ZFile::ProcessDeclarations()
 	{
 		int diff = (int)(rawData.size() - (lastAddr + declarations[lastAddr]->size));
 
-		string src = "\t";
+		string src = "    ";
 
 		for (int i = 0; i < diff; i++)
 		{
 			src += StringHelper::Sprintf("0x%02X, ", rawData[lastAddr + declarations[lastAddr]->size + i]);
 
 			if (i % 16 == 15)
-				src += "\n\t";
+				src += "\n    ";
 		}
 
 		if (declarations.find(lastAddr + declarations[lastAddr]->size) == declarations.end())
 		{
 			if (diff > 0)
 			{
-				AddDeclarationArray(lastAddr + declarations[lastAddr]->size, DeclarationAlignment::None, diff, "static u8", StringHelper::Sprintf("unaccounted%04X", lastAddr + declarations[lastAddr]->size),
+				AddDeclarationArray(lastAddr + declarations[lastAddr]->size, DeclarationAlignment::None, diff, "static u8", StringHelper::Sprintf("unaccounted_%04X", lastAddr + declarations[lastAddr]->size),
 					diff, src);
 			}
 		}
@@ -771,7 +772,7 @@ string ZFile::ProcessDeclarations()
 		if (item.second->includePath != "")
 		{
 			//output += StringHelper::Sprintf("#include \"%s\"\n", item.second->includePath.c_str());
-			output += StringHelper::Sprintf("%s %s[] = {\n#include \"%s\"\n};\n", item.second->varType.c_str(), item.second->varName.c_str(), item.second->includePath.c_str());
+			output += StringHelper::Sprintf("%s %s[] = {\n#include \"%s\"\n};\n\n", item.second->varType.c_str(), item.second->varName.c_str(), item.second->includePath.c_str());
 		}
 		else if (item.second->varType != "")
 		{
@@ -781,20 +782,23 @@ string ZFile::ProcessDeclarations()
 			if (item.second->isArray)
 			{
 				if (item.second->arrayItemCnt == 0)
-					output += StringHelper::Sprintf("%s %s[] = \n{\n", item.second->varType.c_str(), item.second->varName.c_str());
+					output += StringHelper::Sprintf("%s %s[] = {\n", item.second->varType.c_str(), item.second->varName.c_str());
 				else
-					output += StringHelper::Sprintf("%s %s[%i] = \n{\n", item.second->varType.c_str(), item.second->varName.c_str(), item.second->arrayItemCnt);
+					output += StringHelper::Sprintf("%s %s[%i] = {\n", item.second->varType.c_str(), item.second->varName.c_str(), item.second->arrayItemCnt);
 
 				output += item.second->text + "\n";
 			}
 			else
 			{
-				output += StringHelper::Sprintf("%s %s = {", item.second->varType.c_str(), item.second->varName.c_str());
+				output += StringHelper::Sprintf("%s %s = { ", item.second->varType.c_str(), item.second->varName.c_str());
 				output += item.second->text;
 			}
 
+			if (output.back() == '\n')
+				output += "};";
+			else
+				output += " };";
 
-			output += "};";
 			output += " " + item.second->rightText + "\n\n";
 			
 			if (item.second->postText != "")

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -308,8 +308,8 @@ void SetMesh::GenDListDeclarations(std::vector<uint8_t> rawData, ZDisplayList* d
 
 	for (pair<uint32_t, string> vtxEntry : dList->vtxDeclarations)
 	{
-		zRoom->parent->AddDeclarationArray(vtxEntry.first, DeclarationAlignment::Align8, dList->vertices[vtxEntry.first].size() * 16, "Vtx_t",
-			StringHelper::Sprintf("%s_vertices_%08X", zRoom->GetName().c_str(), vtxEntry.first), 0, vtxEntry.second);
+		zRoom->parent->AddDeclarationArray(vtxEntry.first, DeclarationAlignment::Align8, dList->vertices[vtxEntry.first].size() * 16, "Vtx",
+			StringHelper::Sprintf("%s_vtx_%08X", zRoom->GetName().c_str(), vtxEntry.first), 0, vtxEntry.second);
 
 		//zRoom->parent->declarations[vtxEntry.first] = new Declaration(DeclarationAlignment::Align8, dList->vertices[vtxEntry.first].size() * 16, vtxEntry.second);
 	}
@@ -345,7 +345,7 @@ std::string SetMesh::GenDListExterns(ZDisplayList* dList)
 		sourceOutput += GenDListExterns(otherDList);
 
 	for (pair<uint32_t, string> vtxEntry : dList->vtxDeclarations)
-		sourceOutput += StringHelper::Sprintf("extern Vtx_t %s_vertices_%08X[%i];\n", zRoom->GetName().c_str(), vtxEntry.first, dList->vertices[vtxEntry.first].size());
+		sourceOutput += StringHelper::Sprintf("extern Vtx %s_vtx_%08X[%i];\n", zRoom->GetName().c_str(), vtxEntry.first, dList->vertices[vtxEntry.first].size());
 
 	for (pair<uint32_t, string> texEntry : dList->texDeclarations)
 		sourceOutput += StringHelper::Sprintf("extern u64 %s_tex_%08X[];\n", zRoom->GetName().c_str(), texEntry.first);

--- a/ZAPD/ZRoom/Commands/SetPathways.cpp
+++ b/ZAPD/ZRoom/Commands/SetPathways.cpp
@@ -79,7 +79,7 @@ string SetPathways::GenerateSourceCodePass2(string roomName, int baseAddress)
 		int index = 0;
 		for (PathwayEntry* entry : pathways)
 		{
-			declaration += StringHelper::Sprintf("\t{ %i, %i, %i }, //0x%08X \n", entry->x, entry->y, entry->z, listSegmentOffset + (index * 6));
+			declaration += StringHelper::Sprintf("{ %i, %i, %i }, //0x%08X \n", entry->x, entry->y, entry->z, listSegmentOffset + (index * 6));
 			index++;
 		}
 

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -412,10 +412,10 @@ string ZRoom::GetSourceOutputCode(std::string prefix)
 	sourceOutput = "";
 
 	//sourceOutput += "#include <z64.h>\n";
-	sourceOutput += "#include <segment_symbols.h>\n";
-	sourceOutput += "#include <command_macros_base.h>\n";
-	sourceOutput += "#include <z64cutscene_commands.h>\n";
-	sourceOutput += "#include <variables.h>\n";
+	sourceOutput += "#include \"segment_symbols.h\"\n";
+	sourceOutput += "#include \"command_macros_base.h\"\n";
+	sourceOutput += "#include \"z64cutscene_commands.h\"\n";
+	sourceOutput += "#include \"variables.h\"\n";
 
 	if (scene != nullptr)
 		sourceOutput += scene->parent->GetHeaderInclude();

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -63,7 +63,7 @@ string ZLimbStandard::GetSourceOutputCode(string prefix)
 {
 	string dListStr = dListPtr == 0 ? "NULL" : StringHelper::Sprintf("%s", parent->GetVarName(dListPtr).c_str());
 
-	string entryStr = StringHelper::Sprintf("\t{ %i, %i, %i }, %i, %i, %s",
+	string entryStr = StringHelper::Sprintf("{ %i, %i, %i }, %i, %i, %s",
 		transX, transY, transZ, childIndex, siblingIndex, dListStr.c_str());
 
 	Declaration* decl = parent->GetDeclaration(address);
@@ -162,14 +162,14 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 		{
 			ZLimbStandard* limb = limbs[i];
 			
-			string defaultDLName = StringHelper::Sprintf("%s_dlist_%08X", name.c_str(), limb->dListPtr);
+			string defaultDLName = StringHelper::Sprintf("%sLimbDL_%08X", name.c_str(), limb->dListPtr);
 			string dListStr = limb->dListPtr == 0 ? "NULL" : StringHelper::Sprintf("%s", parent->GetDeclarationName(limb->dListPtr, defaultDLName).c_str());
 
 			if (limb->dListPtr != 0 && parent->GetDeclaration(limb->dListPtr) == nullptr)
 			{
 				ZDisplayList* dList = new ZDisplayList(rawData, limb->dListPtr, ZDisplayList::GetDListLength(rawData, limb->dListPtr));
 				dList->parent = parent;
-				dList->SetName(StringHelper::Sprintf("%s_dlist_%08X", name.c_str(), limb->dListPtr));
+				dList->SetName(StringHelper::Sprintf("%sLimbDL_%08X", name.c_str(), limb->dListPtr));
 				dList->GetSourceOutputCode("");
 			}
 
@@ -203,7 +203,7 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 					limb->transX, limb->transY, limb->transZ, limb->childIndex, limb->siblingIndex, dListStr.c_str());
 			}
 
-			string limbName = StringHelper::Sprintf("%s_limb_%04X", name.c_str(), limb->address);
+			string limbName = StringHelper::Sprintf("%sLimb_%04X", name.c_str(), limb->address);
 
 			if (parent->HasDeclaration(limb->address))
 				limbName = parent->GetDeclarationName(limb->address);
@@ -218,11 +218,13 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 		{
 			ZLimbStandard* limb = limbs[i];
 
-			//string decl = StringHelper::Sprintf("\t&_%s_limb_%04X,\n", prefix.c_str(), limb->address);
+			//string decl = StringHelper::Sprintf("    &_%sLimb_%04X,\n", prefix.c_str(), limb->address);
 			string decl = "";
 
 			if (parent->HasDeclaration(limb->address))
-				decl = StringHelper::Sprintf("\t&%s,\n", parent->GetDeclarationName(limb->address).c_str());
+				decl = StringHelper::Sprintf("    &%s,", parent->GetDeclarationName(limb->address).c_str());
+				if (i != (limbs.size() - 1))
+				    decl += "\n";
 
 			tblStr += decl;
 		}
@@ -232,18 +234,18 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 		if (!parent->HasDeclaration(ptr))
 		{
 			parent->AddDeclarationArray(ptr, DeclarationAlignment::None, 4 * limbs.size(),
-				"StandardLimb*", StringHelper::Sprintf("%s_limbs", name.c_str()), limbs.size(), tblStr);
+				"void*", StringHelper::Sprintf("%sLimbs", name.c_str()), limbs.size(), tblStr);
 		}
 
 		if (type == ZSkeletonType::Normal)
 		{
-			string headerStr = StringHelper::Sprintf("%s_limbs, %i", name.c_str(), limbs.size());
+			string headerStr = StringHelper::Sprintf("%sLimbs, %i", name.c_str(), limbs.size());
 			parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align16, 8,
 				"SkeletonHeader", StringHelper::Sprintf("%s", name.c_str()), headerStr);
 		}
 		else
 		{
-			string headerStr = StringHelper::Sprintf("%s_limbs, %i, %i", name.c_str(), limbs.size(), dListCount);
+			string headerStr = StringHelper::Sprintf("%sLimbs, %i, %i", name.c_str(), limbs.size(), dListCount);
 			parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align16, 12,
 				"FlexSkeletonHeader", StringHelper::Sprintf("%s", name.c_str()), headerStr);
 		}


### PR DESCRIPTION
- Vtx_t -> Vtx
- use VTX macro, remove offset comments
- tabs replaced with spaces
- `anim_values` -> `animFrameData`
- `anim_indicies` -> `animJointIndicies`
- `nameSkel_limbs` -> `nameSkelLimbs`
- limb array is now void*
- braces moved to same line as declaration to match oot style
- newline added after texture declarations
- `nameSkel_limb_addr` -> `nameSkelLimb_addr`
- `nameSkel_dlist_addr` -> `nameSkelLimbDL_addr`
- `_verticies_addr` -> `_vtx_addr`
- `unaccountedAddr` -> `unaccounted_addr`
- joint indicies array no longer has trailing newline
- limb array no longer has trailing newline
- includes changed to quotes
- offset comments on `gsDPLoadMultiBlock` removed
- split `gsDPSetCombineLERP` args in half to conform to line limit