### PR TITLE
ZAPD now supports scalar types

### DIFF
--- a/ZAPD/BitConverter.h
+++ b/ZAPD/BitConverter.h
@@ -109,6 +109,8 @@ public:
 		double value;
 		uint64_t floatData = ((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) + ((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) + ((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) + ((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
 		static_assert(sizeof(uint64_t) == sizeof(double));
+		// Checks if the float format on the platform the ZAPD binary is running on supports the same float format as the object file.
+		static_assert(std::numeric_limits<float>::is_iec559);
 		std::memcpy(&value, &floatData, sizeof(value));
 		return value;
 	}
@@ -118,6 +120,8 @@ public:
 		double value;
 		uint64_t floatData = ((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) + ((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) + ((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) + ((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
 		static_assert(sizeof(uint64_t) == sizeof(double));
+		// Checks if the float format on the platform the ZAPD binary is running on supports the same float format as the object file.
+		static_assert(std::numeric_limits<double>::is_iec559);
 		std::memcpy(&value, &floatData, sizeof(value));
 		return value;
 	}

--- a/ZAPD/ZAPD.vcxproj
+++ b/ZAPD/ZAPD.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="HighLevel\HLTexture.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Overlays\ZOverlay.cpp" />
+    <ClCompile Include="ZScalar.cpp" />
     <ClCompile Include="tinyxml2.cpp" />
     <ClCompile Include="ZAnimation.cpp" />
     <ClCompile Include="ZBlob.cpp" />
@@ -220,6 +221,7 @@
     <ClInclude Include="ZCutscene.h" />
     <ClInclude Include="ZDisplayList.h" />
     <ClInclude Include="ZFile.h" />
+    <ClInclude Include="ZScalar.h" />
     <ClInclude Include="ZSkeleton.h" />
     <ClInclude Include="ZResource.h" />
     <ClInclude Include="ZRoom\ActorList.h" />

--- a/ZAPD/ZAPD.vcxproj.filters
+++ b/ZAPD/ZAPD.vcxproj.filters
@@ -192,6 +192,9 @@
     <ClCompile Include="ZCollision.cpp">
       <Filter>Source Files\Z64</Filter>
     </ClCompile>
+    <ClCompile Include="ZScalar.cpp">
+      <Filter>Source Files\Z64</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Path.h">
@@ -408,6 +411,9 @@
       <Filter>Header Files\Libraries</Filter>
     </ClInclude>
     <ClInclude Include="ZCollision.h">
+      <Filter>Header Files\Z64</Filter>
+    </ClInclude>
+    <ClInclude Include="ZScalar.h">
       <Filter>Header Files\Z64</Filter>
     </ClInclude>
   </ItemGroup>

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -33,7 +33,8 @@ enum class ZResourceType
 	Cutscene,
 	Blob,
 	Limb,
-	Skeleton
+	Skeleton,
+	Scalar
 };
 
 class ZResource

--- a/ZAPD/ZScalar.cpp
+++ b/ZAPD/ZScalar.cpp
@@ -1,0 +1,219 @@
+#include "ZScalar.h"
+#include "ZFile.h"
+#include "BitConverter.h"
+#include "StringHelper.h"
+#include "File.h"
+#include "HighLevel/HLAnimationIntermediette.h"
+#include "Globals.h"
+
+ZScalar* ZScalar::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath)
+{
+	ZScalar* scalar = new ZScalar();
+	scalar->rawData = nRawData;
+	scalar->rawDataIndex = rawDataIndex;
+	scalar->ParseXML(reader);
+	scalar->ParseRawData();
+
+	return scalar;
+}
+
+ZScalar::ZScalar() : ZResource()
+{
+	memset(&scalarData, 0, sizeof(ZScalarData));
+	scalarType = ZSCALAR_NONE;
+}
+
+ZScalar::ZScalar(const ZScalarType scalarType) : ZScalar()
+{
+	this->scalarType = scalarType;
+}
+
+void ZScalar::ParseXML(tinyxml2::XMLElement* reader)
+{
+	ZResource::ParseXML(reader);
+
+	name = reader->Attribute("Name");
+
+	std::string type = reader->Attribute("Type");
+	scalarType = ZScalar::MapOutputTypeToScalarType(type);
+}
+
+ZScalarType ZScalar::MapOutputTypeToScalarType(const std::string& type) {
+	if (type == "s8")
+	{
+		return ZSCALAR_S8;
+	}
+	else if (type == "u8")
+	{
+		return ZSCALAR_U8;
+	}
+	else if (type == "s16")
+	{
+		return ZSCALAR_S16;
+	}
+	else if (type == "u16")
+	{
+		return ZSCALAR_U16;
+	}
+	else if (type == "s32")
+	{
+		return ZSCALAR_S32;
+	}
+	else if (type == "u32")
+	{
+		return ZSCALAR_U32;
+	}
+	else if (type == "s64")
+	{
+		return ZSCALAR_S64;
+	}
+	else if (type == "u64")
+	{
+		return ZSCALAR_U64;
+	}
+	else if (type == "f32")
+	{
+		return ZSCALAR_F32;
+	}
+	else if (type == "f64")
+	{
+		return ZSCALAR_F64;
+	}
+
+	return ZSCALAR_NONE;
+}
+
+std::string ZScalar::MapScalarTypeToOutputType(const ZScalarType scalarType)
+{
+	switch (scalarType) {
+	case ZSCALAR_S8:
+		return "s8";
+	case ZSCALAR_U8:
+		return "u8";
+	case ZSCALAR_S16:
+		return "s16";
+	case ZSCALAR_U16:
+		return "u16";
+	case ZSCALAR_S32:
+		return "s32";
+	case ZSCALAR_U32:
+		return "u32";
+	case ZSCALAR_S64:
+		return "s64";
+	case ZSCALAR_U64:
+		return "u64";
+	case ZSCALAR_F32:
+		return "f32";
+	case ZSCALAR_F64:
+		return "f64";
+	default:
+		return "char*";
+	}
+}
+
+int ZScalar::MapTypeToSize(const ZScalarType scalarType)
+{
+	switch (scalarType) {
+	case ZSCALAR_S8:
+		return sizeof(scalarData.s8);
+	case ZSCALAR_U8:
+		return sizeof(scalarData.u8);
+	case ZSCALAR_S16:
+		return sizeof(scalarData.s16);
+	case ZSCALAR_U16:
+		return sizeof(scalarData.u16);
+	case ZSCALAR_S32:
+		return sizeof(scalarData.s32);
+	case ZSCALAR_U32:
+		return sizeof(scalarData.u32);
+	case ZSCALAR_S64:
+		return sizeof(scalarData.s64);
+	case ZSCALAR_U64:
+		return sizeof(scalarData.u64);
+	case ZSCALAR_F32:
+		return sizeof(scalarData.f32);
+	case ZSCALAR_F64:
+		return sizeof(scalarData.f64);
+	default:
+		return 0;
+	}
+}
+
+int ZScalar::GetRawDataSize()
+{
+	return ZScalar::MapTypeToSize(scalarType);
+}
+
+void ZScalar::ParseRawData()
+{
+	ZScalar::ParseRawData(rawData, rawDataIndex);
+}
+
+void ZScalar::ParseRawData(const std::vector<uint8_t>& data, const int offset)
+{
+	switch (scalarType) {
+	case ZSCALAR_S8:
+		scalarData.s8 = BitConverter::ToInt8BE(data, offset);
+	case ZSCALAR_U8:
+		scalarData.u8 = BitConverter::ToUInt8BE(data, offset);
+	case ZSCALAR_S16:
+		scalarData.s16 = BitConverter::ToInt16BE(data, offset);
+	case ZSCALAR_U16:
+		scalarData.u16 = BitConverter::ToUInt16BE(data, offset);
+	case ZSCALAR_S32:
+		scalarData.s32 = BitConverter::ToInt32BE(data, offset);
+	case ZSCALAR_U32:
+		scalarData.u32 = BitConverter::ToUInt32BE(data, offset);
+	case ZSCALAR_S64:
+		scalarData.s64 = BitConverter::ToInt64BE(data, offset);
+	case ZSCALAR_U64:
+		scalarData.u64 = BitConverter::ToUInt64BE(data, offset);
+	case ZSCALAR_F32:
+		scalarData.f32 = BitConverter::ToFloatBE(data, offset);
+	case ZSCALAR_F64:
+		scalarData.f64 = BitConverter::ToDoubleBE(data, offset);
+	}
+}
+
+std::string ZScalar::GetSourceTypeName()
+{
+	return ZScalar::MapScalarTypeToOutputType(scalarType);
+}
+
+std::string ZScalar::GetSourceValue()
+{
+	switch (scalarType) {
+	case ZSCALAR_S8:
+		return StringHelper::Sprintf("%hhd", scalarData.s8);
+	case ZSCALAR_U8:
+		return StringHelper::Sprintf("%hhu", scalarData.u8);
+	case ZSCALAR_S16:
+		return StringHelper::Sprintf("%hd", scalarData.s16);
+	case ZSCALAR_U16:
+		return StringHelper::Sprintf("%hu", scalarData.u16);
+	case ZSCALAR_S32:
+		return StringHelper::Sprintf("%ld", scalarData.s32);
+	case ZSCALAR_U32:
+		return StringHelper::Sprintf("%lu", scalarData.u32);
+	case ZSCALAR_S64:
+		return StringHelper::Sprintf("%lld", scalarData.s64);
+	case ZSCALAR_U64:
+		return StringHelper::Sprintf("%llu", scalarData.u64);
+	case ZSCALAR_F32:
+		return StringHelper::Sprintf("%f", scalarData.f32);
+	case ZSCALAR_F64:
+		return StringHelper::Sprintf("%lf", scalarData.f64);
+	default:
+		return "\"BADTYPE!!\"";
+	}
+}
+
+std::string ZScalar::GetSourceOutputCode(std::string prefix)
+{
+	if (parent != nullptr)
+	{
+		parent->declarations[rawDataIndex] = new Declaration(DeclarationAlignment::None, 16, GetSourceTypeName(), name, false, GetSourceValue());
+	}
+
+	return "";
+}

--- a/ZAPD/ZScalar.cpp
+++ b/ZAPD/ZScalar.cpp
@@ -208,7 +208,7 @@ std::string ZScalar::GetSourceValue()
 	}
 }
 
-std::string ZScalar::GetSourceOutputCode(std::string prefix)
+std::string ZScalar::GetSourceOutputCode(const std::string& prefix)
 {
 	if (parent != nullptr)
 	{

--- a/ZAPD/ZScalar.cpp
+++ b/ZAPD/ZScalar.cpp
@@ -212,7 +212,7 @@ std::string ZScalar::GetSourceOutputCode(const std::string& prefix)
 {
 	if (parent != nullptr)
 	{
-		parent->declarations[rawDataIndex] = new Declaration(DeclarationAlignment::None, 16, GetSourceTypeName(), name, false, GetSourceValue());
+		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(), GetSourceTypeName(), GetName(), GetSourceValue());
 	}
 
 	return "";

--- a/ZAPD/ZScalar.cpp
+++ b/ZAPD/ZScalar.cpp
@@ -217,3 +217,8 @@ std::string ZScalar::GetSourceOutputCode(std::string prefix)
 
 	return "";
 }
+
+ZResourceType ZScalar::GetResourceType()
+{
+	return ZResourceType::Scalar;
+}

--- a/ZAPD/ZScalar.h
+++ b/ZAPD/ZScalar.h
@@ -45,7 +45,7 @@ public:
 	void ParseXML(tinyxml2::XMLElement* reader);
 	std::string GetSourceTypeName();
 	std::string GetSourceValue();
-	std::string GetSourceOutputCode(std::string prefix);
+	std::string GetSourceOutputCode(const std::string& prefix);
 	int GetRawDataSize();
 	ZResourceType GetResourceType();
 

--- a/ZAPD/ZScalar.h
+++ b/ZAPD/ZScalar.h
@@ -47,6 +47,7 @@ public:
 	std::string GetSourceValue();
 	std::string GetSourceOutputCode(std::string prefix);
 	int GetRawDataSize();
+	ZResourceType GetResourceType();
 
 	static ZScalar* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath);
 	static int MapTypeToSize(const ZScalarType scalarType);

--- a/ZAPD/ZScalar.h
+++ b/ZAPD/ZScalar.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <stdint.h>
+#include "ZResource.h"
+#include "tinyxml2.h"
+
+typedef enum ZScalarType {
+	ZSCALAR_NONE,
+	ZSCALAR_S8,
+	ZSCALAR_U8,
+	ZSCALAR_S16,
+	ZSCALAR_U16,
+	ZSCALAR_S32,
+	ZSCALAR_U32,
+	ZSCALAR_S64,
+	ZSCALAR_U64,
+	ZSCALAR_F32,
+	ZSCALAR_F64
+} ZScalarType;
+
+typedef union ZScalarData {
+	uint8_t u8;
+	int8_t s8;
+	uint16_t u16;
+	int16_t s16;
+	uint32_t u32;
+	int32_t s32;
+	uint64_t u64;
+	int64_t s64;
+	float f32;
+	double f64;
+} ZScalarData;
+
+class ZScalar : public ZResource
+{
+public:
+	ZScalarData scalarData;
+	ZScalarType scalarType;
+
+	ZScalar();
+	ZScalar(const ZScalarType primitiveType);
+
+	void ParseXML(tinyxml2::XMLElement* reader);
+	std::string GetSourceTypeName();
+	std::string GetSourceValue();
+	std::string GetSourceOutputCode(std::string prefix);
+	int GetRawDataSize();
+
+	static ZScalar* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath);
+	static int MapTypeToSize(const ZScalarType scalarType);
+	static ZScalarType MapOutputTypeToScalarType(const std::string& type);
+	static std::string MapScalarTypeToOutputType(const ZScalarType scalarType);
+
+protected:
+	void ParseRawData();
+	void ParseRawData(const std::vector<uint8_t>& data, const int offset);
+};


### PR DESCRIPTION
Additionally wrapped a few output statements in verbosity checks.
Additionally added checks for environment float types in BitConverter