### PR TITLE
Made a bunch of declarations static. Removed external writes to declarations dictionary.

### DIFF
--- a/ZAPD/BitConverter.h
+++ b/ZAPD/BitConverter.h
@@ -91,7 +91,7 @@ public:
 		float value;
 		uint32_t floatData = ((uint32_t)data[offset + 0] << 24) + ((uint32_t)data[offset + 1] << 16) + ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
 		static_assert(sizeof(uint32_t) == sizeof(float));
-		std::memcpy(&value, &floatData, sizeof(value));  
+		std::memcpy(&value, &floatData, sizeof(value));
 		return value;
 	}
 

--- a/ZAPD/Directory.h
+++ b/ZAPD/Directory.h
@@ -19,12 +19,12 @@ public:
 		return fs::current_path().u8string();
 	}
 
-	static bool Exists(std::string path)
+	static bool Exists(const std::string& path)
 	{
 		return fs::exists(fs::path(path));
 	}
 
-	static void CreateDirectory(std::string path)
+	static void CreateDirectory(const std::string& path)
 	{
 		fs::create_directory(path);
 	}

--- a/ZAPD/File.h
+++ b/ZAPD/File.h
@@ -11,13 +11,13 @@
 class File
 {
 public:
-	static bool Exists(std::string filePath)
+	static bool Exists(const std::string& filePath)
 	{
 		std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
 		return file.good();
 	}
-	
-	static std::vector<uint8_t> ReadAllBytes(std::string filePath)
+
+	static std::vector<uint8_t> ReadAllBytes(const std::string& filePath)
 	{
 		std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
 		int fileSize = (int)file.tellg();
@@ -27,7 +27,7 @@ public:
 		return std::vector<uint8_t>(data, data + fileSize);
 	};
 
-	static std::string ReadAllText(std::string filePath)
+	static std::string ReadAllText(const std::string& filePath)
 	{
 		std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
 		int fileSize = (int)file.tellg();
@@ -38,7 +38,7 @@ public:
 		return std::string((const char*)data);
 	};
 
-	static std::vector<std::string> ReadAllLines(std::string filePath)
+	static std::vector<std::string> ReadAllLines(const std::string& filePath)
 	{
 		std::string text = ReadAllText(filePath);
 		std::vector<std::string> lines = StringHelper::Split(text, "\n");
@@ -46,13 +46,13 @@ public:
 		return lines;
 	};
 
-	static void WriteAllBytes(std::string filePath, std::vector<uint8_t> data)
+	static void WriteAllBytes(const std::string& filePath, const std::vector<uint8_t>& data)
 	{
 		std::ofstream file(filePath, std::ios::binary);
 		file.write((char*)data.data(), data.size());
 	};
 
-	static void WriteAllText(std::string filePath, std::string text)
+	static void WriteAllText(const std::string& filePath, const std::string& text)
 	{
 		std::ofstream file(filePath, std::ios::out);
 		file.write(text.c_str(), text.size());

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -64,7 +64,7 @@ string Globals::FindSymbolSegRef(int segNumber, uint32_t symbolAddress)
 	return "ERROR";
 }
 
-void Globals::ReadConfigFile(string configFilePath)
+void Globals::ReadConfigFile(const std::string& configFilePath)
 {
 	XMLDocument doc;
 	XMLError eResult = doc.LoadFile(configFilePath.c_str());
@@ -93,7 +93,7 @@ void Globals::ReadConfigFile(string configFilePath)
 	}
 }
 
-void Globals::GenSymbolMap(string symbolMapPath)
+void Globals::GenSymbolMap(const std::string& symbolMapPath)
 {
 	auto symbolLines = File::ReadAllLines(symbolMapPath);
 

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <string>
 #include <vector>
 #include "ZFile.h"
@@ -36,8 +37,8 @@ public:
 
 	Globals();
 	std::string FindSymbolSegRef(int segNumber, uint32_t symbolAddress);
-	void ReadConfigFile(std::string configFilePath);
-	void GenSymbolMap(std::string symbolMapPath);
+	void ReadConfigFile(const std::string& configFilePath);
+	void GenSymbolMap(const std::string& symbolMapPath);
 	void AddSegment(int segment);
 	bool HasSegment(int segment);
 };

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -256,10 +256,10 @@ bool Parse(const std::string& xmlFilePath, const std::string& basePath, const st
 			file->ExtractResources(outPath);
 	}
 
-	XMLElement* element = root->FirstChildElement("File");
+	//XMLElement* element = root->FirstChildElement("File");
 
-	if (element == nullptr)
-		return false;
+	//if (element == nullptr)
+		//return false;
 
 	return true;
 }

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -21,12 +21,12 @@
 using namespace tinyxml2;
 using namespace std;
 
-bool Parse(string xmlFilePath, string basePath, string outPath, ZFileMode fileMode);
+bool Parse(const std::string& xmlFilePath, const std::string& basePath, const std::string& outPath, ZFileMode fileMode);
 
-void BuildAssetTexture(string pngFilePath, TextureType texType, string outPath);
-void BuildAssetBlob(string blobFilePath, string outPath);
-void BuildAssetModelIntermediette(string mdlPath, string outPath);
-void BuildAssetAnimationIntermediette(string animPath, string outPath);
+void BuildAssetTexture(const std::string& pngFilePath, TextureType texType, const std::string& outPath);
+void BuildAssetBlob(const std::string& blobFilePath, const std::string& outPath);
+void BuildAssetModelIntermediette(const std::string& mdlPath, const std::string& outPath);
+void BuildAssetAnimationIntermediette(const std::string& animPath, const std::string& outPath);
 
 int NewMain(int argc, char* argv[]);
 
@@ -214,7 +214,7 @@ int NewMain(int argc, char* argv[])
 	else if (fileMode == ZFileMode::BuildOverlay)
 	{
 		ZOverlay* overlay = ZOverlay::FromBuild(Path::GetDirectoryName(Globals::Instance->inputPath), Path::GetDirectoryName(Globals::Instance->cfgPath));
-		
+
 		if (overlay)
 			File::WriteAllText(Globals::Instance->outputPath, overlay->GetSourceOutputCode(""));
 	}
@@ -222,7 +222,7 @@ int NewMain(int argc, char* argv[])
 	return 0;
 }
 
-bool Parse(string xmlFilePath, string basePath, string outPath, ZFileMode fileMode)
+bool Parse(const std::string& xmlFilePath, const std::string& basePath, const std::string& outPath, ZFileMode fileMode)
 {
 	XMLDocument doc;
 	XMLError eResult = doc.LoadFile(xmlFilePath.c_str());
@@ -264,7 +264,7 @@ bool Parse(string xmlFilePath, string basePath, string outPath, ZFileMode fileMo
 	return true;
 }
 
-void BuildAssetTexture(string pngFilePath, TextureType texType, string outPath)
+void BuildAssetTexture(const std::string& pngFilePath, TextureType texType, const std::string& outPath)
 {
 	vector<string> split = StringHelper::Split(outPath, "/");
 	string name = StringHelper::Split(split[split.size() - 1], ".")[0];
@@ -278,11 +278,11 @@ void BuildAssetTexture(string pngFilePath, TextureType texType, string outPath)
 	string src = tex->GetSourceOutputCode(name);
 
 	File::WriteAllText(outPath, src);
-	
+
 	delete tex;
 }
 
-void BuildAssetBlob(string blobFilePath, string outPath)
+void BuildAssetBlob(const std::string& blobFilePath, const std::string& outPath)
 {
 	vector<string> split = StringHelper::Split(outPath, "/");
 	ZBlob* blob = ZBlob::FromFile(blobFilePath);
@@ -296,7 +296,7 @@ void BuildAssetBlob(string blobFilePath, string outPath)
 	delete blob;
 }
 
-void BuildAssetModelIntermediette(string mdlPath, string outPath)
+void BuildAssetModelIntermediette(const std::string& mdlPath, const std::string& outPath)
 {
 	XMLDocument doc;
 	XMLError eResult = doc.LoadFile(mdlPath.c_str());
@@ -304,13 +304,13 @@ void BuildAssetModelIntermediette(string mdlPath, string outPath)
 	vector<string> split = StringHelper::Split(outPath, "/");
 	HLModelIntermediette* mdl = HLModelIntermediette::FromXML(doc.RootElement());
 	string output = mdl->OutputCode();
-	
+
 	File::WriteAllText(outPath, output);
 
 	delete mdl;
 }
 
-void BuildAssetAnimationIntermediette(string animPath, string outPath)
+void BuildAssetAnimationIntermediette(const std::string& animPath, const std::string& outPath)
 {
 	vector<string> split = StringHelper::Split(outPath, "/");
 	ZFile* file = new ZFile("", split[split.size() - 2]);
@@ -323,7 +323,7 @@ void BuildAssetAnimationIntermediette(string animPath, string outPath)
 
 	zAnim->GetSourceOutputCode(split[split.size() - 2]);
 	string output = "";
-	
+
 	output += file->declarations[2]->text + "\n";
 	output += file->declarations[1]->text + "\n";
 	output += file->declarations[0]->text + "\n";

--- a/ZAPD/Overlays/ZOverlay.cpp
+++ b/ZAPD/Overlays/ZOverlay.cpp
@@ -41,14 +41,14 @@ ZOverlay* ZOverlay::FromBuild(string buildPath, string cfgFolderPath)
 	vector<RelocationEntry*> dataRelocs;
 	vector<RelocationEntry*> rodataRelocs;
 
-	
+
 	// get the elf files
 	vector<elfio*> readers;
-	for (int i = 1; i < cfgLines.size(); i++) 
+	for (int i = 1; i < cfgLines.size(); i++)
 	{
 		string elfPath = buildPath + "/" + cfgLines[i].substr(0, cfgLines[i].size()-2) + ".o";
 		elfio* reader = new elfio();
-		
+
 		if (!reader->load(elfPath))
 		{
 			// not all files were compiled
@@ -59,7 +59,7 @@ ZOverlay* ZOverlay::FromBuild(string buildPath, string cfgFolderPath)
 			delete ovl;
 			return nullptr;
 		}
-		
+
 		readers.push_back(reader);
 	}
 
@@ -108,7 +108,7 @@ ZOverlay* ZOverlay::FromBuild(string buildPath, string cfgFolderPath)
 						{
 							if (curSymShndx != SHN_UNDEF)
 								break;
-								
+
 							if (reader == curReader)
 								continue;
 
@@ -158,7 +158,7 @@ ZOverlay* ZOverlay::FromBuild(string buildPath, string cfgFolderPath)
 				}
 			}
 		}
-		
+
 		// increase section offsets
 		for (int i = 0; i < sec_num; i++)
 		{
@@ -177,7 +177,7 @@ ZOverlay* ZOverlay::FromBuild(string buildPath, string cfgFolderPath)
 		ovl->entries.push_back(reloc);
 	for (auto reloc : rodataRelocs)
 		ovl->entries.push_back(reloc);
-	
+
 	for (auto r: readers)
 		delete r;
 	readers.clear();
@@ -185,7 +185,7 @@ ZOverlay* ZOverlay::FromBuild(string buildPath, string cfgFolderPath)
 	return ovl;
 }
 
-string ZOverlay::GetSourceOutputCode(std::string prefix)
+string ZOverlay::GetSourceOutputCode(const std::string& prefix)
 {
 	string output = "";
 
@@ -226,6 +226,6 @@ SectionType ZOverlay::GetSectionTypeFromStr(string sectionName)
 		return SectionType::RoData;
 	else if (sectionName == ".rel.bss" || sectionName == ".bss")
 		return SectionType::Bss;
-		
+
 	return SectionType::ERROR;
 }

--- a/ZAPD/Overlays/ZOverlay.h
+++ b/ZAPD/Overlays/ZOverlay.h
@@ -28,9 +28,9 @@ public:
 	RelocationType relocationType;
 	int32_t offset;
 
-	RelocationEntry(SectionType nSecType, RelocationType nRelType, int32_t nOffset) 
+	RelocationEntry(SectionType nSecType, RelocationType nRelType, int32_t nOffset)
 	{
-		sectionType = nSecType; 
+		sectionType = nSecType;
 		relocationType = nRelType;
 		offset = nOffset;
 	}
@@ -55,7 +55,7 @@ public:
 	ZOverlay(std::string nName);
 	~ZOverlay();
 	static ZOverlay* FromBuild(std::string buildPath, std::string cfgFolderPath);
-	std::string GetSourceOutputCode(std::string prefix);
+	std::string GetSourceOutputCode(const std::string& prefix);
 
 private:
 	std::vector<RelocationEntry*> entries;

