### PR TITLE
Fix <filesystem> check

### DIFF
--- a/ZAPD/Directory.h
+++ b/ZAPD/Directory.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <iostream>
 
-#if defined(_MSC_VER) || defined(__clang__)
+#if __has_include(<filesystem>)
 #include <filesystem>
 namespace fs = std::filesystem;
 #else

--- a/ZAPD/Path.h
+++ b/ZAPD/Path.h
@@ -4,7 +4,7 @@
 #include <iostream>
 #include "StringHelper.h"
 
-#if defined(_MSC_VER) || defined(__clang__)
+#if __has_include(<filesystem>)
 #include <filesystem>
 namespace fs = std::filesystem;
 #else


### PR DESCRIPTION
GCC >= 9 supports `<filesystem>` and doesn't require the use of
`<experimental/filesystem>` (which would require linking libstdc++fs...)