### PR TITLE
ZAPD now supports multiple verbosity levels

### DIFF
--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -19,11 +19,11 @@ Globals::Globals()
 	segmentRefFiles = map<int, ZFile*>();
 	genSourceFile = true;
 	testMode = false;
-	debugMessages = false;
 	profile = false;
 	includeFilePrefix = false;
 	useExternalResources = true;
 	lastScene = nullptr;
+	verbosity = VERBOSITY_SILENT;
 }
 
 string Globals::FindSymbolSegRef(int segNumber, uint32_t symbolAddress)

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -17,6 +17,7 @@ public:
 	bool debugMessages; // Enables certain printfs
 	bool profile; // Measure performance of certain operations
 	bool includeFilePrefix; // Include the file prefix in symbols
+	bool verbose = false; // ZAPD outputs additional information
 	ZFileMode fileMode;
 	std::string baseRomPath, inputPath, outputPath, cfgPath;
 	TextureType texType;

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -6,6 +6,12 @@
 #include "ZTexture.h"
 #include "ZRoom/ZRoom.h"
 
+typedef enum VerbosityLevel {
+	VERBOSITY_SILENT,
+	VERBOSITY_INFO,
+	VERBOSITY_DEBUG
+} VerbosityLevel;
+
 class Globals
 {
 public:
@@ -16,7 +22,7 @@ public:
 	bool testMode; // Enables certain experimental features
 	bool profile; // Measure performance of certain operations
 	bool includeFilePrefix; // Include the file prefix in symbols
-	VerbosityLevel verbosity = VERBOSITY_SILENT; // ZAPD outputs additional information
+	VerbosityLevel verbosity; // ZAPD outputs additional information
 	ZFileMode fileMode;
 	std::string baseRomPath, inputPath, outputPath, cfgPath;
 	TextureType texType;
@@ -36,11 +42,6 @@ public:
 	bool HasSegment(int segment);
 };
 