--- a/ZAPD/Path.h
+++ b/ZAPD/Path.h
@@ -15,18 +15,18 @@ namespace fs = std::experimental::filesystem;
 class Path
 {
 public:
-	static std::string GetFileNameWithoutExtension(std::string input)
+	static std::string GetFileNameWithoutExtension(const std::string& input)
 	{
 		std::vector<std::string> split = StringHelper::Split(input, "/");
 		return split[split.size() - 1].substr(0, input.find_last_of("."));
 	};
 
-	static std::string GetFileNameExtension(std::string input)
+	static std::string GetFileNameExtension(const std::string& input)
 	{
 		return input.substr(input.find_last_of("."), input.length());
 	};
 
-	static std::string GetPath(std::string input)
+	static std::string GetPath(const std::string& input)
 	{
 		std::vector<std::string> split = StringHelper::Split(input, "/");
 		std::string output = "";
@@ -40,7 +40,7 @@ public:
 		return output;
 	};
 
-	static std::string GetDirectoryName(std::string path)
+	static std::string GetDirectoryName(const std::string& path)
 	{
 		return fs::path(path).parent_path().u8string();
 	};

--- a/ZAPD/StringHelper.h
+++ b/ZAPD/StringHelper.h
@@ -8,7 +8,7 @@
 class StringHelper
 {
 public:
-	static std::vector<std::string> Split(std::string s, std::string delimiter)
+	static std::vector<std::string> Split(std::string s, const std::string& delimiter)
 	{
 		std::vector<std::string> result;
 
@@ -28,7 +28,7 @@ public:
 		return result;
 	}
 
-	static std::string Strip(std::string s, std::string delimiter)
+	static std::string Strip(std::string s, const std::string& delimiter)
 	{
 		size_t pos = 0;
 		std::string token;
@@ -42,17 +42,17 @@ public:
 		return s;
 	}
 
-	static bool StartsWith(std::string s, std::string input)
+	static bool StartsWith(const std::string& s, const std::string& input)
 	{
 		return s.rfind(input, 0) == 0;
 	}
 
-	static bool Contains(std::string s, std::string input)
+	static bool Contains(const std::string& s, const std::string& input)
 	{
 		return s.find(input) != std::string::npos;
 	}
 
-	static bool EndsWith(std::string s, std::string input)
+	static bool EndsWith(const std::string& s, const std::string& input)
 	{
 		int inputLen = strlen(input.c_str());
 		return s.rfind(input) == (s.size() - inputLen);

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -1,4 +1,5 @@
 #include "ZAnimation.h"
+#include <utility>
 #include "ZFile.h"
 #include "BitConverter.h"
 #include "StringHelper.h"
@@ -15,13 +16,13 @@ ZAnimation::ZAnimation() : ZResource()
 
 void ZAnimation::ParseRawData()
 {
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	// Read the header
 	frameCount = BitConverter::ToInt16BE(data, rawDataIndex + 0);
 }
 
-void ZAnimation::Save(string outFolder)
+void ZAnimation::Save(const std::string& outFolder)
 {
 	if (Globals::Instance->testMode)
 	{
@@ -40,7 +41,7 @@ void ZAnimation::ParseXML(tinyxml2::XMLElement* reader)
 	name = reader->Attribute("Name");
 }
 
-string ZAnimation::GetSourceOutputCode(string prefix)
+string ZAnimation::GetSourceOutputCode(const std::string& prefix)
 {
 	return "";
 }
@@ -52,7 +53,7 @@ ZNormalAnimation::ZNormalAnimation() : ZAnimation()
 	limit = 0;
 }
 
-std::string ZNormalAnimation::GetSourceOutputCode(std::string prefix)
+std::string ZNormalAnimation::GetSourceOutputCode(const std::string& prefix)
 {
 	if (parent != nullptr)
 	{
@@ -99,10 +100,10 @@ int ZNormalAnimation::GetRawDataSize()
 	return 16;
 }
 
-ZNormalAnimation* ZNormalAnimation::ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath)
+ZNormalAnimation* ZNormalAnimation::ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, const std::string& nRelPath)
 {
 	ZNormalAnimation* anim = new ZNormalAnimation();
-	anim->rawData = nRawData;
+	anim->rawData = std::move(nRawData);
 	anim->rawDataIndex = rawDataIndex;
 	anim->ParseXML(reader);
 	anim->ParseRawData();
@@ -114,7 +115,7 @@ void ZNormalAnimation::ParseRawData()
 {
 	ZAnimation::ParseRawData();
 
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	rotationValuesSeg = BitConverter::ToInt32BE(data, rawDataIndex + 4) & 0x00FFFFFF;
 	rotationIndicesSeg = BitConverter::ToInt32BE(data, rawDataIndex + 8) & 0x00FFFFFF;
@@ -144,7 +145,7 @@ ZLinkAnimation::ZLinkAnimation() : ZAnimation()
 	segmentAddress = 0;
 }
 
-std::string ZLinkAnimation::GetSourceOutputCode(std::string prefix)
+std::string ZLinkAnimation::GetSourceOutputCode(const std::string& prefix)
 {
 	if (parent != nullptr)
 	{
@@ -162,10 +163,10 @@ int ZLinkAnimation::GetRawDataSize()
 	return 8;
 }
 
-ZLinkAnimation* ZLinkAnimation::ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath)
+ZLinkAnimation* ZLinkAnimation::ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, const std::string& nRelPath)
 {
 	ZLinkAnimation* anim = new ZLinkAnimation();
-	anim->rawData = nRawData;
+	anim->rawData = std::move(nRawData);
 	anim->rawDataIndex = rawDataIndex;
 	anim->ParseXML(reader);
 	anim->ParseRawData();
@@ -177,7 +178,7 @@ void ZLinkAnimation::ParseRawData()
 {
 	ZAnimation::ParseRawData();
 
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	//segmentAddress = SEG2FILESPACE(BitConverter::ToInt32BE(data, rawDataIndex + 4));
 	segmentAddress = (BitConverter::ToInt32BE(data, rawDataIndex + 4));

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -62,7 +62,7 @@ std::string ZNormalAnimation::GetSourceOutputCode(const std::string& prefix)
 
 		string headerStr = StringHelper::Sprintf("{ %i }, %sFrameData, %sJointIndices, %i",
 			frameCount, defaultPrefix.c_str(), defaultPrefix.c_str(), limit);
-		parent->declarations[rawDataIndex] = new Declaration(DeclarationAlignment::None, 16, "AnimationHeader", StringHelper::Sprintf("%s", name.c_str()), false, headerStr);
+		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, 16, "AnimationHeader", StringHelper::Sprintf("%s", name.c_str()), headerStr);
 
 		string indicesStr = "";
 		string valuesStr = "    ";
@@ -152,7 +152,7 @@ std::string ZLinkAnimation::GetSourceOutputCode(const std::string& prefix)
 		string segSymbol = segmentAddress == 0 ? "NULL" : parent->GetDeclarationName(segmentAddress, StringHelper::Sprintf("%sSeg%06X", name.c_str(), segmentAddress));
 		string headerStr = StringHelper::Sprintf("{ %i }, 0x%08X",
 			frameCount, segmentAddress);
-		parent->declarations[rawDataIndex] = new Declaration(DeclarationAlignment::None, 16, "LinkAnimationHeader", StringHelper::Sprintf("%s", name.c_str()), false, headerStr);
+		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, 16, "LinkAnimationHeader", StringHelper::Sprintf("%s", name.c_str()), headerStr);
 	}
 
 	return "";

--- a/ZAPD/ZAnimation.h
+++ b/ZAPD/ZAnimation.h
@@ -20,14 +20,14 @@ class ZAnimation : public ZResource
 public:
 
 	int16_t frameCount;
-	
+
 	ZAnimation();
 
-	std::string GetSourceOutputCode(std::string prefix);
+	std::string GetSourceOutputCode(const std::string& prefix);
 protected:
 
 	virtual void ParseRawData();
-	void Save(std::string outFolder);
+	void Save(const std::string& outFolder);
 	void ParseXML(tinyxml2::XMLElement* reader);
 };
 
@@ -39,13 +39,13 @@ public:
 	uint32_t rotationValuesSeg;
 	uint32_t rotationIndicesSeg;
 	int16_t limit;
-	
+
 	ZNormalAnimation();
 
-	std::string GetSourceOutputCode(std::string prefix);
+	std::string GetSourceOutputCode(const std::string& prefix);
 	virtual int GetRawDataSize();
 
-	static ZNormalAnimation* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath);
+	static ZNormalAnimation* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, const std::string& nRelPath);
 
 protected:
 	virtual void ParseRawData();
@@ -58,10 +58,10 @@ public:
 
 	ZLinkAnimation();
 
-	std::string GetSourceOutputCode(std::string prefix);
+	std::string GetSourceOutputCode(const std::string& prefix);
 	virtual int GetRawDataSize();
 
-	static ZLinkAnimation* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath);
+	static ZLinkAnimation* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, const std::string& nRelPath);
 
 protected:
 	virtual void ParseRawData();

--- a/ZAPD/ZBlob.cpp
+++ b/ZAPD/ZBlob.cpp
@@ -13,14 +13,14 @@ ZBlob::ZBlob() : ZResource()
 
 }
 
-ZBlob::ZBlob(std::vector<uint8_t> nRawData, int nRawDataIndex, int size, std::string nName) : ZBlob()
+ZBlob::ZBlob(const std::vector<uint8_t>& nRawData, int nRawDataIndex, int size, std::string nName) : ZBlob()
 {
 	rawDataIndex = nRawDataIndex;
 	rawData = vector<uint8_t>(nRawData.data() + rawDataIndex, nRawData.data() + rawDataIndex + size);
-	name = nName;
+	name = std::move(nName);
 }
 
-ZBlob* ZBlob::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int nRawDataIndex, string nRelPath)
+ZBlob* ZBlob::ExtractFromXML(XMLElement* reader, const vector<uint8_t>& nRawData, int nRawDataIndex, string nRelPath)
 {
 	ZBlob* blob = new ZBlob();
 
@@ -29,12 +29,12 @@ ZBlob* ZBlob::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int n
 	blob->ParseXML(reader);
 	int size = strtol(reader->Attribute("Size"), NULL, 16);
 	blob->rawData = vector<uint8_t>(nRawData.data() + blob->rawDataIndex, nRawData.data() + blob->rawDataIndex + size);
-	blob->relativePath = nRelPath;
+	blob->relativePath = std::move(nRelPath);
 
 	return blob;
 }
 
-ZBlob* ZBlob::BuildFromXML(XMLElement* reader, string inFolder, bool readFile)
+ZBlob* ZBlob::BuildFromXML(XMLElement* reader, const std::string& inFolder, bool readFile)
 {
 	ZBlob* blob = new ZBlob();
 
@@ -46,7 +46,7 @@ ZBlob* ZBlob::BuildFromXML(XMLElement* reader, string inFolder, bool readFile)
 	return blob;
 }
 
-ZBlob* ZBlob::FromFile(string filePath)
+ZBlob* ZBlob::FromFile(const std::string& filePath)
 {
 	int comp;
 	ZBlob* blob = new ZBlob();
@@ -56,7 +56,7 @@ ZBlob* ZBlob::FromFile(string filePath)
 	return blob;
 }
 
-string ZBlob::GetSourceOutputCode(std::string prefix)
+string ZBlob::GetSourceOutputCode(const std::string& prefix)
 {
 	sourceOutput = "";
 	//sourceOutput += StringHelper::Sprintf("u8 %s_%s[] = \n{\n", prefix.c_str(), name.c_str());
@@ -77,12 +77,12 @@ string ZBlob::GetSourceOutputCode(std::string prefix)
 	return sourceOutput;
 }
 
-string ZBlob::GetSourceOutputHeader(std::string prefix)
+string ZBlob::GetSourceOutputHeader(const std::string& prefix)
 {
 	return StringHelper::Sprintf("extern u8 %s[];\n", name.c_str());
 }
 
-void ZBlob::Save(string outFolder)
+void ZBlob::Save(const std::string& outFolder)
 {
 	//printf("NAME = %s\n", name.c_str());
 	File::WriteAllBytes(outFolder + "/" + name + ".bin", rawData);

--- a/ZAPD/ZBlob.h
+++ b/ZAPD/ZBlob.h
@@ -6,14 +6,14 @@
 class ZBlob : public ZResource
 {
 public:
-	ZBlob(std::vector<uint8_t> nRawData, int rawDataIndex, int size, std::string nName);
+	ZBlob(const std::vector<uint8_t>& nRawData, int rawDataIndex, int size, std::string nName);
 
-	static ZBlob* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath);
-	static ZBlob* BuildFromXML(tinyxml2::XMLElement* reader, std::string inFolder, bool readFile);
-	static ZBlob* FromFile(std::string filePath);
-	std::string GetSourceOutputCode(std::string prefix);
-	std::string GetSourceOutputHeader(std::string prefix);
-	void Save(std::string outFolder);
+	static ZBlob* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int rawDataIndex, std::string nRelPath);
+	static ZBlob* BuildFromXML(tinyxml2::XMLElement* reader, const std::string& inFolder, bool readFile);
+	static ZBlob* FromFile(const std::string& filePath);
+	std::string GetSourceOutputCode(const std::string& prefix);
+	std::string GetSourceOutputHeader(const std::string& prefix);
+	void Save(const std::string& outFolder);
 	bool IsExternalResource();
 	std::string GetExternalExtension();
 	ZResourceType GetResourceType();

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -11,9 +11,9 @@ ZCollisionHeader::ZCollisionHeader()
 
 }
 
