### PR TITLE
Misc changes

### DIFF
--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -59,7 +59,7 @@ std::string ZNormalAnimation::GetSourceOutputCode(std::string prefix)
 		string defaultPrefix = name.c_str();
 		defaultPrefix.replace(0, 1, "s"); // replace g prefix with s for local variables
 
-		string headerStr = StringHelper::Sprintf(" { %i }, %sFrameData, %sJointIndices, %i",
+		string headerStr = StringHelper::Sprintf("{ %i }, %sFrameData, %sJointIndices, %i",
 			frameCount, defaultPrefix.c_str(), defaultPrefix.c_str(), limit);
 		parent->declarations[rawDataIndex] = new Declaration(DeclarationAlignment::None, 16, "AnimationHeader", StringHelper::Sprintf("%s", name.c_str()), false, headerStr);
 
@@ -149,7 +149,7 @@ std::string ZLinkAnimation::GetSourceOutputCode(std::string prefix)
 	if (parent != nullptr)
 	{
 		string segSymbol = segmentAddress == 0 ? "NULL" : parent->GetDeclarationName(segmentAddress, StringHelper::Sprintf("%sSeg%06X", name.c_str(), segmentAddress));
-		string headerStr = StringHelper::Sprintf(" { %i }, 0x%08X",
+		string headerStr = StringHelper::Sprintf("{ %i }, 0x%08X",
 			frameCount, segmentAddress);
 		parent->declarations[rawDataIndex] = new Declaration(DeclarationAlignment::None, 16, "LinkAnimationHeader", StringHelper::Sprintf("%s", name.c_str()), false, headerStr);
 	}

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -56,8 +56,11 @@ std::string ZNormalAnimation::GetSourceOutputCode(std::string prefix)
 {
 	if (parent != nullptr)
 	{
-		string headerStr = StringHelper::Sprintf("%i, %sFrameData, %sJointIndices, %i",
-			frameCount, name.c_str(), name.c_str(), limit);
+		string defaultPrefix = name.c_str();
+		defaultPrefix.replace(0, 1, "s"); // replace g prefix with s for local variables
+
+		string headerStr = StringHelper::Sprintf(" { %i }, %sFrameData, %sJointIndices, %i",
+			frameCount, defaultPrefix.c_str(), defaultPrefix.c_str(), limit);
 		parent->declarations[rawDataIndex] = new Declaration(DeclarationAlignment::None, 16, "AnimationHeader", StringHelper::Sprintf("%s", name.c_str()), false, headerStr);
 
 		string indicesStr = "";
@@ -81,11 +84,11 @@ std::string ZNormalAnimation::GetSourceOutputCode(std::string prefix)
 				indicesStr += "\n";
 		}
 
-		parent->AddDeclarationArray(rotationValuesSeg, DeclarationAlignment::Align16, (int)rotationValues.size() * 2, "s16",
-			StringHelper::Sprintf("%sFrameData", name.c_str()), rotationValues.size(), valuesStr);
+		parent->AddDeclarationArray(rotationValuesSeg, DeclarationAlignment::Align16, (int)rotationValues.size() * 2, "static s16",
+			StringHelper::Sprintf("%sFrameData", defaultPrefix.c_str()), rotationValues.size(), valuesStr);
 
-		parent->AddDeclarationArray(rotationIndicesSeg, DeclarationAlignment::Align16, (int)rotationIndices.size() * 6, "JointIndex",
-			StringHelper::Sprintf("%sJointIndices", name.c_str()), rotationIndices.size(), indicesStr);
+		parent->AddDeclarationArray(rotationIndicesSeg, DeclarationAlignment::Align16, (int)rotationIndices.size() * 6, "static JointIndex",
+			StringHelper::Sprintf("%sJointIndices", defaultPrefix.c_str()), rotationIndices.size(), indicesStr);
 	}
 
 	return "";
@@ -146,7 +149,7 @@ std::string ZLinkAnimation::GetSourceOutputCode(std::string prefix)
 	if (parent != nullptr)
 	{
 		string segSymbol = segmentAddress == 0 ? "NULL" : parent->GetDeclarationName(segmentAddress, StringHelper::Sprintf("%sSeg%06X", name.c_str(), segmentAddress));
-		string headerStr = StringHelper::Sprintf("%i, 0x%08X",
+		string headerStr = StringHelper::Sprintf(" { %i }, 0x%08X",
 			frameCount, segmentAddress);
 		parent->declarations[rawDataIndex] = new Declaration(DeclarationAlignment::None, 16, "LinkAnimationHeader", StringHelper::Sprintf("%s", name.c_str()), false, headerStr);
 	}

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -1113,7 +1113,10 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 
 			for (Vertex vtx : item.second)
 			{
-				declaration += StringHelper::Sprintf("    VTX(%i, %i, %i, %i, %i, %i, %i, %i, %i),\n",
+				if (curAddr != item.first)
+					declaration += "\n";
+
+				declaration += StringHelper::Sprintf("    VTX(%i, %i, %i, %i, %i, %i, %i, %i, %i),",
 					vtx.x, vtx.y, vtx.z, vtx.s, vtx.t, vtx.r, vtx.g, vtx.b, vtx.a);
 
 				curAddr += 16;

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -182,11 +182,11 @@ int ZDisplayList::OptimizationCheck_LoadTextureBlock(int startIndex, string& out
 				if (texDecl != nullptr)
 					texStr = StringHelper::Sprintf("%s", texDecl->varName.c_str());
 				else if (segmentNumber == 2)
-					texStr = StringHelper::Sprintf("%sTex0x%06X", scene->GetName().c_str(), texAddr);
+					texStr = StringHelper::Sprintf("%sTex_%06X", scene->GetName().c_str(), texAddr);
 				else if (!Globals::Instance->HasSegment(segmentNumber)) // Probably an external asset we are unable to track
 					texStr = StringHelper::Sprintf("0x%06X", data);
 				else
-					texStr = StringHelper::Sprintf("%sTex0x%06X", prefix.c_str(), texAddr);
+					texStr = StringHelper::Sprintf("%sTex_%06X", prefix.c_str(), texAddr);
 			}
 			else if (segmentNumber != 3)
 				texStr = StringHelper::Sprintf("0x%06X", data);
@@ -529,7 +529,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 					if (texDecl != nullptr)
 						sprintf(texStr, "%s", texDecl->varName.c_str());
 					else if (data != 0 && Globals::Instance->HasSegment(segmentNumber))
-						sprintf(texStr, "%sTex0x%06X", prefix.c_str(), texAddress);
+						sprintf(texStr, "%sTex_%06X", prefix.c_str(), texAddress);
 					else
 					{
 						// TEST: CHECK OTHER FILES FOR REF
@@ -548,7 +548,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 				else
 				{
 					//sprintf(line, "gsDPSetTextureImage(%s, %s, %i, 0x%08X),", fmtTbl[fmt].c_str(), sizTbl[siz].c_str(), www + 1, data & 0xFFFFFFFF);
-					sprintf(line, "gsDPSetTextureImage(%s, %s, %i, %sTex0x%06X),", fmtTbl[fmt].c_str(), sizTbl[siz].c_str(), www + 1, scene->GetName().c_str(), data & 0x00FFFFFF);
+					sprintf(line, "gsDPSetTextureImage(%s, %s, %i, %sTex_%06X),", fmtTbl[fmt].c_str(), sizTbl[siz].c_str(), www + 1, scene->GetName().c_str(), data & 0x00FFFFFF);
 				}
 			}
 			break;
@@ -1150,7 +1150,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 					{
 						int intersectAmt = (texturesSorted[i].first + texSize) - texturesSorted[i + 1].first;
 
-						defines += StringHelper::Sprintf("#define %sTex0x%06X ((u32)%sTex0x%06X + 0x%06X)\n", scene->GetName().c_str(), texturesSorted[i + 1].first, scene->GetName().c_str(),
+						defines += StringHelper::Sprintf("#define %sTex_%06X ((u32)%sTex_%06X + 0x%06X)\n", scene->GetName().c_str(), texturesSorted[i + 1].first, scene->GetName().c_str(),
 							texturesSorted[i].first, texturesSorted[i + 1].first - texturesSorted[i].first);
 
 						scene->parent->declarations.erase(texturesSorted[i + 1].first);
@@ -1183,7 +1183,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 					{
 						int intersectAmt = (texturesSorted[i].first + texSize) - texturesSorted[i + 1].first;
 
-						defines += StringHelper::Sprintf("#define %sTex0x%06X ((u32)%sTex0x%06X + 0x%06X)\n", prefix.c_str(), texturesSorted[i + 1].first, prefix.c_str(),
+						defines += StringHelper::Sprintf("#define %sTex_%06X ((u32)%sTex_%06X + 0x%06X)\n", prefix.c_str(), texturesSorted[i + 1].first, prefix.c_str(),
 							texturesSorted[i].first, texturesSorted[i + 1].first - texturesSorted[i].first);
 
 						textures.erase(texturesSorted[i + 1].first);
@@ -1216,7 +1216,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 					parent->AddDeclarationIncludeArray(item.first, StringHelper::Sprintf("%s/%s.%s.inc.c",
 						Globals::Instance->outputPath.c_str(), Path::GetFileNameWithoutExtension(item.second->GetName()).c_str(),
 						item.second->GetExternalExtension().c_str()), item.second->GetRawDataSize(),
-						"u64", StringHelper::Sprintf("%sTex0x%06X", prefix.c_str(), item.first), 0);
+						"u64", StringHelper::Sprintf("%sTex_%06X", prefix.c_str(), item.first), 0);
 				}
 			}
 		}
@@ -1254,7 +1254,7 @@ bool ZDisplayList::TextureGenCheck(vector<uint8_t> fileData, map<uint32_t, ZText
 	{
 		if (segmentNumber != 2) // Not from a scene file
 		{
-			ZTexture* tex = ZTexture::FromBinary(TexFormatToTexType(texFmt, texSiz), fileData, texAddr, StringHelper::Sprintf("%sTex0x%06X", prefix.c_str(), texAddr), texWidth, texHeight);
+			ZTexture* tex = ZTexture::FromBinary(TexFormatToTexType(texFmt, texSiz), fileData, texAddr, StringHelper::Sprintf("%sTex_%06X", prefix.c_str(), texAddr), texWidth, texHeight);
 
 			//tex->Save(Globals::Instance->outputPath);
 			textures[texAddr] = tex;
@@ -1264,7 +1264,7 @@ bool ZDisplayList::TextureGenCheck(vector<uint8_t> fileData, map<uint32_t, ZText
 		else
 		{
 			ZTexture* tex = ZTexture::FromBinary(TexFormatToTexType(texFmt, texSiz), scene->GetRawData(), texAddr,
-				StringHelper::Sprintf("%sTex0x%06X", Globals::Instance->lastScene->GetName().c_str(), texAddr), texWidth, texHeight);
+				StringHelper::Sprintf("%sTex_%06X", Globals::Instance->lastScene->GetName().c_str(), texAddr), texWidth, texHeight);
 
 			//tex->Save(Globals::Instance->outputPath);
 
@@ -1273,7 +1273,7 @@ bool ZDisplayList::TextureGenCheck(vector<uint8_t> fileData, map<uint32_t, ZText
 				scene->textures[texAddr] = tex;
 				scene->parent->AddDeclarationIncludeArray(texAddr, StringHelper::Sprintf("%s/%s.%s.inc.c", 
 					Globals::Instance->outputPath.c_str(), Path::GetFileNameWithoutExtension(tex->GetName()).c_str(), tex->GetExternalExtension().c_str()), tex->GetRawDataSize(),
-					"u64", StringHelper::Sprintf("%sTex0x%06X", Globals::Instance->lastScene->GetName().c_str(), texAddr), 0);
+					"u64", StringHelper::Sprintf("%sTex_%06X", Globals::Instance->lastScene->GetName().c_str(), texAddr), 0);
 			}
 
 			return true;

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -460,7 +460,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 				if (GETSEGNUM(data) == 0x80) // Are these vertices defined in code?
 					vtxAddr -= SEG2FILESPACE(parent->baseAddress);
 
-				sprintf(line, "gsSPVertex(%sVertices0x%06X, %i, %i),", prefix.c_str(), vtxAddr, nn, ((aa >> 1) - nn));
+				sprintf(line, "gsSPVertex(%sVtx_%06X, %i, %i),", prefix.c_str(), vtxAddr, nn, ((aa >> 1) - nn));
 
 				{
 					uint32_t currentPtr = data & 0x00FFFFFF;
@@ -1090,7 +1090,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 					vertices[verticesSorted[i].first].push_back(verticesSorted[i + 1].second[j]);
 				}
 
-				defines += StringHelper::Sprintf("#define %sVertices0x%06X ((u32)%sVertices0x%06X + 0x%06X)\n", prefix.c_str(), verticesSorted[i + 1].first, prefix.c_str(), verticesSorted[i].first, verticesSorted[i + 1].first - verticesSorted[i].first);
+				defines += StringHelper::Sprintf("#define %sVtx_%06X ((u32)%sVtx_%06X + 0x%06X)\n", prefix.c_str(), verticesSorted[i + 1].first, prefix.c_str(), verticesSorted[i].first, verticesSorted[i + 1].first - verticesSorted[i].first);
 				
 				int nSize = (int)vertices[verticesSorted[i].first].size();
 
@@ -1127,7 +1127,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 			if (parent != nullptr)
 			{
 				parent->AddDeclarationArray(item.first, DeclarationAlignment::None, item.second.size() * 16, "Vtx", 
-					StringHelper::Sprintf("%sVertices0x%06X", prefix.c_str(), item.first, item.second.size()), 0, declaration);
+					StringHelper::Sprintf("%sVtx_%06X", prefix.c_str(), item.first, item.second.size()), 0, declaration);
 			}
 		}
 

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -711,14 +711,15 @@ string ZFile::ProcessDeclarations()
 			{
 				int diff = item.first - (lastAddr + declarations[lastAddr]->size);
 
-				string src = "\t";
+				string src = "    ";
+
 
 				for (int i = 0; i < diff; i++)
 				{
 					src += StringHelper::Sprintf("0x%02X, ", rawDataArr[lastAddr + declarations[lastAddr]->size + i]);
 
-					if (i % 16 == 15)
-						src += "\n\t";
+					if ((i % 16 == 15) && (i != (diff - 1)))
+						src += "\n    ";
 				}
 
 				if (declarations.find(lastAddr + declarations[lastAddr]->size) == declarations.end())

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -738,7 +738,7 @@ string ZFile::ProcessDeclarations()
 				{
 					if (diff > 0)
 					{
-						AddDeclarationArray(lastAddr + declarations[lastAddr]->size, DeclarationAlignment::None, diff, "static u8", StringHelper::Sprintf("unaccounted_%04X", lastAddr + declarations[lastAddr]->size),
+						AddDeclarationArray(lastAddr + declarations[lastAddr]->size, DeclarationAlignment::None, diff, "static u8", StringHelper::Sprintf("unaccounted_%06X", lastAddr + declarations[lastAddr]->size),
 							diff, src);
 					}
 				}
@@ -767,7 +767,7 @@ string ZFile::ProcessDeclarations()
 		{
 			if (diff > 0)
 			{
-				AddDeclarationArray(lastAddr + declarations[lastAddr]->size, DeclarationAlignment::None, diff, "static u8", StringHelper::Sprintf("unaccounted_%04X", lastAddr + declarations[lastAddr]->size),
+				AddDeclarationArray(lastAddr + declarations[lastAddr]->size, DeclarationAlignment::None, diff, "static u8", StringHelper::Sprintf("unaccounted_%06X", lastAddr + declarations[lastAddr]->size),
 					diff, src);
 			}
 		}

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -309,7 +309,7 @@ void SetMesh::GenDListDeclarations(std::vector<uint8_t> rawData, ZDisplayList* d
 	for (pair<uint32_t, string> vtxEntry : dList->vtxDeclarations)
 	{
 		zRoom->parent->AddDeclarationArray(vtxEntry.first, DeclarationAlignment::Align8, dList->vertices[vtxEntry.first].size() * 16, "Vtx",
-			StringHelper::Sprintf("%sVertices0x%06X", zRoom->GetName().c_str(), vtxEntry.first), 0, vtxEntry.second);
+			StringHelper::Sprintf("%sVtx_%06X", zRoom->GetName().c_str(), vtxEntry.first), 0, vtxEntry.second);
 
 		//zRoom->parent->declarations[vtxEntry.first] = new Declaration(DeclarationAlignment::Align8, dList->vertices[vtxEntry.first].size() * 16, vtxEntry.second);
 	}
@@ -345,7 +345,7 @@ std::string SetMesh::GenDListExterns(ZDisplayList* dList)
 		sourceOutput += GenDListExterns(otherDList);
 
 	for (pair<uint32_t, string> vtxEntry : dList->vtxDeclarations)
-		sourceOutput += StringHelper::Sprintf("extern Vtx %sVertices0x%06X[%i];\n", zRoom->GetName().c_str(), vtxEntry.first, dList->vertices[vtxEntry.first].size());
+		sourceOutput += StringHelper::Sprintf("extern Vtx %sVtx_%06X[%i];\n", zRoom->GetName().c_str(), vtxEntry.first, dList->vertices[vtxEntry.first].size());
 
 	for (pair<uint32_t, string> texEntry : dList->texDeclarations)
 		sourceOutput += StringHelper::Sprintf("extern u64 %sTex0x%06X[];\n", zRoom->GetName().c_str(), texEntry.first);

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -328,7 +328,7 @@ void SetMesh::GenDListDeclarations(std::vector<uint8_t> rawData, ZDisplayList* d
 
 		zRoom->parent->AddDeclarationIncludeArray(texEntry.first, StringHelper::Sprintf("%s/%s.%s.inc.c",
 			Globals::Instance->outputPath.c_str(), Path::GetFileNameWithoutExtension(zRoom->textures[texEntry.first]->GetName()).c_str(), zRoom->textures[texEntry.first]->GetExternalExtension().c_str()), 
-			zRoom->textures[texEntry.first]->GetRawDataSize(), "u64", StringHelper::Sprintf("%sTex0x%06X", zRoom->textures[texEntry.first]->GetName().c_str(), texEntry.first), 0);
+			zRoom->textures[texEntry.first]->GetRawDataSize(), "u64", StringHelper::Sprintf("%sTex_%06X", zRoom->textures[texEntry.first]->GetName().c_str(), texEntry.first), 0);
 	}
 }
 
@@ -348,7 +348,7 @@ std::string SetMesh::GenDListExterns(ZDisplayList* dList)
 		sourceOutput += StringHelper::Sprintf("extern Vtx %sVtx_%06X[%i];\n", zRoom->GetName().c_str(), vtxEntry.first, dList->vertices[vtxEntry.first].size());
 
 	for (pair<uint32_t, string> texEntry : dList->texDeclarations)
-		sourceOutput += StringHelper::Sprintf("extern u64 %sTex0x%06X[];\n", zRoom->GetName().c_str(), texEntry.first);
+		sourceOutput += StringHelper::Sprintf("extern u64 %sTex_%06X[];\n", zRoom->GetName().c_str(), texEntry.first);
 
 	sourceOutput += dList->defines;
 

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -173,7 +173,7 @@ ZRoom* ZRoom::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int r
 			int width = strtol(string(child->Attribute("Width")).c_str(), NULL, 10);
 			int height = strtol(string(child->Attribute("Height")).c_str(), NULL, 10);
 
-			ZTexture* tex = ZTexture::FromBinary(ZTexture::GetTextureTypeFromString(typeStr), room->rawData, address, StringHelper::Sprintf("%sTex0x%06X", room->name.c_str(), address), width, height);
+			ZTexture* tex = ZTexture::FromBinary(ZTexture::GetTextureTypeFromString(typeStr), room->rawData, address, StringHelper::Sprintf("%sTex_%06X", room->name.c_str(), address), width, height);
 			room->parent->AddDeclarationArray(address, DeclarationAlignment::None, tex->GetRawDataSize(), "u64", StringHelper::Sprintf("%s", tex->GetName().c_str()), 0,
 				tex->GetSourceOutputCode(room->name));
 		}
@@ -444,7 +444,7 @@ string ZRoom::GetSourceOutputCode(std::string prefix)
 				{
 					int intersectAmt = (texturesSorted[i].first + texSize) - texturesSorted[i + 1].first;
 
-					defines += StringHelper::Sprintf("#define %sTex0x%06X ((u32)%sTex0x%06X + 0x%06X)\n", prefix.c_str(), texturesSorted[i + 1].first, prefix.c_str(),
+					defines += StringHelper::Sprintf("#define %sTex_%06X ((u32)%sTex_%06X + 0x%06X)\n", prefix.c_str(), texturesSorted[i + 1].first, prefix.c_str(),
 						texturesSorted[i].first, texturesSorted[i + 1].first - texturesSorted[i].first);
 
 					parent->declarations.erase(texturesSorted[i + 1].first);
@@ -473,7 +473,7 @@ string ZRoom::GetSourceOutputCode(std::string prefix)
 
 		parent->AddDeclarationIncludeArray(item.first, StringHelper::Sprintf("%s/%s.%s.inc.c",
 			Globals::Instance->outputPath.c_str(), Path::GetFileNameWithoutExtension(item.second->GetName()).c_str(), item.second->GetExternalExtension().c_str()), item.second->GetRawDataSize(),
-			"u64", StringHelper::Sprintf("%sTex0x%06X", prefix.c_str(), item.first), 0);
+			"u64", StringHelper::Sprintf("%sTex_%06X", prefix.c_str(), item.first), 0);
 	}
 
 	//sourceOutput += "\n";

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -162,9 +162,10 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 		{
 			ZLimbStandard* limb = limbs[i];
 			
-			string defaultDLName = StringHelper::Sprintf("%sLimbDL_%08X", name.c_str(), limb->dListPtr);
 			string defaultPrefix = name.c_str();
-			defaultPrefix.replace(0, 1, "s");
+			defaultPrefix.replace(0, 1, "s"); // replace g prefix with s for local variables
+
+			string defaultDLName = StringHelper::Sprintf("%sLimbDL_%08X", name.c_str(), limb->dListPtr);
 			string dListStr = limb->dListPtr == 0 ? "NULL" : StringHelper::Sprintf("%s", parent->GetDeclarationName(limb->dListPtr, defaultDLName).c_str());
 
 			if (limb->dListPtr != 0 && parent->GetDeclaration(limb->dListPtr) == nullptr)

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -163,6 +163,8 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 			ZLimbStandard* limb = limbs[i];
 			
 			string defaultDLName = StringHelper::Sprintf("%sLimbDL_%08X", name.c_str(), limb->dListPtr);
+			string defaultPrefix = name.c_str();
+			defaultPrefix.replace(0, 1, "s");
 			string dListStr = limb->dListPtr == 0 ? "NULL" : StringHelper::Sprintf("%s", parent->GetDeclarationName(limb->dListPtr, defaultDLName).c_str());
 
 			if (limb->dListPtr != 0 && parent->GetDeclaration(limb->dListPtr) == nullptr)
@@ -170,7 +172,7 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 				ZDisplayList* dList = new ZDisplayList(rawData, limb->dListPtr, ZDisplayList::GetDListLength(rawData, limb->dListPtr));
 				dList->parent = parent;
 				dList->SetName(StringHelper::Sprintf("%sLimbDL_%08X", name.c_str(), limb->dListPtr));
-				dList->GetSourceOutputCode("");
+				dList->GetSourceOutputCode(defaultPrefix);
 			}
 
 			string entryStr = "";
@@ -187,7 +189,7 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 					ZDisplayList* dList = new ZDisplayList(rawData, limbLOD->farDListPtr, ZDisplayList::GetDListLength(rawData, limbLOD->farDListPtr));
 					dList->parent = parent;
 					dList->SetName(StringHelper::Sprintf("%s_farLimbDlist_%08X", name.c_str(), limbLOD->farDListPtr));
-					dList->GetSourceOutputCode("");
+					dList->GetSourceOutputCode(defaultPrefix);
 				}
 
 				entryType = "LodLimb";

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -158,21 +158,21 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 {
 	if (parent != nullptr)
 	{
+		string defaultPrefix = name.c_str();
+		defaultPrefix.replace(0, 1, "s"); // replace g prefix with s for local variables
+
 		for (int i = 0; i < limbs.size(); i++)
 		{
 			ZLimbStandard* limb = limbs[i];
 			
-			string defaultPrefix = name.c_str();
-			defaultPrefix.replace(0, 1, "s"); // replace g prefix with s for local variables
-
-			string defaultDLName = StringHelper::Sprintf("%sLimbDL_%06X", name.c_str(), limb->dListPtr);
+			string defaultDLName = StringHelper::Sprintf("%sLimbDL_%06X", defaultPrefix.c_str(), limb->dListPtr);
 			string dListStr = limb->dListPtr == 0 ? "NULL" : StringHelper::Sprintf("%s", parent->GetDeclarationName(limb->dListPtr, defaultDLName).c_str());
 
 			if (limb->dListPtr != 0 && parent->GetDeclaration(limb->dListPtr) == nullptr)
 			{
 				ZDisplayList* dList = new ZDisplayList(rawData, limb->dListPtr, ZDisplayList::GetDListLength(rawData, limb->dListPtr));
 				dList->parent = parent;
-				dList->SetName(StringHelper::Sprintf("%sLimbDL_%06X", name.c_str(), limb->dListPtr));
+				dList->SetName(StringHelper::Sprintf("%sLimbDL_%06X", defaultPrefix.c_str(), limb->dListPtr));
 				dList->GetSourceOutputCode(defaultPrefix);
 			}
 
@@ -182,14 +182,14 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 			if (typeid(*limb) == typeid(ZLimbLOD))
 			{
 				ZLimbLOD* limbLOD = (ZLimbLOD*)limbs[i];
-				string defaultFarDLName = StringHelper::Sprintf("%sFarLimbDlist0x%06X", name.c_str(), limbLOD->farDListPtr);
+				string defaultFarDLName = StringHelper::Sprintf("%sFarLimbDlist0x%06X", defaultPrefix.c_str(), limbLOD->farDListPtr);
 				string dListStr2 = limbLOD->farDListPtr == 0 ? "NULL" : StringHelper::Sprintf("%s", parent->GetDeclarationName(limbLOD->farDListPtr, defaultFarDLName).c_str());
 
 				if (limbLOD->farDListPtr != 0 && parent->GetDeclaration(limbLOD->farDListPtr) == nullptr)
 				{
 					ZDisplayList* dList = new ZDisplayList(rawData, limbLOD->farDListPtr, ZDisplayList::GetDListLength(rawData, limbLOD->farDListPtr));
 					dList->parent = parent;
-					dList->SetName(StringHelper::Sprintf("%s_farLimbDlist_%06X", name.c_str(), limbLOD->farDListPtr));
+					dList->SetName(StringHelper::Sprintf("%s_farLimbDlist_%06X", defaultPrefix.c_str(), limbLOD->farDListPtr));
 					dList->GetSourceOutputCode(defaultPrefix);
 				}
 
@@ -206,7 +206,7 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 					limb->transX, limb->transY, limb->transZ, limb->childIndex, limb->siblingIndex, dListStr.c_str());
 			}
 
-			string limbName = StringHelper::Sprintf("%sLimb%04X", name.c_str(), limb->address);
+			string limbName = StringHelper::Sprintf("%sLimb_%06X", defaultPrefix.c_str(), limb->address);
 
 			if (parent->HasDeclaration(limb->address))
 				limbName = parent->GetDeclarationName(limb->address);
@@ -237,18 +237,18 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 		if (!parent->HasDeclaration(ptr))
 		{
 			parent->AddDeclarationArray(ptr, DeclarationAlignment::None, 4 * limbs.size(),
-				"void*", StringHelper::Sprintf("%sLimbs", name.c_str()), limbs.size(), tblStr);
+				"static void*", StringHelper::Sprintf("%sLimbs", defaultPrefix.c_str()), limbs.size(), tblStr);
 		}
 
 		if (type == ZSkeletonType::Normal)
 		{
-			string headerStr = StringHelper::Sprintf("%sLimbs, %i", name.c_str(), limbs.size());
+			string headerStr = StringHelper::Sprintf("%sLimbs, %i", defaultPrefix.c_str(), limbs.size());
 			parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align16, 8,
 				"SkeletonHeader", StringHelper::Sprintf("%s", name.c_str()), headerStr);
 		}
 		else
 		{
-			string headerStr = StringHelper::Sprintf("%sLimbs, %i, %i", name.c_str(), limbs.size(), dListCount);
+			string headerStr = StringHelper::Sprintf("%sLimbs, %i, %i", defaultPrefix.c_str(), limbs.size(), dListCount);
 			parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align16, 12,
 				"FlexSkeletonHeader", StringHelper::Sprintf("%s", name.c_str()), headerStr);
 		}


### PR DESCRIPTION
- variables generated automatically for skeletons and animations now have the `s` prefix instead of `g`, and are static
  (note typing as static does not apply to vtx arrays and display lists yet, as that is handled externally. some more work will need to happen for that)
- nameVerticies replaced with nameVtx. made this change last time but it was accidentally reverted
- unaccounted arrays and vtx arrays no longer have an empty line break on the last row
- animations headers wrap the frame count in braces for the common header
- name0x000 replaced with name_000. this is to match the unk styling used in the oot codebase. not sure if we'll keep this longterm

still todo: 
- make scenes and rooms match the codebase style more, like object files do
- have zap label all non xml defined variables as static and use `s` prefix instead of `g`. This is only hardcoded for animations currently 