### PR TITLE
Always print an error if there is a bad "tag"

### DIFF
--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -308,7 +308,6 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, bool placeholderMode)
 			std::cerr << "ERROR bad type\n";
 			printf("Encountered unknown resource type: %s on line: %d\n", child->Name(), child->GetLineNum());
 			std::exit(EXIT_FAILURE);
-				
 		}
 	}
 }

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -305,8 +305,12 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, bool placeholderMode)
 		}
 		else
 		{
-			if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
-				printf("Encountered unknown resource type: %s\n", string(child->Name()).c_str());
+			//if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
+			std::cerr <<"ERROR bad type\n";
+				printf("Encountered unknown resource type: %s on line: %d \n", child->Name(), child->GetLineNum());
+				
+				std::exit(EXIT_FAILURE);
+				
 		}
 	}
 }

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -305,11 +305,9 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, bool placeholderMode)
 		}
 		else
 		{
-			//if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
-			std::cerr <<"ERROR bad type\n";
-				printf("Encountered unknown resource type: %s on line: %d \n", child->Name(), child->GetLineNum());
-				
-				std::exit(EXIT_FAILURE);
+			std::cerr << "ERROR bad type\n";
+			printf("Encountered unknown resource type: %s on line: %d\n", child->Name(), child->GetLineNum());
+			std::exit(EXIT_FAILURE);
 				
 		}
 	}


### PR DESCRIPTION
Removed the check for a certain debug level to print if there is an invalid XML asset tag.  I dont know python and Makefiles well enough to make it stop but its a start.