-ZCollisionHeader::ZCollisionHeader(ZFile* parent, std::string prefix, std::vector<uint8_t> rawData, int rawDataIndex)
+ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, const std::vector<uint8_t>& rawData, int rawDataIndex)
 {
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	absMinX = BitConverter::ToInt16BE(data, rawDataIndex + 0);
 	absMinY = BitConverter::ToInt16BE(data, rawDataIndex + 2);
@@ -161,14 +161,14 @@ ZCollisionHeader* ZCollisionHeader::ExtractFromXML(tinyxml2::XMLElement* reader,
 {
 	ZCollisionHeader* col = new ZCollisionHeader();
 
-	
+
 
 	return col;
 }
 
-PolygonEntry::PolygonEntry(std::vector<uint8_t> rawData, int rawDataIndex)
+PolygonEntry::PolygonEntry(const std::vector<uint8_t>& rawData, int rawDataIndex)
 {
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	type = BitConverter::ToInt16BE(data, rawDataIndex + 0);
 	vtxA = BitConverter::ToInt16BE(data, rawDataIndex + 2);
@@ -180,18 +180,18 @@ PolygonEntry::PolygonEntry(std::vector<uint8_t> rawData, int rawDataIndex)
 	d = BitConverter::ToInt16BE(data, rawDataIndex + 14);
 }
 
-VertexEntry::VertexEntry(std::vector<uint8_t> rawData, int rawDataIndex)
+VertexEntry::VertexEntry(const std::vector<uint8_t>& rawData, int rawDataIndex)
 {
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	x = BitConverter::ToInt16BE(data, rawDataIndex + 0);
 	y = BitConverter::ToInt16BE(data, rawDataIndex + 2);
 	z = BitConverter::ToInt16BE(data, rawDataIndex + 4);
 }
 
-WaterBoxHeader::WaterBoxHeader(std::vector<uint8_t> rawData, int rawDataIndex)
+WaterBoxHeader::WaterBoxHeader(const std::vector<uint8_t>& rawData, int rawDataIndex)
 {
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	xMin = BitConverter::ToInt16BE(data, rawDataIndex + 0);
 	ySurface = BitConverter::ToInt16BE(data, rawDataIndex + 2);
@@ -201,7 +201,7 @@ WaterBoxHeader::WaterBoxHeader(std::vector<uint8_t> rawData, int rawDataIndex)
 	properties = BitConverter::ToInt32BE(data, rawDataIndex + 12);
 }
 
-CameraDataList::CameraDataList(ZFile* parent, std::string prefix, std::vector<uint8_t> rawData, int rawDataIndex, int polyTypeDefSegmentOffset, int polygonTypesCnt)
+CameraDataList::CameraDataList(ZFile* parent, const std::string& prefix, const std::vector<uint8_t>& rawData, int rawDataIndex, int polyTypeDefSegmentOffset, int polygonTypesCnt)
 {
 	string declaration = "";
 
@@ -267,7 +267,7 @@ CameraDataList::CameraDataList(ZFile* parent, std::string prefix, std::vector<ui
 	}
 }
 
-CameraPositionData::CameraPositionData(std::vector<uint8_t> rawData, int rawDataIndex)
+CameraPositionData::CameraPositionData(const std::vector<uint8_t>& rawData, int rawDataIndex)
 {
 	x = BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
 	y = BitConverter::ToInt16BE(rawData, rawDataIndex + 2);

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -82,8 +82,8 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 	}
 
 	if (waterBoxSegmentOffset != 0)
-		parent->declarations[waterBoxSegmentOffset] = new Declaration(DeclarationAlignment::None, 16 * waterBoxes.size(), "WaterBox",
-			StringHelper::Sprintf("%s_waterBoxes_%08X", prefix.c_str(), waterBoxSegmentOffset), true, declaration);
+		parent->AddDeclarationArray(waterBoxSegmentOffset, DeclarationAlignment::None, 16 * waterBoxes.size(), "WaterBox",
+			StringHelper::Sprintf("%s_waterBoxes_%08X", prefix.c_str(), waterBoxSegmentOffset), 0, declaration);
 
 	if (polygons.size() > 0)
 	{
@@ -98,8 +98,8 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 		}
 
 		if (polySegmentOffset != 0) {
-			parent->declarations[polySegmentOffset] = new Declaration(DeclarationAlignment::None, polygons.size() * 16, "RoomPoly", // TODO: Change this to CollisionPoly once the struct has been updated
-				StringHelper::Sprintf("%s_polygons_%08X", prefix.c_str(), polySegmentOffset), true, declaration);
+			parent->AddDeclarationArray(polySegmentOffset, DeclarationAlignment::None, polygons.size() * 16, "RoomPoly", // TODO: Change this to CollisionPoly once the struct has been updated
+				StringHelper::Sprintf("%s_polygons_%08X", prefix.c_str(), polySegmentOffset), 0, declaration);
 		}
 	}
 
@@ -111,8 +111,8 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 	}
 
 	if (polyTypeDefSegmentOffset != 0)
-		parent->declarations[polyTypeDefSegmentOffset] = new Declaration(DeclarationAlignment::None, polygonTypes.size() * 8,
-			"u32", StringHelper::Sprintf("%s_polygonTypes_%08X", prefix.c_str(), polyTypeDefSegmentOffset), true, declaration);
+		parent->AddDeclarationArray(polyTypeDefSegmentOffset, DeclarationAlignment::None, polygonTypes.size() * 8,
+			"u32", StringHelper::Sprintf("%s_polygonTypes_%08X", prefix.c_str(), polyTypeDefSegmentOffset), 0, declaration);
 
 	declaration = "";
 
@@ -128,8 +128,8 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 		}
 
 		if (vtxSegmentOffset != 0)
-			parent->declarations[vtxSegmentOffset] = new Declaration(DeclarationAlignment::None, vertices.size() * 6,
-				"Vec3s", StringHelper::Sprintf("%s_vtx_%08X", prefix.c_str(), vtxSegmentOffset), true, declaration);
+			parent->AddDeclarationArray(vtxSegmentOffset, DeclarationAlignment::None, vertices.size() * 6,
+				"Vec3s", StringHelper::Sprintf("%s_vtx_%08X", prefix.c_str(), vtxSegmentOffset), 0, declaration);
 
 		declaration = "";
 	}
@@ -148,10 +148,6 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 		numVerts, prefix.c_str(), vtxSegmentOffset, numPolygons,
 		prefix.c_str(), polySegmentOffset, prefix.c_str(), polyTypeDefSegmentOffset,
 		prefix.c_str(), camDataSegmentOffset, numWaterBoxes, waterBoxStr);
-
-
-	/*parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, DeclarationPadding::Pad16, 44, "CollisionHeader",
-		StringHelper::Sprintf("%s_collisionHeader_%08X", prefix.c_str(), rawDataIndex), declaration);*/
 
 	parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, DeclarationPadding::Pad16, 44, "CollisionHeader",
 		StringHelper::Sprintf("%s", prefix.c_str(), rawDataIndex), declaration);

--- a/ZAPD/ZCollision.h
+++ b/ZAPD/ZCollision.h
@@ -11,7 +11,7 @@ public:
 	int16_t vtxA, vtxB, vtxC;
 	int16_t a, b, c, d;
 
-	PolygonEntry(std::vector<uint8_t> rawData, int rawDataIndex);
+	PolygonEntry(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class VertexEntry
@@ -19,7 +19,7 @@ class VertexEntry
 public:
 	int16_t x, y, z;
 
-	VertexEntry(std::vector<uint8_t> rawData, int rawDataIndex);
+	VertexEntry(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class WaterBoxHeader
@@ -33,7 +33,7 @@ public:
 	int16_t pad;
 	int32_t properties;
 
-	WaterBoxHeader(std::vector<uint8_t> rawData, int rawDataIndex);
+	WaterBoxHeader(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class CameraPositionData
@@ -41,7 +41,7 @@ class CameraPositionData
 public:
 	int16_t x, y, z;
 
-	CameraPositionData(std::vector<uint8_t> rawData, int rawDataIndex);
+	CameraPositionData(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class CameraDataEntry
@@ -58,7 +58,7 @@ public:
 	std::vector<CameraDataEntry*> entries;
 	std::vector<CameraPositionData*> cameraPositionData;
 
-	CameraDataList(ZFile* parent, std::string prefix, std::vector<uint8_t> rawData, int rawDataIndex, int polyTypeDefSegmentOffset, int polygonTypesCnt);
+	CameraDataList(ZFile* parent, const std::string& prefix, const std::vector<uint8_t>& rawData, int rawDataIndex, int polyTypeDefSegmentOffset, int polygonTypesCnt);
 };
 
 class ZCollisionHeader : public ZResource
@@ -84,7 +84,7 @@ public:
 
 	ZCollisionHeader();
 	//ZCollisionHeader(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex);
-	ZCollisionHeader(ZFile* parent, std::string prefix, std::vector<uint8_t> rawData, int rawDataIndex);
+	ZCollisionHeader(ZFile* parent, const std::string& prefix, const std::vector<uint8_t>& rawData, int rawDataIndex);
 
 	static ZCollisionHeader* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex);
 };

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -6,7 +6,7 @@ using namespace std;
 
 ZCutscene::ZCutscene(std::vector<uint8_t> nRawData, int rawDataIndex, int rawDataSize)
 {
-	rawData = nRawData;
+	rawData = std::move(nRawData);
 	segmentOffset = rawDataIndex;
 
 	numCommands = BitConverter::ToInt32BE(rawData, rawDataIndex + 0);
@@ -78,7 +78,7 @@ ZCutscene::ZCutscene(std::vector<uint8_t> nRawData, int rawDataIndex, int rawDat
 	}
 }
 
-string ZCutscene::GetSourceOutputCode(string prefix)
+string ZCutscene::GetSourceOutputCode(const std::string& prefix)
 {
 	string output = "";
 	int size = 0;
@@ -160,17 +160,17 @@ CutsceneCommands ZCutscene::GetCommandFromID(int id)
 	return CutsceneCommands::Error;
 }
 
-CutsceneCommand::CutsceneCommand(vector<uint8_t> rawData, int rawDataIndex)
+CutsceneCommand::CutsceneCommand(const vector<uint8_t>& rawData, int rawDataIndex)
 {
 
 }
 
-string CutsceneCommand::GetCName(string prefix)
+string CutsceneCommand::GetCName(const std::string& prefix)
 {
 	return "SCmdCutsceneData";
 }
 
-string CutsceneCommand::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommand::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	return StringHelper::Sprintf("%s %sCutsceneData%04XCmd%02X = { 0x%02X,", GetCName(roomName).c_str(), roomName.c_str(), baseAddress, commandIndex, commandID);
 }
@@ -180,9 +180,9 @@ size_t CutsceneCommand::GetCommandSize()
 	return 4;
 }
 
-CutsceneCameraPoint::CutsceneCameraPoint(vector<uint8_t> rawData, int rawDataIndex)
+CutsceneCameraPoint::CutsceneCameraPoint(const vector<uint8_t>& rawData, int rawDataIndex)
 {
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	continueFlag = data[rawDataIndex + 0];
 	cameraRoll = data[rawDataIndex + 1];
@@ -196,9 +196,9 @@ CutsceneCameraPoint::CutsceneCameraPoint(vector<uint8_t> rawData, int rawDataInd
 	unused = BitConverter::ToInt16BE(data, rawDataIndex + 14);
 }
 
-CutsceneCommandSetCameraPos::CutsceneCommandSetCameraPos(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandSetCameraPos::CutsceneCommandSetCameraPos(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	base = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 0);
 	startFrame = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 2);
@@ -224,12 +224,12 @@ CutsceneCommandSetCameraPos::CutsceneCommandSetCameraPos(vector<uint8_t> rawData
 }
 
 // TODO
-string CutsceneCommandSetCameraPos::GetCName(string prefix)
+string CutsceneCommandSetCameraPos::GetCName(const std::string& prefix)
 {
 	return "";
 }
 
-string CutsceneCommandSetCameraPos::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandSetCameraPos::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -273,7 +273,7 @@ size_t CutsceneCommandSetCameraPos::GetCommandSize()
 	return 8 + (entries.size() * 16);
 }
 
-MusicFadeEntry::MusicFadeEntry(vector<uint8_t> rawData, int rawDataIndex)
+MusicFadeEntry::MusicFadeEntry(const vector<uint8_t>& rawData, int rawDataIndex)
 {
 	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
 	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
@@ -291,7 +291,7 @@ MusicFadeEntry::MusicFadeEntry(vector<uint8_t> rawData, int rawDataIndex)
 	unknown10 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 44);
 }
 
-CutsceneCommandFadeBGM::CutsceneCommandFadeBGM(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandFadeBGM::CutsceneCommandFadeBGM(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	int numEntries = BitConverter::ToInt32BE(rawData, rawDataIndex + 0);
 
@@ -304,12 +304,12 @@ CutsceneCommandFadeBGM::CutsceneCommandFadeBGM(vector<uint8_t> rawData, int rawD
 	}
 }
 
-string CutsceneCommandFadeBGM::GetCName(string prefix)
+string CutsceneCommandFadeBGM::GetCName(const std::string& prefix)
 {
 	return "CsCmdMusicFade";
 }
 
-string CutsceneCommandFadeBGM::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandFadeBGM::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -330,7 +330,7 @@ size_t CutsceneCommandFadeBGM::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + 0x30;
 }
 
-MusicChangeEntry::MusicChangeEntry(vector<uint8_t> rawData, int rawDataIndex)
+MusicChangeEntry::MusicChangeEntry(const vector<uint8_t>& rawData, int rawDataIndex)
 {
 	sequence = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
 	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
@@ -345,7 +345,7 @@ MusicChangeEntry::MusicChangeEntry(vector<uint8_t> rawData, int rawDataIndex)
 	unknown7 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 32);
 }
 