-typedef enum VerbosityLevel {
-	VERBOSITY_SILENT,
-	VERBOSITY_INFO,
-	VERBOSITY_DEBUG
-} VerbosityLevel;
 /*
  * Note: In being able to track references across files, there are a few major files that make use of segments...
  * Segment 1: nintendo_rogo_static/title_static

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -14,10 +14,9 @@ public:
 	bool genSourceFile; // Used for extraction
 	bool useExternalResources;
 	bool testMode; // Enables certain experimental features
-	bool debugMessages; // Enables certain printfs
 	bool profile; // Measure performance of certain operations
 	bool includeFilePrefix; // Include the file prefix in symbols
-	bool verbose = false; // ZAPD outputs additional information
+	VerbosityLevel verbosity = VERBOSITY_SILENT; // ZAPD outputs additional information
 	ZFileMode fileMode;
 	std::string baseRomPath, inputPath, outputPath, cfgPath;
 	TextureType texType;
@@ -37,6 +36,11 @@ public:
 	bool HasSegment(int segment);
 };
 
+typedef enum VerbosityLevel {
+	VERBOSITY_SILENT,
+	VERBOSITY_INFO,
+	VERBOSITY_DEBUG
+} VerbosityLevel;
 /*
  * Note: In being able to track references across files, there are a few major files that make use of segments...
  * Segment 1: nintendo_rogo_static/title_static

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -175,8 +175,7 @@ int NewMain(int argc, char* argv[])
 		}
 		else if (arg == "-v") // Verbose
 		{
-			Globals::Instance->verbosity = strtol(argv[i + 1], NULL, 16);
-			i++;
+			Globals::Instance->verbosity = (VerbosityLevel)strtol(argv[++i], NULL, 16);
 		}
 	}
 

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -129,11 +129,6 @@ int NewMain(int argc, char* argv[])
 			Globals::Instance->testMode = string(argv[i + 1]) == "1";
 			i++;
 		}
-		else if (arg == "-dm") // Debug Messages
-		{
-			Globals::Instance->debugMessages = string(argv[i + 1]) == "1";
-			i++;
-		}
 		else if (arg == "-profile") // Profile
 		{
 			Globals::Instance->profile = string(argv[i + 1]) == "1";
@@ -180,11 +175,12 @@ int NewMain(int argc, char* argv[])
 		}
 		else if (arg == "-v") // Verbose
 		{
-			Globals::Instance->verbose = true;
+			Globals::Instance->verbosity = strtol(argv[i + 1], NULL, 16);
+			i++;
 		}
 	}
 
-	if (Globals::Instance->verbose)
+	if (Globals::Instance->verbosity >= VERBOSITY_INFO)
 	{
 		printf("ZAPD: Zelda Asset Processor For Decomp\n");
 	}

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -60,7 +60,6 @@ int main(int argc, char* argv[])
 int NewMain(int argc, char* argv[])
 {
 	// Syntax: ZAPD.exe [mode (b/btex/bovl/e)] (Arbritrary Number of Arguments)
-	//printf("ZAPD: Zelda Asset Processor For Decomp\n");
 
 	if (argc < 2)
 	{
@@ -179,6 +178,15 @@ int NewMain(int argc, char* argv[])
 			signal(SIGSEGV, ErrorHandler);
 #endif
 		}
+		else if (arg == "-v") // Verbose
+		{
+			Globals::Instance->verbose = true;
+		}
+	}
+
+	if (Globals::Instance->verbose)
+	{
+		printf("ZAPD: Zelda Asset Processor For Decomp\n");
 	}
 
 	if (fileMode == ZFileMode::Build || fileMode == ZFileMode::Extract || fileMode == ZFileMode::BuildSourceFile)

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char* argv[])
 int NewMain(int argc, char* argv[])
 {
 	// Syntax: ZAPD.exe [mode (b/btex/bovl/e)] (Arbritrary Number of Arguments)
-	printf("ZAPD: Zelda Asset Processor For Decomp\n");
+	//printf("ZAPD: Zelda Asset Processor For Decomp\n");
 
 	if (argc < 2)
 	{

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -495,7 +495,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 				uint32_t fmt = (__ & 0xE0) >> 5;
 				uint32_t siz = (__ & 0x18) >> 3;
 
-				if (Globals::Instance->debugMessages)
+				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 					printf("TextureGenCheck G_SETTIMG\n");
 				
 				TextureGenCheck(prefix); // HOTSPOT
@@ -866,10 +866,10 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 				lastTexWidth = (uuu >> shiftAmtW) + 1;
 				lastTexHeight = (vvv >> shiftAmtH) + 1;
 				
-				if (Globals::Instance->debugMessages)
+				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 					printf("lastTexWidth: %i lastTexHeight: %i, lastTexSizTest: 0x%x, lastTexFmt: 0x%x\n", lastTexWidth, lastTexHeight, (uint32_t)lastTexSizTest, (uint32_t)lastTexFmt);
 
-				if (Globals::Instance->debugMessages)
+				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 					printf("TextureGenCheck G_SETTILESIZE\n");
 				
 				TextureGenCheck(prefix);
@@ -929,7 +929,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 
 				lastTexLoaded = true;
 
-				if (Globals::Instance->debugMessages)
+				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 					printf("TextureGenCheck G_LOADTLUT (lastCISiz: %i)\n", (uint32_t)lastCISiz);
 				
 				TextureGenCheck(prefix);
@@ -995,7 +995,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 			case F3DZEXOpcode::G_ENDDL:
 				sprintf(line, "gsSPEndDisplayList(),");
 
-				if (Globals::Instance->debugMessages)
+				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 					printf("TextureGenCheck G_ENDDL\n");
 				
 				TextureGenCheck(prefix);
@@ -1208,7 +1208,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 			{
 				if (parent->GetDeclaration(item.first) == nullptr)
 				{
-					if (Globals::Instance->debugMessages)
+					if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 						printf("SAVING IMAGE TO %s\n", Globals::Instance->outputPath.c_str());
 
 					item.second->Save(Globals::Instance->outputPath);
@@ -1247,7 +1247,7 @@ bool ZDisplayList::TextureGenCheck(vector<uint8_t> fileData, map<uint32_t, ZText
 {
 	int segmentNumber = (texSeg & 0xFF000000) >> 24;
 
-	if (Globals::Instance->debugMessages)
+	if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 		printf("TextureGenCheck seg=%i width=%i height=%i addr=0x%06X\n", segmentNumber, texWidth, texHeight, texAddr);
 
 	if (texAddr != 0 && texWidth != 0 && texHeight != 0 && texLoaded && Globals::Instance->HasSegment(segmentNumber))

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -321,7 +321,7 @@ void SetMesh::GenDListDeclarations(std::vector<uint8_t> rawData, ZDisplayList* d
 		//zRoom->parent->AddDeclarationArray(texEntry.first, DeclarationAlignment::None, dList->textures[texEntry.first]->GetRawDataSize(), "u64",
 			//zRoom->textures[texEntry.first]->GetName(), 0, texEntry.second);
 
-		if (Globals::Instance->debugMessages)
+		if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 			printf("SAVING IMAGE TO %s\n", Globals::Instance->outputPath.c_str());
 		
 		zRoom->textures[texEntry.first]->Save(Globals::Instance->outputPath);

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -466,7 +466,7 @@ string ZRoom::GetSourceOutputCode(std::string prefix)
 
 		declaration += item.second->GetSourceOutputCode(prefix);
 
-		if (Globals::Instance->debugMessages)
+		if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 			printf("SAVING IMAGE TO %s\n", Globals::Instance->outputPath.c_str());
 		
 		item.second->Save(Globals::Instance->outputPath);


### PR DESCRIPTION
This wastes CPU cycles and creates unnecessary IO time. ZAPD doesn't need to output this.