-CutsceneCommandPlayBGM::CutsceneCommandPlayBGM(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandPlayBGM::CutsceneCommandPlayBGM(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	int numEntries = BitConverter::ToInt32BE(rawData, rawDataIndex + 0);
 
@@ -358,7 +358,7 @@ CutsceneCommandPlayBGM::CutsceneCommandPlayBGM(vector<uint8_t> rawData, int rawD
 	}
 }
 
-string CutsceneCommandPlayBGM::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandPlayBGM::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -374,7 +374,7 @@ string CutsceneCommandPlayBGM::GenerateSourceCode(string roomName, int baseAddre
 	return result;
 }
 
-string CutsceneCommandPlayBGM::GetCName(string prefix)
+string CutsceneCommandPlayBGM::GetCName(const std::string& prefix)
 {
 	return "CsCmdMusicChange";
 }
@@ -384,7 +384,7 @@ size_t CutsceneCommandPlayBGM::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + 0x30;
 }
 
-CutsceneCommandStopBGM::CutsceneCommandStopBGM(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandStopBGM::CutsceneCommandStopBGM(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	int numEntries = BitConverter::ToInt32BE(rawData, rawDataIndex + 0);
 
@@ -397,7 +397,7 @@ CutsceneCommandStopBGM::CutsceneCommandStopBGM(vector<uint8_t> rawData, int rawD
 	}
 }
 
-string CutsceneCommandStopBGM::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandStopBGM::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -413,7 +413,7 @@ string CutsceneCommandStopBGM::GenerateSourceCode(string roomName, int baseAddre
 	return result;
 }
 
-string CutsceneCommandStopBGM::GetCName(string prefix)
+string CutsceneCommandStopBGM::GetCName(const std::string& prefix)
 {
 	return "CsCmdMusicChange";
 }
@@ -423,7 +423,7 @@ size_t CutsceneCommandStopBGM::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + 0x30;
 }
 
-EnvLightingEntry::EnvLightingEntry(vector<uint8_t> rawData, int rawDataIndex)
+EnvLightingEntry::EnvLightingEntry(const vector<uint8_t>& rawData, int rawDataIndex)
 {
 	setting = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
 	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
@@ -438,7 +438,7 @@ EnvLightingEntry::EnvLightingEntry(vector<uint8_t> rawData, int rawDataIndex)
 	unused7 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 32);
 }
 
-CutsceneCommandEnvLighting::CutsceneCommandEnvLighting(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandEnvLighting::CutsceneCommandEnvLighting(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	int numEntries = BitConverter::ToInt32BE(rawData, rawDataIndex + 0);
 
@@ -451,7 +451,7 @@ CutsceneCommandEnvLighting::CutsceneCommandEnvLighting(vector<uint8_t> rawData, 
 	}
 }
 
-string CutsceneCommandEnvLighting::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandEnvLighting::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -467,7 +467,7 @@ string CutsceneCommandEnvLighting::GenerateSourceCode(string roomName, int baseA
 	return result;
 }
 
-string CutsceneCommandEnvLighting::GetCName(string prefix)
+string CutsceneCommandEnvLighting::GetCName(const std::string& prefix)
 {
 	return "CsCmdEnvLighting";
 }
@@ -477,7 +477,7 @@ size_t CutsceneCommandEnvLighting::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + (0x30 * entries.size());
 }
 
-Unknown9Entry::Unknown9Entry(vector<uint8_t> rawData, int rawDataIndex)
+Unknown9Entry::Unknown9Entry(const vector<uint8_t>& rawData, int rawDataIndex)
 {
 	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
 	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
@@ -489,7 +489,7 @@ Unknown9Entry::Unknown9Entry(vector<uint8_t> rawData, int rawDataIndex)
 	unused1 = rawData[rawDataIndex + 11];;
 }
 
-CutsceneCommandUnknown9::CutsceneCommandUnknown9(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandUnknown9::CutsceneCommandUnknown9(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	int numEntries = BitConverter::ToInt32BE(rawData, rawDataIndex);
 
@@ -502,7 +502,7 @@ CutsceneCommandUnknown9::CutsceneCommandUnknown9(vector<uint8_t> rawData, int ra
 	}
 }
 
-string CutsceneCommandUnknown9::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandUnknown9::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -517,7 +517,7 @@ string CutsceneCommandUnknown9::GenerateSourceCode(string roomName, int baseAddr
 	return result;
 }
 
-string CutsceneCommandUnknown9::GetCName(string prefix)
+string CutsceneCommandUnknown9::GetCName(const std::string& prefix)
 {
 	return "CsCmdUnknown9";
 }
@@ -527,7 +527,7 @@ size_t CutsceneCommandUnknown9::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + (entries.size() * 12);
 }
 
-UnkEntry::UnkEntry(vector<uint8_t> rawData, int rawDataIndex)
+UnkEntry::UnkEntry(const vector<uint8_t>& rawData, int rawDataIndex)
 {
 	unused0 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 0);
 	unused1 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 4);
@@ -543,7 +543,7 @@ UnkEntry::UnkEntry(vector<uint8_t> rawData, int rawDataIndex)
 	unused11 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 44);
 }
 
-CutsceneCommandUnknown::CutsceneCommandUnknown(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandUnknown::CutsceneCommandUnknown(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	int numEntries = BitConverter::ToInt32BE(rawData, rawDataIndex);
 
@@ -556,7 +556,7 @@ CutsceneCommandUnknown::CutsceneCommandUnknown(vector<uint8_t> rawData, int rawD
 	}
 }
 
-string CutsceneCommandUnknown::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandUnknown::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -572,7 +572,7 @@ string CutsceneCommandUnknown::GenerateSourceCode(string roomName, int baseAddre
 	return result;
 }
 
-string CutsceneCommandUnknown::GetCName(string prefix)
+string CutsceneCommandUnknown::GetCName(const std::string& prefix)
 {
 	return "CsCmdUnknown1A";
 }
@@ -582,7 +582,7 @@ size_t CutsceneCommandUnknown::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + (entries.size() * 0x30);
 }
 
-DayTimeEntry::DayTimeEntry(vector<uint8_t> rawData, int rawDataIndex)
+DayTimeEntry::DayTimeEntry(const vector<uint8_t>& rawData, int rawDataIndex)
 {
 	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
 	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
@@ -592,7 +592,7 @@ DayTimeEntry::DayTimeEntry(vector<uint8_t> rawData, int rawDataIndex)
 	unused = rawData[rawDataIndex + 8];
 }
 
-CutsceneCommandDayTime::CutsceneCommandDayTime(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandDayTime::CutsceneCommandDayTime(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	int numEntries = BitConverter::ToInt32BE(rawData, rawDataIndex);
 
@@ -605,12 +605,12 @@ CutsceneCommandDayTime::CutsceneCommandDayTime(vector<uint8_t> rawData, int rawD
 	}
 }
 
-string CutsceneCommandDayTime::GetCName(string prefix)
+string CutsceneCommandDayTime::GetCName(const std::string& prefix)
 {
 	return "CsCmdDayTime";
 }
 
-string CutsceneCommandDayTime::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandDayTime::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -630,7 +630,7 @@ size_t CutsceneCommandDayTime::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + (entries.size() * 12);
 }
 
-TextboxEntry::TextboxEntry(vector<uint8_t> rawData, int rawDataIndex)
+TextboxEntry::TextboxEntry(const vector<uint8_t>& rawData, int rawDataIndex)
 {
 	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
 	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
@@ -640,7 +640,7 @@ TextboxEntry::TextboxEntry(vector<uint8_t> rawData, int rawDataIndex)
 	textID2 = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 10);
 }
 
-CutsceneCommandTextbox::CutsceneCommandTextbox(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandTextbox::CutsceneCommandTextbox(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	int numEntries = BitConverter::ToInt32BE(rawData, rawDataIndex);
 
@@ -653,12 +653,12 @@ CutsceneCommandTextbox::CutsceneCommandTextbox(vector<uint8_t> rawData, int rawD
 	}
 }
 
-string CutsceneCommandTextbox::GetCName(string prefix)
+string CutsceneCommandTextbox::GetCName(const std::string& prefix)
 {
 	return "CsCmdTextbox";
 }
 
-string CutsceneCommandTextbox::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandTextbox::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -685,9 +685,9 @@ size_t CutsceneCommandTextbox::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + (entries.size() * 12);
 }
 
-ActorAction::ActorAction(vector<uint8_t> rawData, int rawDataIndex)
+ActorAction::ActorAction(const vector<uint8_t>& rawData, int rawDataIndex)
 {
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	action = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 0);
 	startFrame = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 2);
@@ -706,7 +706,7 @@ ActorAction::ActorAction(vector<uint8_t> rawData, int rawDataIndex)
 	normalZ = BitConverter::ToInt32BE(data, rawDataIndex + 44);
 }
 
-CutsceneCommandActorAction::CutsceneCommandActorAction(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandActorAction::CutsceneCommandActorAction(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	int numEntries = BitConverter::ToInt32BE(rawData, rawDataIndex);
 
@@ -719,7 +719,7 @@ CutsceneCommandActorAction::CutsceneCommandActorAction(vector<uint8_t> rawData, 
 	}
 }
 
-string CutsceneCommandActorAction::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandActorAction::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -735,7 +735,7 @@ string CutsceneCommandActorAction::GenerateSourceCode(string roomName, int baseA
 	return result;
 }
 
-string CutsceneCommandActorAction::GetCName(string prefix)
+string CutsceneCommandActorAction::GetCName(const std::string& prefix)
 {
 	return "CsCmdBase";
 }
@@ -745,7 +745,7 @@ size_t CutsceneCommandActorAction::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + (entries.size() * 0x30);
 }
 
-CutsceneCommandTerminator::CutsceneCommandTerminator(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandTerminator::CutsceneCommandTerminator(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	rawDataIndex += 4;
 
@@ -755,12 +755,12 @@ CutsceneCommandTerminator::CutsceneCommandTerminator(vector<uint8_t> rawData, in
 	unknown = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 6);
 }
 
-string CutsceneCommandTerminator::GetCName(string prefix)
+string CutsceneCommandTerminator::GetCName(const std::string& prefix)
 {
 	return "CsCmdBase";
 }
 
-string CutsceneCommandTerminator::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandTerminator::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -774,14 +774,14 @@ size_t CutsceneCommandTerminator::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + 8;
 }
 
-CutsceneCommandEnd::CutsceneCommandEnd(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandEnd::CutsceneCommandEnd(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
 	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
 	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
 }
 
-string CutsceneCommandEnd::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandEnd::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -790,7 +790,7 @@ string CutsceneCommandEnd::GenerateSourceCode(string roomName, int baseAddress)
 	return result;
 }
 
-string CutsceneCommandEnd::GetCName(string prefix)
+string CutsceneCommandEnd::GetCName(const std::string& prefix)
 {
 	return "CsCmdBase";
 }
@@ -800,7 +800,7 @@ size_t CutsceneCommandEnd::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + 6;
 }
 
-SpecialActionEntry::SpecialActionEntry(vector<uint8_t> rawData, int rawDataIndex)
+SpecialActionEntry::SpecialActionEntry(const vector<uint8_t>& rawData, int rawDataIndex)
 {
 	const uint8_t* data = rawData.data();
 
@@ -820,7 +820,7 @@ SpecialActionEntry::SpecialActionEntry(vector<uint8_t> rawData, int rawDataIndex
 	unused10 = BitConverter::ToUInt32BE(data, rawDataIndex + 44);
 }
 
-CutsceneCommandSpecialAction::CutsceneCommandSpecialAction(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandSpecialAction::CutsceneCommandSpecialAction(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	int numEntries = BitConverter::ToInt32BE(rawData, rawDataIndex + 0);
 
@@ -833,7 +833,7 @@ CutsceneCommandSpecialAction::CutsceneCommandSpecialAction(vector<uint8_t> rawDa
 	}
 }
 
-string CutsceneCommandSpecialAction::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandSpecialAction::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
 
@@ -844,12 +844,12 @@ string CutsceneCommandSpecialAction::GenerateSourceCode(string roomName, int bas
 		result += StringHelper::Sprintf("\t\tCS_MISC(0x%04X, %i, %i, 0x%04X, 0x%04X, 0x%04X, %i, %i, %i, %i, %i, %i, %i, %i),\n", entries[i]->base, entries[i]->startFrame, entries[i]->endFrame,
 			entries[i]->unused0, entries[i]->unused1, entries[i]->unused2, entries[i]->unused3, entries[i]->unused4, entries[i]->unused5, entries[i]->unused6,
 			entries[i]->unused7, entries[i]->unused8, entries[i]->unused9, entries[i]->unused10);
-	}	
+	}
 
 	return result;
 }
 
-string CutsceneCommandSpecialAction::GetCName(string prefix)
+string CutsceneCommandSpecialAction::GetCName(const std::string& prefix)
 {
 	return "CsCmdBase";
 }
@@ -859,14 +859,14 @@ size_t CutsceneCommandSpecialAction::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + (0x30 * entries.size());
 }
 
-CutsceneCommandNop::CutsceneCommandNop(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandNop::CutsceneCommandNop(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
 	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
 	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
 }
 
-string CutsceneCommandNop::GetCName(string prefix)
+string CutsceneCommandNop::GetCName(const std::string& prefix)
 {
 	return "CsCmdBase";
 }
@@ -876,7 +876,7 @@ size_t CutsceneCommandNop::GetCommandSize()
 	return CutsceneCommand::GetCommandSize() + 6;
 }
 
-CutsceneCommandSceneTransFX::CutsceneCommandSceneTransFX(vector<uint8_t> rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
+CutsceneCommandSceneTransFX::CutsceneCommandSceneTransFX(const vector<uint8_t>& rawData, int rawDataIndex) : CutsceneCommand(rawData, rawDataIndex)
 {
 	rawDataIndex += 4;
 
@@ -885,12 +885,12 @@ CutsceneCommandSceneTransFX::CutsceneCommandSceneTransFX(vector<uint8_t> rawData
 	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
 }
 
-string CutsceneCommandSceneTransFX::GenerateSourceCode(string roomName, int baseAddress)
+string CutsceneCommandSceneTransFX::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	return StringHelper::Sprintf("CS_SCENE_TRANS_FX(%i, %i, %i, %i),\n", base, startFrame, endFrame);
 }
 
-string CutsceneCommandSceneTransFX::GetCName(string prefix)
+string CutsceneCommandSceneTransFX::GetCName(const std::string& prefix)
 {
 	return "CsCmdBase";
 }

--- a/ZAPD/ZCutscene.h
+++ b/ZAPD/ZCutscene.h
@@ -52,7 +52,7 @@ public:
 	int16_t posX, posY, posZ;
 	int16_t unused;
 
-	CutsceneCameraPoint(std::vector<uint8_t> rawData, int rawDataIndex);
+	CutsceneCameraPoint(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class CutsceneCommand
@@ -61,9 +61,9 @@ public:
 	uint32_t commandID;
 	uint32_t commandIndex;
 
-	CutsceneCommand(std::vector<uint8_t> rawData, int rawDataIndex);
-	virtual std::string GetCName(std::string prefix);
-	virtual std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommand(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	virtual std::string GetCName(const std::string& prefix);
+	virtual std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	virtual size_t GetCommandSize();
 };
 
@@ -77,9 +77,9 @@ public:
 
 	std::vector<CutsceneCameraPoint*> entries;
 
-	CutsceneCommandSetCameraPos(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandSetCameraPos(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -101,7 +101,7 @@ public:
 	uint32_t unused9;
 	uint32_t unused10;
 
-	SpecialActionEntry(std::vector<uint8_t> rawData, int rawDataIndex);
+	SpecialActionEntry(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class CutsceneCommandSpecialAction : public CutsceneCommand
@@ -109,9 +109,9 @@ class CutsceneCommandSpecialAction : public CutsceneCommand
 public:
 	std::vector<SpecialActionEntry*> entries;
 
-	CutsceneCommandSpecialAction(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandSpecialAction(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -133,7 +133,7 @@ public:
 	uint32_t unknown9;
 	uint32_t unknown10;
 
-	MusicFadeEntry(std::vector<uint8_t> rawData, int rawDataIndex);
+	MusicFadeEntry(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class CutsceneCommandFadeBGM : public CutsceneCommand
@@ -141,9 +141,9 @@ class CutsceneCommandFadeBGM : public CutsceneCommand
 public:
 	std::vector<MusicFadeEntry*> entries;
 
-	CutsceneCommandFadeBGM( std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandFadeBGM( const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -162,7 +162,7 @@ public:
 	uint32_t unknown6;
 	uint32_t unknown7;
 
-	MusicChangeEntry(std::vector<uint8_t> rawData, int rawDataIndex);
+	MusicChangeEntry(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class CutsceneCommandPlayBGM : public CutsceneCommand
@@ -170,9 +170,9 @@ class CutsceneCommandPlayBGM : public CutsceneCommand
 public:
 	std::vector<MusicChangeEntry*> entries;
 
-	CutsceneCommandPlayBGM(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandPlayBGM(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -181,9 +181,9 @@ class CutsceneCommandStopBGM : public CutsceneCommand
 public:
 	std::vector<MusicChangeEntry*> entries;
 
-	CutsceneCommandStopBGM(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandStopBGM(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -202,7 +202,7 @@ public:
 	uint32_t unused6;
 	uint32_t unused7;
 
-	EnvLightingEntry(std::vector<uint8_t> rawData, int rawDataIndex);
+	EnvLightingEntry(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class CutsceneCommandEnvLighting : public CutsceneCommand
@@ -210,9 +210,9 @@ class CutsceneCommandEnvLighting : public CutsceneCommand
 public:
 	std::vector<EnvLightingEntry*> entries;
 
-	CutsceneCommandEnvLighting(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandEnvLighting(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -223,9 +223,9 @@ public:
 	uint16_t startFrame;
 	uint16_t endFrame;
 
-	CutsceneCommandSceneTransFX(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandSceneTransFX(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -241,7 +241,7 @@ public:
 	uint8_t unused0;
 	uint8_t unused1;
 
-	Unknown9Entry(std::vector<uint8_t> rawData, int rawDataIndex);
+	Unknown9Entry(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class CutsceneCommandUnknown9 : public CutsceneCommand
@@ -249,9 +249,9 @@ class CutsceneCommandUnknown9 : public CutsceneCommand
 public:
 	std::vector<Unknown9Entry*> entries;
 
-	CutsceneCommandUnknown9(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandUnknown9(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -271,7 +271,7 @@ public:
 	uint32_t unused10;
 	uint32_t unused11;
 
-	UnkEntry(std::vector<uint8_t> rawData, int rawDataIndex);
+	UnkEntry(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class CutsceneCommandUnknown : public CutsceneCommand
@@ -279,9 +279,9 @@ class CutsceneCommandUnknown : public CutsceneCommand
 public:
 	std::vector<UnkEntry*> entries;
 
-	CutsceneCommandUnknown(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandUnknown(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -295,7 +295,7 @@ public:
 	uint8_t minute;
 	uint8_t unused;
 
-	DayTimeEntry(std::vector<uint8_t> rawData, int rawDataIndex);
+	DayTimeEntry(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class CutsceneCommandDayTime : public CutsceneCommand
@@ -303,9 +303,9 @@ class CutsceneCommandDayTime : public CutsceneCommand
 public:
 	std::vector<DayTimeEntry*> entries;
 
-	CutsceneCommandDayTime(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandDayTime(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -319,7 +319,7 @@ public:
 	uint16_t textID1;
 	uint16_t textID2;
 
-	TextboxEntry(std::vector<uint8_t> rawData, int rawDataIndex);
+	TextboxEntry(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class CutsceneCommandTextbox : public CutsceneCommand
@@ -327,9 +327,9 @@ class CutsceneCommandTextbox : public CutsceneCommand
 public:
 	std::vector<TextboxEntry*> entries;
 
-	CutsceneCommandTextbox(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandTextbox(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -344,7 +344,7 @@ public:
 	int32_t endPosX, endPosY, endPosZ;
 	int32_t normalX, normalY, normalZ;
 
-	ActorAction(std::vector<uint8_t> rawData, int rawDataIndex);
+	ActorAction(const std::vector<uint8_t>& rawData, int rawDataIndex);
 };
 
 class CutsceneCommandActorAction : public CutsceneCommand
@@ -352,9 +352,9 @@ class CutsceneCommandActorAction : public CutsceneCommand
 public:
 	std::vector<ActorAction*> entries;
 
-	CutsceneCommandActorAction(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandActorAction(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -366,9 +366,9 @@ public:
 	uint16_t endFrame;
 	uint16_t unknown;
 
-	CutsceneCommandTerminator(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandTerminator(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -379,9 +379,9 @@ public:
 	uint16_t startFrame;
 	uint16_t endFrame;
 
-	CutsceneCommandEnd(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
-	std::string GenerateSourceCode(std::string roomName, int baseAddress);
+	CutsceneCommandEnd(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
+	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
 };
 
@@ -392,8 +392,8 @@ public:
 	uint16_t startFrame;
 	uint16_t endFrame;
 
-	CutsceneCommandNop(std::vector<uint8_t> rawData, int rawDataIndex);
-	std::string GetCName(std::string prefix);
+	CutsceneCommandNop(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	std::string GetCName(const std::string& prefix);
 	size_t GetCommandSize();
 };
 
@@ -401,11 +401,11 @@ class ZCutscene : public ZResource
 {
 public:
 	uint32_t segmentOffset;
-	
+
 	CutsceneCommands GetCommandFromID(int id);
 	ZCutscene(std::vector<uint8_t> nRawData, int rawDataIndex, int rawDataSize);
 
-	std::string GetSourceOutputCode(std::string prefix);
+	std::string GetSourceOutputCode(const std::string& prefix);
 	int GetRawDataSize();
 private:
 	int numCommands;

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -156,10 +156,10 @@ int ZDisplayList::OptimizationCheck_LoadTextureBlock(int startIndex, string& out
 			siz = (__ & 0x18) >> 3;
 			texAddr = SEG2FILESPACE(data);
 			int segmentNumber = (data & 0xFF000000) >> 24;
-			
+
 			if (segmentNumber == 0x80) // Is this texture defined in code?
 				texAddr -= SEG2FILESPACE(parent->baseAddress);
-			
+
 			lastTexSeg = (data & 0xFF000000);
 
 			if (texAddr == 0xb880e0)
@@ -168,7 +168,7 @@ int ZDisplayList::OptimizationCheck_LoadTextureBlock(int startIndex, string& out
 			}
 
 			Declaration* texDecl = nullptr;
-			
+
 			if (parent != nullptr)
 			{
 				texDecl = parent->GetDeclaration(texAddr);
@@ -199,7 +199,7 @@ int ZDisplayList::OptimizationCheck_LoadTextureBlock(int startIndex, string& out
 			uint64_t data = instructions[startIndex + 1];
 
 			tmem = (data & 0b0000000000000000111111111111111100000000000000000000000000000000) >> 32;
-			
+
 			cmt = (data & 0b0000000000000000000000000000000000000000000011000000000000000000) >> 18;
 			maskt = (data & 0b0000000000000000000000000000000000000000000000111100000000000000) >> 14;
 			shiftt = (data & 0b0000000000000000000000000000000000000000000000000011110000000000) >> 10;
@@ -260,7 +260,7 @@ int ZDisplayList::OptimizationCheck_LoadTextureBlock(int startIndex, string& out
 		string fmtTbl[] = { "G_IM_FMT_RGBA", "G_IM_FMT_YUV", "G_IM_FMT_CI", "G_IM_FMT_IA", "G_IM_FMT_I" };
 		string sizTbl[] = { "G_IM_SIZ_4b", "G_IM_SIZ_8b", "G_IM_SIZ_16b", "G_IM_SIZ_32b" };
 
-		//output += StringHelper::Sprintf("gsDPLoadTextureBlock(%s, %s, %s, %i, %i, %i, %i, %i, %i, %i, %i, %i),", 
+		//output += StringHelper::Sprintf("gsDPLoadTextureBlock(%s, %s, %s, %i, %i, %i, %i, %i, %i, %i, %i, %i),",
 									//texStr.c_str(), fmtTbl[fmt].c_str(), sizTbl[siz].c_str(), width, height, pal, cms, cmt, masks, maskt, shifts, shiftt);
 
 		if (siz == 2 && sizB == 0)
@@ -317,17 +317,17 @@ int ZDisplayList::OptimizationCheck_LoadTextureBlock(int startIndex, string& out
 	return -1;
 }
 
-string ZDisplayList::GetSourceOutputHeader(string prefix)
+string ZDisplayList::GetSourceOutputHeader(const std::string& prefix)
 {
 	return "";
 }
 
-string ZDisplayList::GetSourceOutputCode(std::string prefix)
+string ZDisplayList::GetSourceOutputCode(const std::string& prefix)
 {
 	char line[4096];
 	string sourceOutput = "";
 
-	for (int i = 0; i < instructions.size(); i++) 
+	for (int i = 0; i < instructions.size(); i++)
 	{
 		F3DZEXOpcode opcode = (F3DZEXOpcode)(instructions[i] >> 56);
 		uint64_t data = instructions[i];
@@ -355,7 +355,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 				int segNum = (data & 0xFF000000) >> 24;
 
 				Declaration* dListDecl = nullptr;
-				
+
 				if (parent != nullptr)
 					dListDecl = parent->GetDeclaration(SEG2FILESPACE(data));
 
@@ -497,7 +497,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 
 				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 					printf("TextureGenCheck G_SETTIMG\n");
-				
+
 				TextureGenCheck(prefix); // HOTSPOT
 
 				lastTexFmt = (F3DZEXTexFormats)fmt;
@@ -517,7 +517,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 					int32_t texAddress = SEG2FILESPACE(data);
 
 					Declaration* texDecl = nullptr;
-					
+
 					if (parent != nullptr)
 					{
 						if (Globals::Instance->HasSegment(segmentNumber))
@@ -592,7 +592,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 
 				if (geoModeParam & 0x00800000)
 					geoModeStr += " | G_CLIPPING";
-				
+
 				if (ssssssss != 0)
 				{
 					if ((~cccccc & 0xFF000000) != 0)
@@ -602,7 +602,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 				}
 				else
 					sprintf(line, "gsSPClearGeometryMode(%s),", geoModeStr.c_str());
-					
+
 				//sprintf(line, "gsSPGeometryMode(0x%08X, 0x%08X),", ~cccccc, ssssssss);
 			}
 			break;
@@ -632,7 +632,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 					int mode2 = (dd & 0x33330000) >> 0;
 
 					// TODO: Jesus Christ This is Messy
-					
+
 					uint32_t tblA[] =
 					{
 						G_RM_FOG_SHADE_A, G_RM_FOG_PRIM_A, G_RM_PASS, G_RM_AA_ZB_OPA_SURF,
@@ -671,7 +671,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 						G_RM_ADD2, G_RM_NOOP2,G_RM_VISCVG2, G_RM_OPA_CI2
 					};
 
-					map<uint32_t, string> str = 
+					map<uint32_t, string> str =
 					{
 						{ G_RM_FOG_SHADE_A, "G_RM_FOG_SHADE_A" },
 						{ G_RM_FOG_PRIM_A, "G_RM_FOG_PRIM_A" },
@@ -865,13 +865,13 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 
 				lastTexWidth = (uuu >> shiftAmtW) + 1;
 				lastTexHeight = (vvv >> shiftAmtH) + 1;
-				
+
 				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 					printf("lastTexWidth: %i lastTexHeight: %i, lastTexSizTest: 0x%x, lastTexFmt: 0x%x\n", lastTexWidth, lastTexHeight, (uint32_t)lastTexSizTest, (uint32_t)lastTexFmt);
 
 				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 					printf("TextureGenCheck G_SETTILESIZE\n");
-				
+
 				TextureGenCheck(prefix);
 
 				sprintf(line, "gsDPSetTileSize(%i, %i, %i, %i, %i),", i, sss, ttt, uuu, vvv);
@@ -931,7 +931,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 
 				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 					printf("TextureGenCheck G_LOADTLUT (lastCISiz: %i)\n", (uint32_t)lastCISiz);
-				
+
 				TextureGenCheck(prefix);
 
 				sprintf(line, "gsDPLoadTLUTCmd(%i, %i),", t, ccc);
@@ -997,7 +997,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 
 				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 					printf("TextureGenCheck G_ENDDL\n");
-				
+
 				TextureGenCheck(prefix);
 				break;
 			case F3DZEXOpcode::G_RDPHALF_1:
@@ -1060,7 +1060,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 #endif
 
 		sourceOutput += line;
-		
+
 		if (i < instructions.size() - 1)
 			sourceOutput += "\n";
 	}
@@ -1091,7 +1091,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 				}
 
 				defines += StringHelper::Sprintf("#define %sVtx_%06X ((u32)%sVtx_%06X + 0x%06X)\n", prefix.c_str(), verticesSorted[i + 1].first, prefix.c_str(), verticesSorted[i].first, verticesSorted[i + 1].first - verticesSorted[i].first);
-				
+
 				int nSize = (int)vertices[verticesSorted[i].first].size();
 
 				vertices.erase(verticesSorted[i + 1].first);
@@ -1126,7 +1126,7 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 
 			if (parent != nullptr)
 			{
-				parent->AddDeclarationArray(item.first, DeclarationAlignment::None, item.second.size() * 16, "Vtx", 
+				parent->AddDeclarationArray(item.first, DeclarationAlignment::None, item.second.size() * 16, "Vtx",
 					StringHelper::Sprintf("%sVtx_%06X", prefix.c_str(), item.first, item.second.size()), 0, declaration);
 			}
 		}
@@ -1271,7 +1271,7 @@ bool ZDisplayList::TextureGenCheck(vector<uint8_t> fileData, map<uint32_t, ZText
 			if (scene != nullptr)
 			{
 				scene->textures[texAddr] = tex;
-				scene->parent->AddDeclarationIncludeArray(texAddr, StringHelper::Sprintf("%s/%s.%s.inc.c", 
+				scene->parent->AddDeclarationIncludeArray(texAddr, StringHelper::Sprintf("%s/%s.%s.inc.c",
 					Globals::Instance->outputPath.c_str(), Path::GetFileNameWithoutExtension(tex->GetName()).c_str(), tex->GetExternalExtension().c_str()), tex->GetRawDataSize(),
 					"u64", StringHelper::Sprintf("%sTex_%06X", Globals::Instance->lastScene->GetName().c_str(), texAddr), 0);
 			}
@@ -1318,7 +1318,7 @@ TextureType ZDisplayList::TexFormatToTexType(F3DZEXTexFormats fmt, F3DZEXTexSize
 	return TextureType::RGBA16bpp;
 }
 
-void ZDisplayList::Save(string outFolder)
+void ZDisplayList::Save(const std::string& outFolder)
 {
 	//HLModelIntermediette* mdl = HLModelIntermediette::FromZDisplayList(this);
 
@@ -1382,7 +1382,7 @@ Vertex::Vertex(int16_t nX, int16_t nY, int16_t nZ, uint16_t nFlag, int16_t nS, i
 
 Vertex::Vertex(std::vector<uint8_t> rawData, int rawDataIndex)
 {
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	x = BitConverter::ToInt16BE(data, rawDataIndex + 0);
 	y = BitConverter::ToInt16BE(data, rawDataIndex + 2);

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -1126,8 +1126,8 @@ string ZDisplayList::GetSourceOutputCode(std::string prefix)
 
 			if (parent != nullptr)
 			{
-				parent->AddDeclarationArray(item.first, DeclarationAlignment::None, item.second.size() * 16, "Vtx", 
-					StringHelper::Sprintf("%sVtx_%06X", prefix.c_str(), item.first, item.second.size()), 0, declaration);
+				parent->AddDeclarationArray(item.first, DeclarationAlignment::None, item.second.size() * 16, "static Vtx", 
+					StringHelper::Sprintf("%sVtx_%06X", prefix.c_str(), item.first, item.second.size()), item.second.size(), declaration);
 			}
 		}
 

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -205,7 +205,7 @@ public:
 	uint16_t flag;
 	int16_t s, t;
 	uint8_t r, g, b, a;
-	
+
 	Vertex();
 	Vertex(int16_t nX, int16_t nY, int16_t nZ, uint16_t nFlag, int16_t nS, int16_t nT, uint8_t nR, uint8_t nG, uint8_t nB, uint8_t nA);
 	Vertex(std::vector<uint8_t> rawData, int rawDataIndex);
@@ -258,8 +258,8 @@ public:
 
 	std::vector<uint8_t> GetRawData();
 	int GetRawDataSize();
-	std::string GetSourceOutputHeader(std::string prefix);
-	std::string GetSourceOutputCode(std::string prefix);
-	void Save(std::string outFolder);
+	std::string GetSourceOutputHeader(const std::string& prefix);
+	std::string GetSourceOutputCode(const std::string& prefix);
+	void Save(const std::string& outFolder);
 	virtual void GenerateHLIntermediette(HLFileIntermediette& hlFile);
 };

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -780,6 +780,30 @@ string ZFile::ProcessDeclarations()
 		return lhs.first < rhs.first;
 	});
 
+	// First, handle the prototypes (static only for now)
+	int protoCnt = 0;
+	for (pair<int32_t, Declaration*> item : declarationKeysSorted)
+	{
+		if (item.second->includePath == "" && StringHelper::StartsWith(item.second->varType, "static ") && !StringHelper::StartsWith(item.second->varName, "unaccounted_"))
+		{
+			if (item.second->isArray)
+			{
+				if (item.second->arrayItemCnt == 0)
+					output += StringHelper::Sprintf("%s %s[];\n", item.second->varType.c_str(), item.second->varName.c_str());
+				else
+					output += StringHelper::Sprintf("%s %s[%i];\n", item.second->varType.c_str(), item.second->varName.c_str(), item.second->arrayItemCnt);
+			}
+			else
+				output += StringHelper::Sprintf("%s %s;\n", item.second->varType.c_str(), item.second->varName.c_str());
+
+			protoCnt++;
+		}
+	}
+
+	if (protoCnt > 0)
+		output += "\n";
+
+	// Next, output the actual declarations
 	for (pair<int32_t, Declaration*> item : declarationKeysSorted)
 	{
 		if (item.second->includePath != "")

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -328,7 +328,9 @@ void ZFile::ExtractResources(string outputDir)
 
 	for (ZResource* res : resources)
 	{
-		printf("Saving resource %s\n", res->GetName().c_str());
+		if (Globals::Instance->verbosity >= VERBOSITY_INFO)
+			printf("Saving resource %s\n", res->GetName().c_str());
+		
 		res->CalcHash(); // TEST
 		res->Save(outputPath);
 	}

--- a/ZAPD/ZResource.cpp
+++ b/ZAPD/ZResource.cpp
@@ -25,7 +25,7 @@ void ZResource::ParseXML(tinyxml2::XMLElement* reader)
 		outName = name;
 }
 
-void ZResource::Save(string outFolder)
+void ZResource::Save(const std::string& outFolder)
 {
 
 }
@@ -46,7 +46,7 @@ std::string ZResource::GetOutName()
 
 void ZResource::SetName(string nName)
 {
-	name = nName;
+	name = std::move(nName);
 }
 
 bool ZResource::IsExternalResource()
@@ -84,12 +84,12 @@ void ZResource::SetRawDataIndex(int value)
 	rawDataIndex = value;
 }
 
-string ZResource::GetSourceOutputCode(std::string prefix)
+string ZResource::GetSourceOutputCode(const std::string& prefix)
 {
 	return "";
 }
 
-string ZResource::GetSourceOutputHeader(std::string prefix)
+string ZResource::GetSourceOutputHeader(const std::string& prefix)
 {
 	return "";
 }

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -45,7 +45,7 @@ public:
 
 	ZResource();
 	virtual void ParseXML(tinyxml2::XMLElement* reader);
-	virtual void Save(std::string outFolder);
+	virtual void Save(const std::string& outFolder);
 	virtual void PreGenSourceFiles();
 	std::string GetName();
 	std::string GetOutName();
@@ -57,8 +57,8 @@ public:
 	virtual int GetRawDataIndex();
 	virtual int GetRawDataSize();
 	virtual void SetRawDataIndex(int value);
-	virtual std::string GetSourceOutputCode(std::string prefix);
-	virtual std::string GetSourceOutputHeader(std::string prefix);
+	virtual std::string GetSourceOutputCode(const std::string& prefix);
+	virtual std::string GetSourceOutputHeader(const std::string& prefix);
 	virtual void GenerateHLIntermediette(HLFileIntermediette& hlFile);
 	virtual ZResourceType GetResourceType();
 	virtual void CalcHash();

--- a/ZAPD/ZRoom/Commands/SetActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetActorList.cpp
@@ -66,9 +66,9 @@ string SetActorList::GenerateSourceCodePass2(string roomName, int baseAddress)
 		index++;
 	}
 
-	zRoom->parent->AddDeclarationArray(segmentOffset, DeclarationAlignment::None, DeclarationPadding::Pad16, actors.size() * 16, 
+	zRoom->parent->AddDeclarationArray(segmentOffset, DeclarationAlignment::None, DeclarationPadding::Pad16, actors.size() * 16,
 		"ActorEntry", StringHelper::Sprintf("%sActorList0x%06X", roomName.c_str(), segmentOffset), actors.size(), declaration);
-	
+
 	return sourceOutput;
 }
 
@@ -94,7 +94,7 @@ RoomCommand SetActorList::GetRoomCommand()
 
 ActorSpawnEntry::ActorSpawnEntry(std::vector<uint8_t> rawData, int rawDataIndex)
 {
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	actorNum = BitConverter::ToInt16BE(data, rawDataIndex + 0);
 	posX = BitConverter::ToInt16BE(data, rawDataIndex + 2);

--- a/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
+++ b/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
@@ -44,8 +44,8 @@ string SetAlternateHeaders::GenerateSourceCodePass1(string roomName, int baseAdd
 			declaration += StringHelper::Sprintf("\t(u32)&%sSet%04XCmd00,\n", roomName.c_str(), headers[i] & 0x00FFFFFF);
 	}
 
-	zRoom->parent->declarations[segmentOffset] = new Declaration(DeclarationAlignment::None, headers.size() * 4, 
-		"u32", StringHelper::Sprintf("%sAlternateHeaders0x%06X", roomName.c_str(), segmentOffset), true, declaration);
+	zRoom->parent->AddDeclarationArray(segmentOffset, DeclarationAlignment::None, headers.size() * 4, 
+		"u32", StringHelper::Sprintf("%sAlternateHeaders0x%06X", roomName.c_str(), segmentOffset), 0, declaration);
 
 	return sourceOutput;
 }

--- a/ZAPD/ZRoom/Commands/SetLightingSettings.cpp
+++ b/ZAPD/ZRoom/Commands/SetLightingSettings.cpp
@@ -62,7 +62,7 @@ RoomCommand SetLightingSettings::GetRoomCommand()
 
 LightingSettings::LightingSettings(vector<uint8_t> rawData, int rawDataIndex)
 {
-	uint8_t* data = rawData.data();
+	const uint8_t* data = rawData.data();
 
 	ambientClrR = data[rawDataIndex + 0];
 	ambientClrG = data[rawDataIndex + 1];

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -109,8 +109,6 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 		zRoom->parent->AddDeclaration(meshHeader0->dListStart + (meshHeader0->entries.size() * 8) + 0, DeclarationAlignment::None, DeclarationPadding::Pad16, 4, "static s32",
 			"terminatorMaybe", " 0x01000000 ");
 
-		//zRoom->parent->declarations[meshHeader0->dListStart] = new Declaration(DeclarationAlignment::None, DeclarationPadding::Pad16, (meshHeader0->entries.size() * 8) + 4, declaration);
-
 		meshHeader = meshHeader0;
 	}
 	else if (meshHeaderType == 1)
@@ -146,11 +144,6 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 			zRoom->parent->AddDeclaration(segmentOffset, DeclarationAlignment::None, DeclarationPadding::Pad16, 0x1E, "MeshHeader1Single",
 				StringHelper::Sprintf("%sMeshHeader0x%06X", zRoom->GetName().c_str(), segmentOffset), declaration);
 
-			//if (headerSingle->imagePtr != 0)
-			//{
-				//zRoom->declarations[headerSingle->imagePtr] = new Declaration(DeclarationAlignment::None, DeclarationPadding::Pad16, 0x1E, declaration);
-			//}
-
 			meshHeader1 = headerSingle;
 ;		}
 		else if (fmt == 2) // Multi-Format
@@ -164,15 +157,11 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 			headerMulti->bgCnt = rawData[segmentOffset + 8];
 			headerMulti->bgRecordPtr = BitConverter::ToInt32BE(rawData, segmentOffset + 12);
 
-			//zRoom->declarations[segmentOffset] = new Declaration(DeclarationAlignment::None, DeclarationPadding::Pad16, 12, "");
-
 			declaration += StringHelper::Sprintf("{ { 1 }, 2, 0x%06X }, 0x%06X, 0x%06X",
 				headerMulti->entryRecord, headerMulti->bgCnt, headerMulti->bgRecordPtr);
 
 			zRoom->parent->AddDeclaration(segmentOffset, DeclarationAlignment::None, DeclarationPadding::Pad16, 16, "MeshHeader1Multi",
 				StringHelper::Sprintf("%sMeshHeader0x%06X", zRoom->GetName().c_str(), segmentOffset), declaration);
-
-			//zRoom->parent->declarations[segmentOffset] = new Declaration(DeclarationAlignment::None, DeclarationPadding::Pad16, 16, declaration);
 
 			meshHeader1 = headerMulti;
 		}
@@ -310,16 +299,11 @@ void SetMesh::GenDListDeclarations(std::vector<uint8_t> rawData, ZDisplayList* d
 	{
 		zRoom->parent->AddDeclarationArray(vtxEntry.first, DeclarationAlignment::Align8, dList->vertices[vtxEntry.first].size() * 16, "Vtx",
 			StringHelper::Sprintf("%sVtx_%06X", zRoom->GetName().c_str(), vtxEntry.first), 0, vtxEntry.second);
-
-		//zRoom->parent->declarations[vtxEntry.first] = new Declaration(DeclarationAlignment::Align8, dList->vertices[vtxEntry.first].size() * 16, vtxEntry.second);
 	}
 
 	for (pair<uint32_t, string> texEntry : dList->texDeclarations)
 	{
 		zRoom->textures[texEntry.first] = dList->textures[texEntry.first];
-		
-		//zRoom->parent->AddDeclarationArray(texEntry.first, DeclarationAlignment::None, dList->textures[texEntry.first]->GetRawDataSize(), "u64",
-			//zRoom->textures[texEntry.first]->GetName(), 0, texEntry.second);
 
 		if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 			printf("SAVING IMAGE TO %s\n", Globals::Instance->outputPath.c_str());

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -301,15 +301,15 @@ void SetMesh::GenDListDeclarations(std::vector<uint8_t> rawData, ZDisplayList* d
 	else
 		srcVarName = StringHelper::Sprintf("%s", dList->GetName().c_str());
 
-	zRoom->parent->AddDeclarationArray(dList->GetRawDataIndex(), DeclarationAlignment::None, dList->GetRawDataSize(), "Gfx", srcVarName, 0, sourceOutput);
+	zRoom->parent->AddDeclarationArray(dList->GetRawDataIndex(), DeclarationAlignment::None, dList->GetRawDataSize(), "static Gfx", srcVarName, dList->GetRawDataSize() / 8, sourceOutput);
 
 	for (ZDisplayList* otherDList : dList->otherDLists)
 		GenDListDeclarations(rawData, otherDList);
 
 	for (pair<uint32_t, string> vtxEntry : dList->vtxDeclarations)
 	{
-		zRoom->parent->AddDeclarationArray(vtxEntry.first, DeclarationAlignment::Align8, dList->vertices[vtxEntry.first].size() * 16, "Vtx",
-			StringHelper::Sprintf("%sVtx_%06X", zRoom->GetName().c_str(), vtxEntry.first), 0, vtxEntry.second);
+		zRoom->parent->AddDeclarationArray(vtxEntry.first, DeclarationAlignment::Align8, dList->vertices[vtxEntry.first].size() * 16, "static Vtx",
+			StringHelper::Sprintf("%sVtx_%06X", zRoom->GetName().c_str(), vtxEntry.first), dList->vertices[vtxEntry.first].size(), vtxEntry.second);
 
 		//zRoom->parent->declarations[vtxEntry.first] = new Declaration(DeclarationAlignment::Align8, dList->vertices[vtxEntry.first].size() * 16, vtxEntry.second);
 	}
@@ -344,8 +344,8 @@ std::string SetMesh::GenDListExterns(ZDisplayList* dList)
 	for (ZDisplayList* otherDList : dList->otherDLists)
 		sourceOutput += GenDListExterns(otherDList);
 
-	for (pair<uint32_t, string> vtxEntry : dList->vtxDeclarations)
-		sourceOutput += StringHelper::Sprintf("extern Vtx %sVtx_%06X[%i];\n", zRoom->GetName().c_str(), vtxEntry.first, dList->vertices[vtxEntry.first].size());
+	//for (pair<uint32_t, string> vtxEntry : dList->vtxDeclarations)
+		//sourceOutput += StringHelper::Sprintf("extern Vtx %sVtx_%06X[%i];\n", zRoom->GetName().c_str(), vtxEntry.first, dList->vertices[vtxEntry.first].size());
 
 	for (pair<uint32_t, string> texEntry : dList->texDeclarations)
 		sourceOutput += StringHelper::Sprintf("extern u64 %sTex_%06X[];\n", zRoom->GetName().c_str(), texEntry.first);

--- a/ZAPD/ZRoom/Commands/SetPathways.cpp
+++ b/ZAPD/ZRoom/Commands/SetPathways.cpp
@@ -19,10 +19,7 @@ SetPathways::SetPathways(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDat
 	uint32_t currentPtr = listSegmentOffset;
 
 	if (segmentOffset != 0)
-		zRoom->parent->declarations[segmentOffset] = new Declaration(DeclarationAlignment::None, 0, "", "", false, "");
-
-	//if (listSegmentOffset != 0)
-		//zRoom->declarations[listSegmentOffset] = new Declaration(DeclarationAlignment::None, 0, "");
+		zRoom->parent->AddDeclarationPlaceholder(segmentOffset);
 }
 
 void SetPathways::InitList(uint32_t address)

--- a/ZAPD/ZRoom/Commands/SetRoomList.cpp
+++ b/ZAPD/ZRoom/Commands/SetRoomList.cpp
@@ -23,19 +23,6 @@ SetRoomList::SetRoomList(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDat
 
 		currentPtr += 8;
 	}
-
-	//string declaration = "";
-
-	/*for (int i = 0; i < rooms.size(); i++)
-	{
-		RoomEntry* entry = rooms[i];
-
-		string roomName = StringHelper::Sprintf("%sRoom%i", StringHelper::Split(zRoom->GetName(), "_scene")[0].c_str(), i);
-		declaration += StringHelper::Sprintf("\t{ (u32)%sSegmentRomStart, (u32)%sSegmentRomEnd },\n", roomName.c_str(), roomName.c_str());
-	}*/
-	
-	//zRoom->parent->declarations[segmentOffset] = new Declaration(DeclarationAlignment::None, rooms.size() * 8, 
-		//"RomFile", StringHelper::Sprintf("%sRoomList0x%06X", zRoom->GetName().c_str(), segmentOffset), true, declaration);
 }
 
 string SetRoomList::GenerateSourceCodePass1(string roomName, int baseAddress)
@@ -79,8 +66,8 @@ std::string SetRoomList::PreGenSourceFiles()
 		}
 	}
 
-	zRoom->parent->declarations[segmentOffset] = new Declaration(DeclarationAlignment::None, rooms.size() * 8,
-		"RomFile", StringHelper::Sprintf("%sRoomList0x%06X", zRoom->GetName().c_str(), segmentOffset), true, declaration);
+	zRoom->parent->AddDeclarationArray(segmentOffset, DeclarationAlignment::None, rooms.size() * 8,
+		"RomFile", StringHelper::Sprintf("%sRoomList0x%06X", zRoom->GetName().c_str(), segmentOffset), 0, declaration);
 
 	return std::string();
 }

--- a/ZAPD/ZRoom/Commands/SetTransitionActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetTransitionActorList.cpp
@@ -38,8 +38,8 @@ string SetTransitionActorList::GenerateSourceCodePass1(string roomName, int base
 	for (TransitionActorEntry* entry : transitionActors)
 		declaration += StringHelper::Sprintf("\t{ %i, %i, %i, %i, %s, %i, %i, %i, %i, 0x%04X }, \n", entry->frontObjectRoom, entry->frontTransitionReaction, entry->backObjectRoom, entry->backTransitionReaction, ActorList[entry->actorNum].c_str(), entry->posX, entry->posY, entry->posZ, entry->rotY, (uint16_t)entry->initVar);
 
-	zRoom->parent->declarations[segmentOffset] = new Declaration(DeclarationAlignment::None, transitionActors.size() * 16, "TransitionActorEntry",
-		StringHelper::Sprintf("%sTransitionActorList0x%06X", roomName.c_str(), segmentOffset), true, declaration);
+	zRoom->parent->AddDeclarationArray(segmentOffset, DeclarationAlignment::None, transitionActors.size() * 16, "TransitionActorEntry",
+		StringHelper::Sprintf("%sTransitionActorList0x%06X", roomName.c_str(), segmentOffset), 0, declaration);
 
 	return sourceOutput;
 }

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -86,8 +86,6 @@ ZRoom* ZRoom::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int r
 			int address = strtol(StringHelper::Split(addressStr, "0x")[1].c_str(), NULL, 16);
 
 			ZDisplayList* dList = new ZDisplayList(room->rawData, address, ZDisplayList::GetDListLength(room->rawData, address));
-			//room->parent->declarations[address] = new Declaration(DeclarationAlignment::None, dList->GetRawDataSize(), comment + dList->GetSourceOutputCode(room->name));
-			//room->parent->AddDeclarationArray(address, DeclarationAlignment::None, dList->GetRawDataSize(), "Gfx", "", 0, comment + dList->GetSourceOutputCode(room->name));
 
 			dList->GetSourceOutputCode(room->name);
 		}

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -78,7 +78,7 @@ ZRoom* ZRoom::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int r
 		if (string(child->Name()) == "DListHint")
 		{
 			string comment = "";
-			
+
 			if (child->Attribute("Comment") != NULL)
 				comment = "// " + string(child->Attribute("Comment")) + "\n";
 
@@ -118,7 +118,7 @@ ZRoom* ZRoom::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int r
 			int address = strtol(StringHelper::Split(addressStr, "0x")[1].c_str(), NULL, 16);
 
 			ZCutscene* cutscene = new ZCutscene(room->rawData, address, 9999);
-			
+
 			room->parent->AddDeclarationArray(address, DeclarationAlignment::None, DeclarationPadding::Pad16, cutscene->GetRawDataSize(), "s32",
 				StringHelper::Sprintf("%sCutsceneData0x%06X", room->name.c_str(), cutscene->segmentOffset), 0, cutscene->GetSourceOutputCode(room->name));
 		}
@@ -201,7 +201,7 @@ void ZRoom::ParseCommands(std::vector<ZRoomCommand*>& commandList, CommandSet co
 		if (commandsLeft <= 0)
 			break;
 
-		RoomCommand opcode = (RoomCommand)rawData[rawDataIndex]; 
+		RoomCommand opcode = (RoomCommand)rawData[rawDataIndex];
 
 		ZRoomCommand* cmd = nullptr;
 
@@ -308,7 +308,7 @@ void ZRoom::ProcessCommandSets()
  */
 void ZRoom::SyotesRoomHack()
 {
-	char headerData[] = 
+	char headerData[] =
 	{
 		0x0A, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x08
 	};
@@ -392,10 +392,10 @@ size_t ZRoom::GetCommandSizeFromNeighbor(ZRoomCommand* cmd)
 	return 0;
 }
 
-string ZRoom::GetSourceOutputHeader(string prefix)
+string ZRoom::GetSourceOutputHeader(const std::string& prefix)
 {
 	sourceOutput = "";
-	
+
 	for (ZRoomCommand* cmd : commands)
 		sourceOutput += cmd->GenerateExterns();
 
@@ -407,7 +407,7 @@ string ZRoom::GetSourceOutputHeader(string prefix)
 	return sourceOutput;
 }
 
-string ZRoom::GetSourceOutputCode(std::string prefix)
+string ZRoom::GetSourceOutputCode(const std::string& prefix)
 {
 	sourceOutput = "";
 
@@ -468,7 +468,7 @@ string ZRoom::GetSourceOutputCode(std::string prefix)
 
 		if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 			printf("SAVING IMAGE TO %s\n", Globals::Instance->outputPath.c_str());
-		
+
 		item.second->Save(Globals::Instance->outputPath);
 
 		parent->AddDeclarationIncludeArray(item.first, StringHelper::Sprintf("%s/%s.%s.inc.c",
@@ -501,7 +501,7 @@ ZResourceType ZRoom::GetResourceType()
 	return ZResourceType::Room;
 }
 
-void ZRoom::Save(string outFolder)
+void ZRoom::Save(const std::string& outFolder)
 {
 	for (ZRoomCommand* cmd : commands)
 		cmd->Save();

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -280,7 +280,7 @@ void ZRoom::ProcessCommandSets()
 			cmd->commandSet = commandSet & 0x00FFFFFF;
 			string pass1 = cmd->GenerateSourceCodePass1(name, cmd->commandSet);
 
-			Declaration* decl = parent->AddDeclaration(cmd->cmdAddress, i == 0 ? DeclarationAlignment::Align16 : DeclarationAlignment::None, 8, cmd->GetCommandCName(),
+			Declaration* decl = parent->AddDeclaration(cmd->cmdAddress, i == 0 ? DeclarationAlignment::Align16 : DeclarationAlignment::None, 8, StringHelper::Sprintf("static %s", cmd->GetCommandCName().c_str()),
 				StringHelper::Sprintf("%sSet%04XCmd%02X", name.c_str(), commandSet & 0x00FFFFFF, cmd->cmdIndex, cmd->cmdID),
 				StringHelper::Sprintf("%s", pass1.c_str()));
 
@@ -298,7 +298,7 @@ void ZRoom::ProcessCommandSets()
 		string pass2 = cmd->GenerateSourceCodePass2(name, cmd->commandSet);
 
 		if (pass2 != "")
-			parent->AddDeclaration(cmd->cmdAddress, DeclarationAlignment::None, 8, cmd->GetCommandCName(), StringHelper::Sprintf("%sSet%04XCmd%02X", name.c_str(), cmd->commandSet & 0x00FFFFFF, cmd->cmdIndex, cmd->cmdID), StringHelper::Sprintf("%s // 0x%04X", pass2.c_str(), cmd->cmdAddress));
+			parent->AddDeclaration(cmd->cmdAddress, DeclarationAlignment::None, 8, StringHelper::Sprintf("static %s", cmd->GetCommandCName().c_str()), StringHelper::Sprintf("%sSet%04XCmd%02X", name.c_str(), cmd->commandSet & 0x00FFFFFF, cmd->cmdIndex, cmd->cmdID), StringHelper::Sprintf("%s // 0x%04X", pass2.c_str(), cmd->cmdAddress));
 	}
 }
 

--- a/ZAPD/ZRoom/ZRoom.h
+++ b/ZAPD/ZRoom/ZRoom.h
@@ -14,8 +14,8 @@ class ZRoom : public ZResource
 protected:
 	std::vector<ZRoomCommand*> commands;
 
-	std::string GetSourceOutputHeader(std::string prefix);
-	std::string GetSourceOutputCode(std::string prefix);
+	std::string GetSourceOutputHeader(const std::string& prefix);
+	std::string GetSourceOutputCode(const std::string& prefix);
 	void ProcessCommandSets();
 	void SyotesRoomHack();
 
@@ -36,7 +36,7 @@ public:
 	std::vector<uint8_t> GetRawData();
 	int GetRawDataSize();
 	virtual ZResourceType GetResourceType();
-	virtual void Save(std::string outFolder);
+	virtual void Save(const std::string& outFolder);
 	virtual void PreGenSourceFiles();
 };
 

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -50,16 +50,16 @@ ZLimbStandard* ZLimbStandard::FromRawData(std::vector<uint8_t> nRawData, int raw
 	limb->transX = BitConverter::ToInt16BE(nRawData, rawDataIndex + 0);
 	limb->transY = BitConverter::ToInt16BE(nRawData, rawDataIndex + 2);
 	limb->transZ = BitConverter::ToInt16BE(nRawData, rawDataIndex + 4);
-	
+
 	limb->childIndex = nRawData[rawDataIndex + 6];
 	limb->siblingIndex = nRawData[rawDataIndex + 7];
-	
+
 	limb->dListPtr = BitConverter::ToInt32BE(nRawData, rawDataIndex + 8) & 0x00FFFFFF;
 
 	return limb;
 }
 
-string ZLimbStandard::GetSourceOutputCode(string prefix)
+string ZLimbStandard::GetSourceOutputCode(const std::string& prefix)
 {
 	string dListStr = dListPtr == 0 ? "NULL" : StringHelper::Sprintf("%s", parent->GetVarName(dListPtr).c_str());
 
@@ -154,7 +154,7 @@ ZSkeleton* ZSkeleton::FromXML(XMLElement* reader, vector<uint8_t> nRawData, int 
 	return skeleton;
 }
 
-std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
+std::string ZSkeleton::GetSourceOutputCode(const std::string& prefix)
 {
 	if (parent != nullptr)
 	{
@@ -164,7 +164,7 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 		for (int i = 0; i < limbs.size(); i++)
 		{
 			ZLimbStandard* limb = limbs[i];
-			
+
 			string defaultDLName = StringHelper::Sprintf("%sLimbDL_%06X", defaultPrefix.c_str(), limb->dListPtr);
 			string dListStr = limb->dListPtr == 0 ? "NULL" : StringHelper::Sprintf("%s", parent->GetDeclarationName(limb->dListPtr, defaultDLName).c_str());
 
@@ -257,7 +257,7 @@ std::string ZSkeleton::GetSourceOutputCode(std::string prefix)
 	return "";
 }
 
-void ZSkeleton::Save(string outFolder)
+void ZSkeleton::Save(const std::string& outFolder)
 {
 
 }
@@ -286,7 +286,7 @@ ZLimbLOD* ZLimbLOD::FromRawData(vector<uint8_t> nRawData, int rawDataIndex)
 	return limb;
 }
 
-string ZLimbLOD::GetSourceOutputCode(string prefix)
+string ZLimbLOD::GetSourceOutputCode(const std::string& prefix)
 {
 	return std::string();
 }

--- a/ZAPD/ZSkeleton.h
+++ b/ZAPD/ZSkeleton.h
@@ -25,7 +25,7 @@ struct ZLimbStandard : public ZResource
 	ZLimbStandard();
 	static ZLimbStandard* FromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* parent);
 	static ZLimbStandard* FromRawData(std::vector<uint8_t> nRawData, int rawDataIndex);
-	std::string GetSourceOutputCode(std::string prefix);
+	std::string GetSourceOutputCode(const std::string& prefix);
 	virtual int GetRawDataSize();
 };
 
@@ -36,7 +36,7 @@ struct ZLimbLOD : ZLimbStandard
 	ZLimbLOD();
 	//static ZLimbLOD* FromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* parent);
 	static ZLimbLOD* FromRawData(std::vector<uint8_t> nRawData, int rawDataIndex);
-	std::string GetSourceOutputCode(std::string prefix);
+	std::string GetSourceOutputCode(const std::string& prefix);
 	virtual int GetRawDataSize();
 };
 
@@ -58,7 +58,7 @@ public:
 	ZSkeleton();
 	virtual void GenerateHLIntermediette(HLFileIntermediette& hlFile);
 	static ZSkeleton* FromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* nParent);
-	void Save(std::string outFolder);
+	void Save(const std::string& outFolder);
 
-	std::string GetSourceOutputCode(std::string prefix);
+	std::string GetSourceOutputCode(const std::string& prefix);
 };

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -348,9 +348,9 @@ void ZTexture::PrepareBitmapPalette4()
 				else
 					paletteIndex = (uint8_t)((rawData[pos] & 0x0F));
 
-				bmpRgb[(((y * width) + x) * 3) + 0] = paletteIndex * 16;
-				bmpRgb[(((y * width) + x) * 3) + 1] = paletteIndex * 16;
-				bmpRgb[(((y * width) + x) * 3) + 2] = paletteIndex * 16;
+				bmpRgb[(((y * width) + x + i) * 3) + 0] = paletteIndex * 16;
+				bmpRgb[(((y * width) + x + i) * 3) + 1] = paletteIndex * 16;
+				bmpRgb[(((y * width) + x + i) * 3) + 2] = paletteIndex * 16;
 			}
 		}
 	}

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -98,7 +98,7 @@ ZTexture* ZTexture::FromPNG(string pngFilePath, TextureType texType)
 	ZTexture* tex = new ZTexture();
 	tex->type = texType;
 	tex->name = StringHelper::Split(Path::GetFileNameWithoutExtension(pngFilePath), ".")[0];
-
+	
 	tex->bmpRgb = (uint8_t*)stbi_load((pngFilePath).c_str(), &tex->width, &tex->height, &comp, STBI_rgb);
 	stbi_image_free(tex->bmpRgb);
 	tex->bmpRgb = nullptr;

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -103,7 +103,7 @@ ZTexture* ZTexture::FromPNG(string pngFilePath, TextureType texType)
 	stbi_image_free(tex->bmpRgb);
 	tex->bmpRgb = nullptr;
 	tex->rawData = vector<uint8_t>(tex->GetRawDataSize());
-	
+
 	switch (texType)
 	{
 		case TextureType::RGBA16bpp: tex->PrepareRawDataRGBA16(pngFilePath); break;
@@ -116,7 +116,7 @@ ZTexture* ZTexture::FromPNG(string pngFilePath, TextureType texType)
 		case TextureType::Palette4bpp: tex->PrepareRawDataPalette4(pngFilePath); break;
 		case TextureType::Palette8bpp: tex->PrepareRawDataPalette8(pngFilePath); break;
 	}
-	
+
 	tex->FixRawData();
 
 	return tex;
@@ -129,7 +129,7 @@ ZTexture* ZTexture::FromHLTexture(HLTexture* hlTex)
 	tex->width = hlTex->width;
 	tex->height = hlTex->height;
 	tex->type = (TextureType)hlTex->type;
-	
+
 	return tex;
 }
 
@@ -139,14 +139,14 @@ void ZTexture::ParseXML(XMLElement* reader)
 
 	if (reader->Attribute("Width") != nullptr)
 		width = atoi(reader->Attribute("Width"));
-	
+
 	if (reader->Attribute("Height") != nullptr)
 		height = atoi(reader->Attribute("Height"));
 
 	string formatStr = reader->Attribute("Format");
 
 	type = GetTextureTypeFromString(formatStr);
-	
+
 	if (type == TextureType::Error)
 		throw "Format " + formatStr + " is not supported!";
 }
@@ -260,7 +260,7 @@ void ZTexture::PrepareBitmapGrayscale8()
 		for (int x = 0; x < width; x++)
 		{
 			int pos = ((y * width) + x) * 1;
-			
+
 			bmpRgb[(((y * width) + x) * 3) + 0] = rawData[pos];
 			bmpRgb[(((y * width) + x) * 3) + 1] = rawData[pos];
 			bmpRgb[(((y * width) + x) * 3) + 2] = rawData[pos];
@@ -363,7 +363,7 @@ void ZTexture::PrepareBitmapPalette8()
 		for (int x = 0; x < width; x++)
 		{
 			int pos = ((y * width) + x) * 1;
-			
+
 			bmpRgb[(((y * width) + x) * 3) + 0] = rawData[pos];
 			bmpRgb[(((y * width) + x) * 3) + 1] = rawData[pos];
 			bmpRgb[(((y * width) + x) * 3) + 2] = rawData[pos];
@@ -426,7 +426,7 @@ void ZTexture::PrepareRawDataRGBA32(string rgbaPath)
 	int comp;
 
 	bmpRgba = (uint8_t*)stbi_load(rgbaPath.c_str(), &width, &height, &comp, STBI_rgb_alpha);
-	
+
 	for (int y = 0; y < height; y++)
 	{
 		for (int x = 0; x < width; x++)
@@ -518,7 +518,7 @@ void ZTexture::PrepareRawDataGrayscaleAlpha8(string grayAlphaPath)
 	int comp;
 
 	bmpRgba = (uint8_t*)stbi_load(grayAlphaPath.c_str(), &width, &height, &comp, STBI_rgb_alpha);
-	
+
 	for (int y = 0; y < height; y++)
 	{
 		for (int x = 0; x < width; x++)
@@ -657,7 +657,7 @@ int ZTexture::GetHeight()
 	return height;
 }
 
-void ZTexture::Save(string outFolder)
+void ZTexture::Save(const std::string& outFolder)
 {
 	if (type == TextureType::RGBA32bpp)
 		stbi_write_png((outFolder + "/" + outName + ".rgba32.png").c_str(), width, height, 4, bmpRgba, width * 4);
@@ -683,7 +683,7 @@ void ZTexture::Save(string outFolder)
 }
 
 // HOTSPOT
-string ZTexture::GetSourceOutputCode(std::string prefix)
+string ZTexture::GetSourceOutputCode(const std::string& prefix)
 {
 	sourceOutput = "";
 
@@ -748,7 +748,7 @@ std::string ZTexture::GetExternalExtension()
 }
 
 
-string ZTexture::GetSourceOutputHeader(std::string prefix)
+string ZTexture::GetSourceOutputHeader(const std::string& prefix)
 {
 	//return StringHelper::Sprintf("extern u64 %s[];\n", name.c_str());
 	return "";

--- a/ZAPD/ZTexture.h
+++ b/ZAPD/ZTexture.h
@@ -67,8 +67,8 @@ public:
 	static ZTexture* FromHLTexture(HLTexture* hlTex);
 	static TextureType GetTextureTypeFromString(std::string str);
 
-	std::string GetSourceOutputCode(std::string prefix);
-	std::string GetSourceOutputHeader(std::string prefix);
+	std::string GetSourceOutputCode(const std::string& prefix) override;
+	std::string GetSourceOutputHeader(const std::string& prefix) override;
 
 	std::vector<uint8_t> GetRawData();
 	int GetRawDataSize();
@@ -76,6 +76,6 @@ public:
 	std::string GetIMSizFromType();
 	int GetWidth();
 	int GetHeight();
-	void Save(std::string outFolder);
+	void Save(const std::string& outFolder);
 	std::string GetExternalExtension();
 };


### PR DESCRIPTION
Static declarations are prototyped at the top of the C file now. Some of these may be redundant, but until we add in a system to detect if a prototype is needed based on declaration order, it'll have to do. Overall with the number of vtx declarations, the header files should be a fair bit slimmer now due to not having a bunch of externs anymore.