### PR TITLE
Fix some memory leaks issues

### DIFF
--- a/ZAPD/File.h
+++ b/ZAPD/File.h
@@ -14,7 +14,8 @@ public:
 	static bool Exists(const std::string& filePath)
 	{
 		std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
-		return file.good();
+		bool good = file.good();
+		return good;
 	}
 
 	static std::vector<uint8_t> ReadAllBytes(const std::string& filePath)
@@ -26,6 +27,7 @@ public:
 		file.read(data, fileSize);
 		std::vector<uint8_t> result = std::vector<uint8_t>(data, data + fileSize);
 		delete[] data;
+		file.close();
 
 		return result;
 	};
@@ -40,6 +42,7 @@ public:
 		file.read(data, fileSize);
 		std::string str = std::string((const char*)data);
 		delete[] data;
+		file.close();
 
 		return str;
 	};
@@ -56,11 +59,13 @@ public:
 	{
 		std::ofstream file(filePath, std::ios::binary);
 		file.write((char*)data.data(), data.size());
+		file.close();
 	};
 
 	static void WriteAllText(const std::string& filePath, const std::string& text)
 	{
 		std::ofstream file(filePath, std::ios::out);
 		file.write(text.c_str(), text.size());
+		file.close();
 	}
 };

--- a/ZAPD/File.h
+++ b/ZAPD/File.h
@@ -25,7 +25,7 @@ public:
 		char* data = new char[fileSize];
 		file.read(data, fileSize);
 		std::vector<uint8_t> result = std::vector<uint8_t>(data, data + fileSize);
-		delete data;
+		delete[] data;
 
 		return result;
 	};
@@ -39,7 +39,7 @@ public:
 		memset(data, 0, fileSize + 1);
 		file.read(data, fileSize);
 		std::string str = std::string((const char*)data);
-		delete data;
+		delete[] data;
 
 		return str;
 	};

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -66,6 +66,10 @@ string Globals::FindSymbolSegRef(int segNumber, uint32_t symbolAddress)
 				{
 					ZFile* file = new ZFile(fileMode, child, "", "", "", true);
 					file->GeneratePlaceholderDeclarations();
+					if (segmentRefFiles.find(segNumber) != segmentRefFiles.end()) {
+						// Maybe print an error (?)
+						delete segmentRefFiles[segNumber];
+					}
 					segmentRefFiles[segNumber] = file;
 					break;
 				}

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -10,12 +10,6 @@ Globals Globals::Instance;
 
 Globals::Globals()
 {
-
-	files = std::vector<ZFile*>();
-	segments = std::vector<int>();
-	symbolMap = std::map <uint32_t, std::string>();
-	segmentRefs = map<int, string>();
-	segmentRefFiles = map<int, ZFile*>();
 	game = ZGame::OOT_RETAIL;
 	genSourceFile = true;
 	testMode = false;
@@ -24,17 +18,6 @@ Globals::Globals()
 	useExternalResources = true;
 	lastScene = nullptr;
 	verbosity = VERBOSITY_SILENT;
-}
-
-
-Globals::~Globals()
-{
-	for (ZFile* file: files) {
-		delete file;
-	}
-	for (auto& file: segmentRefFiles) {
-		delete file.second;
-	}
 }
 
 string Globals::FindSymbolSegRef(int segNumber, uint32_t symbolAddress)
@@ -61,13 +44,9 @@ string Globals::FindSymbolSegRef(int segNumber, uint32_t symbolAddress)
 			{
 				if (string(child->Name()) == "File")
 				{
-					ZFile* file = new ZFile(fileMode, child, "", "", "", true);
-					file->GeneratePlaceholderDeclarations();
-					if (segmentRefFiles.find(segNumber) != segmentRefFiles.end()) {
-						// Maybe print an error (?)
-						delete segmentRefFiles[segNumber];
-					}
-					segmentRefFiles[segNumber] = file;
+					segmentRefFiles[segNumber] = std::make_shared<ZFile>(fileMode, child, "", "", "", true);;
+					segmentRefFiles[segNumber]->GeneratePlaceholderDeclarations();
+
 					break;
 				}
 			}
@@ -131,13 +110,4 @@ void Globals::AddSegment(int segment)
 bool Globals::HasSegment(int segment)
 {
 	return std::find(segments.begin(), segments.end(), segment) != segments.end();
-}
-
-GameConfig::GameConfig()
-{
-	segmentRefs = map<int, string>();
-	segmentRefFiles = map<int, ZFile*>();
-	symbolMap = std::map<uint32_t, std::string>();
-	actorList = std::vector<std::string>();
-	objectList = std::vector<std::string>();
 }

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -27,6 +27,19 @@ Globals::Globals()
 	verbosity = VERBOSITY_SILENT;
 }
 
+
+Globals::~Globals()
+{
+	Instance = nullptr;
+
+	for (ZFile* file: files) {
+		delete file;
+	}
+	for (auto& file: segmentRefFiles) {
+		delete file.second;
+	}
+}
+
 string Globals::FindSymbolSegRef(int segNumber, uint32_t symbolAddress)
 {
 	if (segmentRefs.find(segNumber) != segmentRefs.end())

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -6,11 +6,10 @@
 using namespace tinyxml2;
 using namespace std;
 
-Globals* Globals::Instance;
+Globals Globals::Instance;
 
 Globals::Globals()
 {
-	Instance = this;
 
 	files = std::vector<ZFile*>();
 	segments = std::vector<int>();
@@ -30,8 +29,6 @@ Globals::Globals()
 
 Globals::~Globals()
 {
-	Instance = nullptr;
-
 	for (ZFile* file: files) {
 		delete file;
 	}

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -39,6 +39,7 @@ public:
 	std::map<uint32_t, std::string> symbolMap;
 
 	Globals();
+	~Globals();
 	std::string FindSymbolSegRef(int segNumber, uint32_t symbolAddress);
 	void ReadConfigFile(const std::string& configFilePath);
 	void GenSymbolMap(const std::string& symbolMapPath);

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -31,15 +31,14 @@ public:
 	TextureType texType;
 	ZGame game;
 
-	std::vector<ZFile*> files;
+	std::vector<std::shared_ptr<ZFile>> files;
 	std::vector<int> segments;
 	std::map<int, std::string> segmentRefs;
-	std::map<int, ZFile*> segmentRefFiles;
-	ZRoom* lastScene;
+	std::map<int, std::shared_ptr<ZFile>> segmentRefFiles;
+	std::shared_ptr<ZRoom> lastScene;
 	std::map<uint32_t, std::string> symbolMap;
 
 	Globals();
-	~Globals();
 	std::string FindSymbolSegRef(int segNumber, uint32_t symbolAddress);
 	void ReadConfigFile(const std::string& configFilePath);
 	void GenSymbolMap(const std::string& symbolMapPath);
@@ -51,15 +50,10 @@ class GameConfig
 {
 public:
 	std::map<int, std::string> segmentRefs;
-	std::map<int, ZFile*> segmentRefFiles;
+	std::map<int, std::shared_ptr<ZFile>> segmentRefFiles;
 	std::map<uint32_t, std::string> symbolMap;
 	std::vector<std::string> actorList;
 	std::vector<std::string> objectList;
-
-	GameConfig();
-
-private:
-
 };
 
 /*

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -18,7 +18,7 @@ class GameConfig;
 class Globals
 {
 public:
-	static Globals* Instance;
+	static Globals Instance;
 
 	bool genSourceFile; // Used for extraction
 	bool useExternalResources;

--- a/ZAPD/HighLevel/HLModelIntermediette.cpp
+++ b/ZAPD/HighLevel/HLModelIntermediette.cpp
@@ -25,6 +25,9 @@ HLModelIntermediette::HLModelIntermediette()
 
 HLModelIntermediette::~HLModelIntermediette()
 {
+	for (HLIntermediette* block: blocks) {
+		delete block;
+	}
 }
 
 HLModelIntermediette* HLModelIntermediette::FromXML(tinyxml2::XMLElement* root)
@@ -880,6 +883,13 @@ HLTextureIntermediette::HLTextureIntermediette()
 	tex = nullptr;
 }
 
+HLTextureIntermediette::~HLTextureIntermediette()
+{
+	if (tex != nullptr) {
+		delete tex;
+	}
+}
+
 void HLTextureIntermediette::InitFromXML(tinyxml2::XMLElement* xmlElement)
 {
 	name = xmlElement->Attribute("Name");
@@ -1036,6 +1046,13 @@ void HLMeshIntermediette::OutputXML(tinyxml2::XMLDocument* doc, tinyxml2::XMLEle
 HLLimbIntermediette::HLLimbIntermediette()
 {
 	commands = vector<HLLimbCommand*>();
+}
+
+HLLimbIntermediette::~HLLimbIntermediette()
+{
+	for (HLLimbCommand* cmd: commands) {
+		delete cmd;
+	}
 }
 
 void HLLimbIntermediette::InitFromXML(tinyxml2::XMLElement* xmlElement)

--- a/ZAPD/HighLevel/HLModelIntermediette.cpp
+++ b/ZAPD/HighLevel/HLModelIntermediette.cpp
@@ -899,12 +899,12 @@ void HLTextureIntermediette::InitFromXML(tinyxml2::XMLElement* xmlElement)
 	string format = "rgb5a1"; // TEST
 
 	//tex = HLTexture::FromPNG(fileName, (HLTextureType)ZTexture::GetTextureTypeFromString(format));
-	tex = ZTexture::FromPNG(Path::GetDirectoryName(Globals::Instance->inputPath) + "/" + fileName, ZTexture::GetTextureTypeFromString(format));
+	tex = ZTexture::FromPNG(Path::GetDirectoryName(Globals::Instance.inputPath) + "/" + fileName, ZTexture::GetTextureTypeFromString(format));
 }
 
 std::string HLTextureIntermediette::OutputCode()
 {
-	return StringHelper::Sprintf("#include <../%s/%s.inc.c>", Globals::Instance->outputPath.c_str(), name.c_str());
+	return StringHelper::Sprintf("#include <../%s/%s.inc.c>", Globals::Instance.outputPath.c_str(), name.c_str());
 }
 
 void HLTextureIntermediette::OutputXML(tinyxml2::XMLDocument* doc, tinyxml2::XMLElement* root)
@@ -913,7 +913,7 @@ void HLTextureIntermediette::OutputXML(tinyxml2::XMLDocument* doc, tinyxml2::XML
 
 	element->SetAttribute("Name", name.c_str());
 	element->SetAttribute("TextureName", (name + "." + tex->GetExternalExtension() + ".png").c_str());
-	tex->Save(Globals::Instance->outputPath);
+	tex->Save(Globals::Instance.outputPath);
 
 	root->InsertEndChild(element);
 }

--- a/ZAPD/HighLevel/HLModelIntermediette.cpp
+++ b/ZAPD/HighLevel/HLModelIntermediette.cpp
@@ -87,7 +87,7 @@ void HLModelIntermediette::FromZDisplayList(HLModelIntermediette* model, ZDispla
 	model->blocks.push_back(vertIntr);
 
 	// Go through textures
-	for (pair<uint32_t, ZTexture*> pair : zDisplayList->textures)
+	for (auto& pair : zDisplayList->textures)
 	{
 		HLTextureIntermediette* texIntr = new HLTextureIntermediette();
 		texIntr->tex = pair.second;
@@ -262,7 +262,7 @@ void HLModelIntermediette::FromZSkeleton(HLModelIntermediette* model, ZSkeleton*
 
 	for (int i = 0; i < zSkeleton->limbs.size(); i++)
 	{
-		ZLimbStandard* limb = zSkeleton->limbs[i];
+		auto& limb = zSkeleton->limbs[i];
 
 		for (int j = 0; j < model->blocks.size(); j++)
 		{
@@ -880,14 +880,6 @@ std::string HLDisplayListCmdDrawMesh::OutputCode()
 
 HLTextureIntermediette::HLTextureIntermediette()
 {
-	tex = nullptr;
-}
-
-HLTextureIntermediette::~HLTextureIntermediette()
-{
-	if (tex != nullptr) {
-		delete tex;
-	}
 }
 
 void HLTextureIntermediette::InitFromXML(tinyxml2::XMLElement* xmlElement)

--- a/ZAPD/HighLevel/HLModelIntermediette.h
+++ b/ZAPD/HighLevel/HLModelIntermediette.h
@@ -68,7 +68,7 @@ public:
 class HLTextureIntermediette : public HLIntermediette
 {
 public:
-	ZTexture* tex;
+	std::shared_ptr<ZTexture> tex;
 	std::string fileName;
 
 	HLTextureIntermediette();

--- a/ZAPD/HighLevel/HLModelIntermediette.h
+++ b/ZAPD/HighLevel/HLModelIntermediette.h
@@ -72,6 +72,7 @@ public:
 	std::string fileName;
 
 	HLTextureIntermediette();
+	~HLTextureIntermediette();
 
 	virtual void InitFromXML(tinyxml2::XMLElement* xmlElement);
 	virtual std::string OutputCode();
@@ -275,6 +276,7 @@ public:
 	std::vector<HLLimbCommand*> commands;
 
 	HLLimbIntermediette();
+	~HLLimbIntermediette();
 
 	void InitFromXML(tinyxml2::XMLElement* xmlElement);
 	std::string OutputCode();

--- a/ZAPD/HighLevel/HLTexture.cpp
+++ b/ZAPD/HighLevel/HLTexture.cpp
@@ -4,6 +4,13 @@
 
 using namespace std;
 
+HLTexture::~HLTexture()
+{
+	if (bmpRgba != nullptr) {
+		stbi_image_free(bmpRgba);
+	}
+}
+
 HLTexture* HLTexture::FromPNG(std::string pngFilePath, HLTextureType texType)
 {
 	int comp;

--- a/ZAPD/HighLevel/HLTexture.h
+++ b/ZAPD/HighLevel/HLTexture.h
@@ -23,6 +23,8 @@ enum class HLTextureType
 class HLTexture
 {
 public:
+	~HLTexture();
+
 	static HLTexture* FromPNG(std::string pngFilePath, HLTextureType texType);
 
 	HLTextureType type;

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -212,7 +212,7 @@ int NewMain(int argc, char* argv[])
 	}
 	else if (fileMode == ZFileMode::BuildOverlay)
 	{
-		ZOverlay* overlay = ZOverlay::FromBuild(Path::GetDirectoryName(Globals::Instance.inputPath), Path::GetDirectoryName(Globals::Instance.cfgPath));
+		auto overlay = ZOverlay::FromBuild(Path::GetDirectoryName(Globals::Instance.inputPath), Path::GetDirectoryName(Globals::Instance.cfgPath));
 
 		if (overlay)
 			File::WriteAllText(Globals::Instance.outputPath, overlay->GetSourceOutputCode(""));

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -238,12 +238,11 @@ bool Parse(const std::string& xmlFilePath, const std::string& basePath, const st
 	{
 		if (string(child->Name()) == "File")
 		{
-			ZFile* file = new ZFile(fileMode, child, basePath, outPath, "", false);
-			Globals::Instance.files.push_back(file);
+			Globals::Instance.files.push_back(std::make_shared<ZFile>(fileMode, child, basePath, outPath, "", false));
 		}
 	}
 
-	for (ZFile* file : Globals::Instance.files)
+	for (auto& file : Globals::Instance.files)
 	{
 		if (fileMode == ZFileMode::Build)
 			file->BuildResources();
@@ -254,9 +253,6 @@ bool Parse(const std::string& xmlFilePath, const std::string& basePath, const st
 	}
 
 	// All done, free files
-	for (ZFile* file : Globals::Instance.files)
-		delete file;
-
 	Globals::Instance.files.clear();
 
 	return true;
@@ -266,7 +262,7 @@ void BuildAssetTexture(const std::string& pngFilePath, TextureType texType, cons
 {
 	vector<string> split = StringHelper::Split(outPath, "/");
 	string name = StringHelper::Split(split[split.size() - 1], ".")[0];
-	ZTexture* tex = ZTexture::FromPNG(pngFilePath, texType);
+	auto tex = ZTexture::FromPNG(pngFilePath, texType);
 	string cfgPath = StringHelper::Split(pngFilePath, ".")[0] + ".cfg";
 
 	if (File::Exists(cfgPath))
@@ -276,22 +272,18 @@ void BuildAssetTexture(const std::string& pngFilePath, TextureType texType, cons
 	string src = tex->GetSourceOutputCode(name);
 
 	File::WriteAllText(outPath, src);
-
-	delete tex;
 }
 
 void BuildAssetBlob(const std::string& blobFilePath, const std::string& outPath)
 {
 	vector<string> split = StringHelper::Split(outPath, "/");
-	ZBlob* blob = ZBlob::FromFile(blobFilePath);
+	auto blob = ZBlob::FromFile(blobFilePath);
 	string name = StringHelper::Split(split[split.size() - 1], ".")[0];
 
 	//string src = StringHelper::Sprintf("u8 %s[] = \n{\n", name.c_str()) + blob->GetSourceOutputCode(name) + "};\n";
 	string src = blob->GetSourceOutputCode(name);
 
 	File::WriteAllText(outPath, src);
-
-	delete blob;
 }
 
 void BuildAssetModelIntermediette(const std::string& mdlPath, const std::string& outPath)

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -303,23 +303,22 @@ void BuildAssetModelIntermediette(const std::string& mdlPath, const std::string&
 void BuildAssetAnimationIntermediette(const std::string& animPath, const std::string& outPath)
 {
 	vector<string> split = StringHelper::Split(outPath, "/");
-	ZFile* file = new ZFile("", split[split.size() - 2]);
+	ZFile file("", split[split.size() - 2]);
 	HLAnimationIntermediette* anim = HLAnimationIntermediette::FromXML(animPath);
 	ZAnimation* zAnim = anim->ToZAnimation();
 	zAnim->SetName(Path::GetFileNameWithoutExtension(split[split.size() - 1]));
-	zAnim->parent = file;
+	zAnim->parent = &file;
 	//zAnim->rotationIndicesSeg = 1;
 	//zAnim->rotationValuesSeg = 2;
 
 	zAnim->GetSourceOutputCode(split[split.size() - 2]);
 	string output = "";
 
-	output += file->declarations[2]->text + "\n";
-	output += file->declarations[1]->text + "\n";
-	output += file->declarations[0]->text + "\n";
+	output += file.declarations[2]->text + "\n";
+	output += file.declarations[1]->text + "\n";
+	output += file.declarations[0]->text + "\n";
 
 	File::WriteAllText(outPath, output);
 
 	delete zAnim;
-	delete file;
 }

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -56,7 +56,9 @@ void ErrorHandler(int sig)
 int main(int argc, char* argv[])
 {
 	Globals* g = new Globals();
-	return NewMain(argc, argv);
+	int retval = NewMain(argc, argv);
+	delete g;
+	return retval;
 }
 
 int NewMain(int argc, char* argv[])

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -55,10 +55,7 @@ void ErrorHandler(int sig)
 
 int main(int argc, char* argv[])
 {
-	Globals* g = new Globals();
-	int retval = NewMain(argc, argv);
-	delete g;
-	return retval;
+	return NewMain(argc, argv);
 }
 
 int NewMain(int argc, char* argv[])
@@ -105,62 +102,62 @@ int NewMain(int argc, char* argv[])
 
 		if (arg == "-o" || arg == "--outputpath") // Set output path
 		{
-			Globals::Instance->outputPath = argv[i + 1];
+			Globals::Instance.outputPath = argv[i + 1];
 			i++;
 		}
 		else if (arg == "-i" || arg == "--inputpath") // Set input path
 		{
-			Globals::Instance->inputPath = argv[i + 1];
+			Globals::Instance.inputPath = argv[i + 1];
 			i++;
 		}
 		else if (arg == "-b" || arg == "--baserompath") // Set baserom path
 		{
-			Globals::Instance->baseRomPath = argv[i + 1];
+			Globals::Instance.baseRomPath = argv[i + 1];
 			i++;
 		}
 		else if (arg == "-gsf") // Generate source file during extraction
 		{
-			Globals::Instance->genSourceFile = string(argv[i + 1]) == "1";
+			Globals::Instance.genSourceFile = string(argv[i + 1]) == "1";
 			i++;
 		}
 		else if (arg == "-ifp") // Include file prefix in generated symbols
 		{
-			Globals::Instance->includeFilePrefix = string(argv[i + 1]) == "1";
+			Globals::Instance.includeFilePrefix = string(argv[i + 1]) == "1";
 			i++;
 		}
 		else if (arg == "-tm") // Test Mode
 		{
-			Globals::Instance->testMode = string(argv[i + 1]) == "1";
+			Globals::Instance.testMode = string(argv[i + 1]) == "1";
 			i++;
 		}
 		else if (arg == "-profile") // Profile
 		{
-			Globals::Instance->profile = string(argv[i + 1]) == "1";
+			Globals::Instance.profile = string(argv[i + 1]) == "1";
 			i++;
 		}
 		else if (arg == "-uer") // Split resources into their individual components (enabled by default)
 		{
-			Globals::Instance->useExternalResources = string(argv[i + 1]) == "1";
+			Globals::Instance.useExternalResources = string(argv[i + 1]) == "1";
 			i++;
 		}
 		else if (arg == "-tt") // Set texture type
 		{
-			Globals::Instance->texType = ZTexture::GetTextureTypeFromString(argv[i + 1]);
+			Globals::Instance.texType = ZTexture::GetTextureTypeFromString(argv[i + 1]);
 			i++;
 		}
 		else if (arg == "-cfg") // Set cfg path
 		{
-			Globals::Instance->cfgPath = argv[i + 1];
+			Globals::Instance.cfgPath = argv[i + 1];
 			i++;
 		}
 		else if (arg == "-sm") // Set symbol map path
 		{
-			Globals::Instance->GenSymbolMap(argv[i + 1]);
+			Globals::Instance.GenSymbolMap(argv[i + 1]);
 			i++;
 		}
 		else if (arg == "-rconf") // Read Config File
 		{
-			Globals::Instance->ReadConfigFile(argv[i + 1]);
+			Globals::Instance.ReadConfigFile(argv[i + 1]);
 			i++;
 		}
 		else if (arg == "-al") // Set actor list
@@ -179,46 +176,46 @@ int NewMain(int argc, char* argv[])
 		}
 		else if (arg == "-v") // Verbose
 		{
-			Globals::Instance->verbosity = (VerbosityLevel)strtol(argv[++i], NULL, 16);
+			Globals::Instance.verbosity = (VerbosityLevel)strtol(argv[++i], NULL, 16);
 		}
 	}
 
-	if (Globals::Instance->verbosity >= VERBOSITY_INFO)
+	if (Globals::Instance.verbosity >= VERBOSITY_INFO)
 		printf("ZAPD: Zelda Asset Processor For Decomp: %s\n", gBuildHash);
 
 	if (fileMode == ZFileMode::Build || fileMode == ZFileMode::Extract || fileMode == ZFileMode::BuildSourceFile)
 	{
-		Parse(Globals::Instance->inputPath, Globals::Instance->baseRomPath, Globals::Instance->outputPath, fileMode);
+		Parse(Globals::Instance.inputPath, Globals::Instance.baseRomPath, Globals::Instance.outputPath, fileMode);
 	}
 	else if (fileMode == ZFileMode::BuildTexture)
 	{
-		TextureType texType = Globals::Instance->texType;
-		string pngFilePath = Globals::Instance->inputPath;
-		string outFilePath = Globals::Instance->outputPath;
+		TextureType texType = Globals::Instance.texType;
+		string pngFilePath = Globals::Instance.inputPath;
+		string outFilePath = Globals::Instance.outputPath;
 
 		BuildAssetTexture(pngFilePath, texType, outFilePath);
 	}
 	else if (fileMode == ZFileMode::BuildBlob)
 	{
-		string blobFilePath = Globals::Instance->inputPath;
-		string outFilePath = Globals::Instance->outputPath;
+		string blobFilePath = Globals::Instance.inputPath;
+		string outFilePath = Globals::Instance.outputPath;
 
 		BuildAssetBlob(blobFilePath, outFilePath);
 	}
 	else if (fileMode == ZFileMode::BuildModelIntermediette)
 	{
-		BuildAssetModelIntermediette(Globals::Instance->inputPath, Globals::Instance->outputPath);
+		BuildAssetModelIntermediette(Globals::Instance.inputPath, Globals::Instance.outputPath);
 	}
 	else if (fileMode == ZFileMode::BuildAnimationIntermediette)
 	{
-		BuildAssetAnimationIntermediette(Globals::Instance->inputPath, Globals::Instance->outputPath);
+		BuildAssetAnimationIntermediette(Globals::Instance.inputPath, Globals::Instance.outputPath);
 	}
 	else if (fileMode == ZFileMode::BuildOverlay)
 	{
-		ZOverlay* overlay = ZOverlay::FromBuild(Path::GetDirectoryName(Globals::Instance->inputPath), Path::GetDirectoryName(Globals::Instance->cfgPath));
+		ZOverlay* overlay = ZOverlay::FromBuild(Path::GetDirectoryName(Globals::Instance.inputPath), Path::GetDirectoryName(Globals::Instance.cfgPath));
 
 		if (overlay)
-			File::WriteAllText(Globals::Instance->outputPath, overlay->GetSourceOutputCode(""));
+			File::WriteAllText(Globals::Instance.outputPath, overlay->GetSourceOutputCode(""));
 	}
 
 	return 0;
@@ -242,11 +239,11 @@ bool Parse(const std::string& xmlFilePath, const std::string& basePath, const st
 		if (string(child->Name()) == "File")
 		{
 			ZFile* file = new ZFile(fileMode, child, basePath, outPath, "", false);
-			Globals::Instance->files.push_back(file);
+			Globals::Instance.files.push_back(file);
 		}
 	}
 
-	for (ZFile* file : Globals::Instance->files)
+	for (ZFile* file : Globals::Instance.files)
 	{
 		if (fileMode == ZFileMode::Build)
 			file->BuildResources();
@@ -257,10 +254,10 @@ bool Parse(const std::string& xmlFilePath, const std::string& basePath, const st
 	}
 
 	// All done, free files
-	for (ZFile* file : Globals::Instance->files)
+	for (ZFile* file : Globals::Instance.files)
 		delete file;
 
-	Globals::Instance->files.clear();
+	Globals::Instance.files.clear();
 
 	return true;
 }

--- a/ZAPD/Overlays/ZOverlay.h
+++ b/ZAPD/Overlays/ZOverlay.h
@@ -53,13 +53,12 @@ public:
 	std::string name;
 
 	ZOverlay(std::string nName);
-	~ZOverlay();
-	static ZOverlay* FromBuild(std::string buildPath, std::string cfgFolderPath);
+	static std::shared_ptr<ZOverlay> FromBuild(std::string buildPath, std::string cfgFolderPath);
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 	ZResourceType GetResourceType() override;
 
 private:
-	std::vector<RelocationEntry*> entries;
+	std::vector<std::shared_ptr<RelocationEntry>> entries;
 
 	ZOverlay();
 

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -103,9 +103,9 @@ int ZNormalAnimation::GetRawDataSize()
 	return 16;
 }
 
-ZNormalAnimation* ZNormalAnimation::ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, const std::string& nRelPath)
+std::shared_ptr<ZNormalAnimation> ZNormalAnimation::ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, const std::string& nRelPath)
 {
-	ZNormalAnimation* anim = new ZNormalAnimation();
+	std::shared_ptr<ZNormalAnimation> anim = std::make_shared<ZNormalAnimation>();
 	anim->rawData = std::move(nRawData);
 	anim->rawDataIndex = rawDataIndex;
 	anim->ParseXML(reader);
@@ -166,9 +166,9 @@ int ZLinkAnimation::GetRawDataSize()
 	return 8;
 }
 
-ZLinkAnimation* ZLinkAnimation::ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, const std::string& nRelPath)
+std::shared_ptr<ZLinkAnimation> ZLinkAnimation::ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, const std::string& nRelPath)
 {
-	ZLinkAnimation* anim = new ZLinkAnimation();
+	std::shared_ptr<ZLinkAnimation> anim = std::make_shared<ZLinkAnimation>();
 	anim->rawData = std::move(nRawData);
 	anim->rawDataIndex = rawDataIndex;
 	anim->ParseXML(reader);

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -24,7 +24,7 @@ void ZAnimation::ParseRawData()
 
 void ZAnimation::Save(const std::string& outFolder)
 {
-	if (Globals::Instance->testMode)
+	if (Globals::Instance.testMode)
 	{
 		HLAnimationIntermediette* anim = HLAnimationIntermediette::FromZAnimation(this);
 		string xml = anim->OutputXML();

--- a/ZAPD/ZAnimation.h
+++ b/ZAPD/ZAnimation.h
@@ -46,7 +46,7 @@ public:
 	std::string GetSourceOutputCode(const std::string& prefix);
 	int GetRawDataSize() override;
 
-	static ZNormalAnimation* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, const std::string& nRelPath);
+	static std::shared_ptr<ZNormalAnimation> ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, const std::string& nRelPath);
 
 protected:
 	virtual void ParseRawData();
@@ -62,7 +62,7 @@ public:
 	std::string GetSourceOutputCode(const std::string& prefix);
 	int GetRawDataSize() override;
 
-	static ZLinkAnimation* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, const std::string& nRelPath);
+	static std::shared_ptr<ZLinkAnimation> ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, const std::string& nRelPath);
 
 protected:
 	virtual void ParseRawData();

--- a/ZAPD/ZArray.cpp
+++ b/ZAPD/ZArray.cpp
@@ -20,7 +20,7 @@ void ZArray::ParseXML(tinyxml2::XMLElement* reader)
 	ZResource::ParseXML(reader);
 
 	arrayCnt = reader->IntAttribute("Count", 0);
-	testFile = new ZFile(ZFileMode::Extract, reader, Globals::Instance->baseRomPath, "", parent->GetName(), true);
+	testFile = new ZFile(ZFileMode::Extract, reader, Globals::Instance.baseRomPath, "", parent->GetName(), true);
 }
 
 // TODO: This is a bit hacky, but until we refactor how ZFile parses the XML, it'll have to do.

--- a/ZAPD/ZArray.cpp
+++ b/ZAPD/ZArray.cpp
@@ -8,6 +8,13 @@ ZArray::ZArray()
 
 }
 
+ZArray::~ZArray()
+{
+	if (testFile != nullptr) {
+		delete testFile;
+	}
+}
+
 void ZArray::ParseXML(tinyxml2::XMLElement* reader)
 {
 	ZResource::ParseXML(reader);

--- a/ZAPD/ZArray.cpp
+++ b/ZAPD/ZArray.cpp
@@ -33,7 +33,7 @@ std::string ZArray::GetSourceOutputCode(const std::string& prefix)
 		throw StringHelper::Sprintf("Error! Array needs at least one sub-element.\n");
 	}
 
-	ZResource* res = testFile->resources[0];
+	auto& res = testFile->resources[0];
 	int resSize = res->GetRawDataSize();
 
 	if (!res->DoesSupportArray())
@@ -67,9 +67,9 @@ int ZArray::GetRawDataSize()
     return arrayCnt * testFile->resources[0]->GetRawDataSize();
 }
 
-ZArray* ZArray::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath, ZFile* nParent)
+std::shared_ptr<ZArray> ZArray::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath, ZFile* nParent)
 {
-	ZArray* arr = new ZArray();
+	std::shared_ptr<ZArray> arr = std::make_shared<ZArray>();
 	arr->rawData = nRawData;
 	arr->rawDataIndex = rawDataIndex;
 	arr->parent = nParent;

--- a/ZAPD/ZArray.h
+++ b/ZAPD/ZArray.h
@@ -10,6 +10,7 @@ class ZArray : public ZResource
 {
 public:
 	ZArray();
+	~ZArray();
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	std::string GetSourceOutputCode(const std::string& prefix) override;

--- a/ZAPD/ZArray.h
+++ b/ZAPD/ZArray.h
@@ -16,7 +16,7 @@ public:
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 	int GetRawDataSize() override;
 
-	static ZArray* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath, ZFile* nParent);
+	static std::shared_ptr<ZArray> ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath, ZFile* nParent);
 
 protected:
 	int arrayCnt;

--- a/ZAPD/ZBlob.cpp
+++ b/ZAPD/ZBlob.cpp
@@ -20,9 +20,9 @@ ZBlob::ZBlob(const std::vector<uint8_t>& nRawData, int nRawDataIndex, int size, 
 	name = std::move(nName);
 }
 
-ZBlob* ZBlob::ExtractFromXML(XMLElement* reader, const vector<uint8_t>& nRawData, int nRawDataIndex, string nRelPath)
+std::shared_ptr<ZBlob> ZBlob::ExtractFromXML(XMLElement* reader, const vector<uint8_t>& nRawData, int nRawDataIndex, string nRelPath)
 {
-	ZBlob* blob = new ZBlob();
+	std::shared_ptr<ZBlob> blob = make_shared<ZBlob>();
 
 	blob->rawDataIndex = nRawDataIndex;
 
@@ -34,9 +34,9 @@ ZBlob* ZBlob::ExtractFromXML(XMLElement* reader, const vector<uint8_t>& nRawData
 	return blob;
 }
 
-ZBlob* ZBlob::BuildFromXML(XMLElement* reader, const std::string& inFolder, bool readFile)
+std::shared_ptr<ZBlob> ZBlob::BuildFromXML(XMLElement* reader, const std::string& inFolder, bool readFile)
 {
-	ZBlob* blob = new ZBlob();
+	std::shared_ptr<ZBlob> blob = make_shared<ZBlob>();
 
 	blob->ParseXML(reader);
 
@@ -46,10 +46,10 @@ ZBlob* ZBlob::BuildFromXML(XMLElement* reader, const std::string& inFolder, bool
 	return blob;
 }
 
-ZBlob* ZBlob::FromFile(const std::string& filePath)
+std::shared_ptr<ZBlob> ZBlob::FromFile(const std::string& filePath)
 {
 	int comp;
-	ZBlob* blob = new ZBlob();
+	std::shared_ptr<ZBlob> blob = make_shared<ZBlob>();
 	blob->name = StringHelper::Split(Path::GetFileNameWithoutExtension(filePath), ".")[0];
 	blob->rawData = File::ReadAllBytes(filePath);
 

--- a/ZAPD/ZBlob.h
+++ b/ZAPD/ZBlob.h
@@ -6,11 +6,12 @@
 class ZBlob : public ZResource
 {
 public:
+	ZBlob();
 	ZBlob(const std::vector<uint8_t>& nRawData, int rawDataIndex, int size, std::string nName);
 
-	static ZBlob* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int rawDataIndex, std::string nRelPath);
-	static ZBlob* BuildFromXML(tinyxml2::XMLElement* reader, const std::string& inFolder, bool readFile);
-	static ZBlob* FromFile(const std::string& filePath);
+	static std::shared_ptr<ZBlob> ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int rawDataIndex, std::string nRelPath);
+	static std::shared_ptr<ZBlob> BuildFromXML(tinyxml2::XMLElement* reader, const std::string& inFolder, bool readFile);
+	static std::shared_ptr<ZBlob> FromFile(const std::string& filePath);
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 	std::string GetSourceOutputHeader(const std::string& prefix) override;
 	void Save(const std::string& outFolder) override;
@@ -18,7 +19,4 @@ public:
 	std::string GetExternalExtension() override;
 	std::string GetSourceTypeName() override;
 	ZResourceType GetResourceType() override;
-
-private:
-	ZBlob();
 };

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -68,7 +68,7 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 		camData = new CameraDataList(parent, prefix, rawData, SEG2FILESPACE(camDataSegmentOffset), SEG2FILESPACE(polyTypeDefSegmentOffset), polygonTypes.size());
 
 	for (int i = 0; i < numWaterBoxes; i++)
-		waterBoxes.push_back(new WaterBoxHeader(rawData, waterBoxSegmentOffset + (i * (Globals::Instance->game == ZGame::OOT_SW97 ? 12 : 16))));
+		waterBoxes.push_back(new WaterBoxHeader(rawData, waterBoxSegmentOffset + (i * (Globals::Instance.game == ZGame::OOT_SW97 ? 12 : 16))));
 
 	string declaration = "";
 	char line[2048];
@@ -218,7 +218,7 @@ WaterBoxHeader::WaterBoxHeader(const std::vector<uint8_t>& rawData, int rawDataI
 	zMin = BitConverter::ToInt16BE(data, rawDataIndex + 4);
 	xLength = BitConverter::ToInt16BE(data, rawDataIndex + 6);
 	zLength = BitConverter::ToInt16BE(data, rawDataIndex + 8);
-	if (Globals::Instance->game == ZGame::OOT_SW97)
+	if (Globals::Instance.game == ZGame::OOT_SW97)
 	{
 		properties = BitConverter::ToInt16BE(data, rawDataIndex + 10);
 	}

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -166,6 +166,10 @@ ZCollisionHeader::~ZCollisionHeader()
 
 	for (WaterBoxHeader* waterBox : waterBoxes)
 		delete waterBox;
+	
+	if (camData != nullptr) {
+		delete camData;
+	}
 }
 
 ZResourceType ZCollisionHeader::GetResourceType()
@@ -298,4 +302,14 @@ CameraPositionData::CameraPositionData(const std::vector<uint8_t>& rawData, int 
 	x = BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
 	y = BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
 	z = BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
+}
+
+CameraDataList::~CameraDataList()
+{
+	for (CameraDataEntry* entry: entries) {
+		delete entry;
+	}
+	for (CameraPositionData* pos: cameraPositionData) {
+		delete pos;
+	}
 }

--- a/ZAPD/ZCollision.h
+++ b/ZAPD/ZCollision.h
@@ -59,6 +59,7 @@ public:
 	std::vector<CameraPositionData*> cameraPositionData;
 
 	CameraDataList(ZFile* parent, const std::string& prefix, const std::vector<uint8_t>& rawData, int rawDataIndex, int polyTypeDefSegmentOffset, int polygonTypesCnt);
+	~CameraDataList();
 };
 
 class ZCollisionHeader : public ZResource

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -126,9 +126,9 @@ int ZCutscene::GetRawDataSize()
 	return size;
 }
 
-ZCutscene* ZCutscene::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath)
+std::shared_ptr<ZCutscene> ZCutscene::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath)
 {
-	ZCutscene* cs = new ZCutscene(nRawData, rawDataIndex, 9999);
+	std::shared_ptr<ZCutscene> cs = std::make_shared<ZCutscene>(nRawData, rawDataIndex, 9999);
 	cs->rawData = nRawData;
 	cs->rawDataIndex = rawDataIndex;
 	cs->ParseXML(reader);

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -249,6 +249,12 @@ CutsceneCommandSetCameraPos::CutsceneCommandSetCameraPos(const vector<uint8_t>& 
 	}
 }
 
+CutsceneCommandSetCameraPos::~CutsceneCommandSetCameraPos()
+{
+	for (CutsceneCameraPoint* entry: entries)
+		delete entry;
+}
+
 // TODO
 string CutsceneCommandSetCameraPos::GetCName(const std::string& prefix)
 {
@@ -330,6 +336,12 @@ CutsceneCommandFadeBGM::CutsceneCommandFadeBGM(const vector<uint8_t>& rawData, i
 	}
 }
 
+CutsceneCommandFadeBGM::~CutsceneCommandFadeBGM()
+{
+	for (MusicFadeEntry* entry: entries)
+		delete entry;
+}
+
 string CutsceneCommandFadeBGM::GetCName(const std::string& prefix)
 {
 	return "CsCmdMusicFade";
@@ -384,6 +396,12 @@ CutsceneCommandPlayBGM::CutsceneCommandPlayBGM(const vector<uint8_t>& rawData, i
 	}
 }
 
+CutsceneCommandPlayBGM::~CutsceneCommandPlayBGM()
+{
+	for (MusicChangeEntry* entry: entries)
+		delete entry;
+}
+
 string CutsceneCommandPlayBGM::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
@@ -421,6 +439,12 @@ CutsceneCommandStopBGM::CutsceneCommandStopBGM(const vector<uint8_t>& rawData, i
 		entries.push_back(new MusicChangeEntry(rawData, rawDataIndex));
 		rawDataIndex += 0x30;
 	}
+}
+
+CutsceneCommandStopBGM::~CutsceneCommandStopBGM()
+{
+	for (MusicChangeEntry* entry: entries)
+		delete entry;
 }
 
 string CutsceneCommandStopBGM::GenerateSourceCode(const std::string& roomName, int baseAddress)
@@ -477,6 +501,12 @@ CutsceneCommandEnvLighting::CutsceneCommandEnvLighting(const vector<uint8_t>& ra
 	}
 }
 
+CutsceneCommandEnvLighting::~CutsceneCommandEnvLighting()
+{
+	for (EnvLightingEntry* entry: entries)
+		delete entry;
+}
+
 string CutsceneCommandEnvLighting::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
@@ -526,6 +556,12 @@ CutsceneCommandUnknown9::CutsceneCommandUnknown9(const vector<uint8_t>& rawData,
 		entries.push_back(new Unknown9Entry(rawData, rawDataIndex));
 		rawDataIndex += 0x0C;
 	}
+}
+
+CutsceneCommandUnknown9::~CutsceneCommandUnknown9()
+{
+	for (Unknown9Entry* entry: entries)
+		delete entry;
 }
 
 string CutsceneCommandUnknown9::GenerateSourceCode(const std::string& roomName, int baseAddress)
@@ -582,6 +618,12 @@ CutsceneCommandUnknown::CutsceneCommandUnknown(const vector<uint8_t>& rawData, i
 	}
 }
 
+CutsceneCommandUnknown::~CutsceneCommandUnknown()
+{
+	for (UnkEntry* entry: entries)
+		delete entry;
+}
+
 string CutsceneCommandUnknown::GenerateSourceCode(const std::string& roomName, int baseAddress)
 {
 	string result = "";
@@ -631,6 +673,12 @@ CutsceneCommandDayTime::CutsceneCommandDayTime(const vector<uint8_t>& rawData, i
 	}
 }
 
+CutsceneCommandDayTime::~CutsceneCommandDayTime()
+{
+	for (DayTimeEntry* entry: entries)
+		delete entry;
+}
+
 string CutsceneCommandDayTime::GetCName(const std::string& prefix)
 {
 	return "CsCmdDayTime";
@@ -677,6 +725,12 @@ CutsceneCommandTextbox::CutsceneCommandTextbox(const vector<uint8_t>& rawData, i
 		entries.push_back(new TextboxEntry(rawData, rawDataIndex));
 		rawDataIndex += 12;
 	}
+}
+
+CutsceneCommandTextbox::~CutsceneCommandTextbox()
+{
+	for (TextboxEntry* entry: entries)
+		delete entry;
 }
 
 string CutsceneCommandTextbox::GetCName(const std::string& prefix)
@@ -743,6 +797,12 @@ CutsceneCommandActorAction::CutsceneCommandActorAction(const vector<uint8_t>& ra
 		entries.push_back(new ActorAction(rawData, rawDataIndex));
 		rawDataIndex += 0x30;
 	}
+}
+
+CutsceneCommandActorAction::~CutsceneCommandActorAction()
+{
+	for (ActorAction* entry: entries)
+		delete entry;
 }
 
 string CutsceneCommandActorAction::GenerateSourceCode(const std::string& roomName, int baseAddress)
@@ -857,6 +917,12 @@ CutsceneCommandSpecialAction::CutsceneCommandSpecialAction(const vector<uint8_t>
 		entries.push_back(new SpecialActionEntry(rawData, rawDataIndex));
 		rawDataIndex += 0x30;
 	}
+}
+
+CutsceneCommandSpecialAction::~CutsceneCommandSpecialAction()
+{
+	for (SpecialActionEntry* entry: entries)
+		delete entry;
 }
 
 string CutsceneCommandSpecialAction::GenerateSourceCode(const std::string& roomName, int baseAddress)

--- a/ZAPD/ZCutscene.h
+++ b/ZAPD/ZCutscene.h
@@ -78,6 +78,7 @@ public:
 	std::vector<CutsceneCameraPoint*> entries;
 
 	CutsceneCommandSetCameraPos(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	~CutsceneCommandSetCameraPos();
 	std::string GetCName(const std::string& prefix);
 	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
@@ -110,6 +111,7 @@ public:
 	std::vector<SpecialActionEntry*> entries;
 
 	CutsceneCommandSpecialAction(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	~CutsceneCommandSpecialAction();
 	std::string GetCName(const std::string& prefix);
 	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
@@ -142,6 +144,7 @@ public:
 	std::vector<MusicFadeEntry*> entries;
 
 	CutsceneCommandFadeBGM( const std::vector<uint8_t>& rawData, int rawDataIndex);
+	~CutsceneCommandFadeBGM();
 	std::string GetCName(const std::string& prefix);
 	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
@@ -171,6 +174,7 @@ public:
 	std::vector<MusicChangeEntry*> entries;
 
 	CutsceneCommandPlayBGM(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	~CutsceneCommandPlayBGM();
 	std::string GetCName(const std::string& prefix);
 	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
@@ -182,6 +186,7 @@ public:
 	std::vector<MusicChangeEntry*> entries;
 
 	CutsceneCommandStopBGM(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	~CutsceneCommandStopBGM();
 	std::string GetCName(const std::string& prefix);
 	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
@@ -211,6 +216,7 @@ public:
 	std::vector<EnvLightingEntry*> entries;
 
 	CutsceneCommandEnvLighting(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	~CutsceneCommandEnvLighting();
 	std::string GetCName(const std::string& prefix);
 	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
@@ -250,6 +256,7 @@ public:
 	std::vector<Unknown9Entry*> entries;
 
 	CutsceneCommandUnknown9(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	~CutsceneCommandUnknown9();
 	std::string GetCName(const std::string& prefix);
 	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
@@ -280,6 +287,7 @@ public:
 	std::vector<UnkEntry*> entries;
 
 	CutsceneCommandUnknown(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	~CutsceneCommandUnknown();
 	std::string GetCName(const std::string& prefix);
 	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
@@ -304,6 +312,7 @@ public:
 	std::vector<DayTimeEntry*> entries;
 
 	CutsceneCommandDayTime(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	~CutsceneCommandDayTime();
 	std::string GetCName(const std::string& prefix);
 	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
@@ -328,6 +337,7 @@ public:
 	std::vector<TextboxEntry*> entries;
 
 	CutsceneCommandTextbox(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	~CutsceneCommandTextbox();
 	std::string GetCName(const std::string& prefix);
 	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();
@@ -353,6 +363,7 @@ public:
 	std::vector<ActorAction*> entries;
 
 	CutsceneCommandActorAction(const std::vector<uint8_t>& rawData, int rawDataIndex);
+	~CutsceneCommandActorAction();
 	std::string GetCName(const std::string& prefix);
 	std::string GenerateSourceCode(const std::string& roomName, int baseAddress);
 	size_t GetCommandSize();

--- a/ZAPD/ZCutscene.h
+++ b/ZAPD/ZCutscene.h
@@ -422,7 +422,7 @@ public:
 
 	ZResourceType GetResourceType() override;
 
-	static ZCutscene* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath);
+	static std::shared_ptr<ZCutscene> ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath);
 protected:
 	int numCommands;
 	int endFrame;

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -73,6 +73,19 @@ ZDisplayList::ZDisplayList(vector<uint8_t> nRawData, int nRawDataIndex, int rawD
 	ParseRawData();
 }
 
+ZDisplayList::~ZDisplayList()
+{
+	if (scene != nullptr) {
+		delete scene;
+	}
+	for (ZDisplayList* nList: otherDLists) {
+		delete nList;
+	}
+	for (auto& tex: textures) {
+		delete tex.second;
+	}
+}
+
 void ZDisplayList::ParseRawData()
 {
 	int numInstructions = (int)rawData.size() / 8;

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -360,6 +360,7 @@ public:
 
 	ZDisplayList();
 	ZDisplayList(std::vector<uint8_t> nRawData, int rawDataIndex, int rawDataSize);
+	~ZDisplayList();
 
 	static ZDisplayList* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, int rawDataSize, std::string nRelPath);
 	static ZDisplayList* BuildFromXML(tinyxml2::XMLElement* reader, std::string inFolder, bool readFile);

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -348,7 +348,7 @@ public:
 
 	std::map<uint32_t, std::vector<Vertex>> vertices;
 	std::map<uint32_t, std::string> vtxDeclarations;
-	std::vector<ZDisplayList*> otherDLists;
+	std::vector<ZDisplayList> otherDLists;
 
 	std::map<uint32_t, ZTexture*> textures;
 	std::map<uint32_t, std::string> texDeclarations;

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -339,7 +339,7 @@ protected:
 	void Opcode_G_ENDDL(uint64_t data, int i, std::string prefix, char* line);
 public:
 	std::string sceneSegName;
-	ZRoom* scene;
+	std::shared_ptr<ZRoom> scene;
 	std::vector<uint64_t> instructions;
 
 	DListType dListType;
@@ -348,9 +348,9 @@ public:
 
 	std::map<uint32_t, std::vector<Vertex>> vertices;
 	std::map<uint32_t, std::string> vtxDeclarations;
-	std::vector<ZDisplayList> otherDLists;
+	std::vector<std::shared_ptr<ZDisplayList>> otherDLists;
 
-	std::map<uint32_t, ZTexture*> textures;
+	std::map<uint32_t, std::shared_ptr<ZTexture>> textures;
 	std::map<uint32_t, std::string> texDeclarations;
 
 	std::vector<uint32_t> references;
@@ -359,14 +359,13 @@ public:
 	std::vector<uint8_t> fileData;
 
 	ZDisplayList();
-	ZDisplayList(std::vector<uint8_t> nRawData, int rawDataIndex, int rawDataSize);
-	~ZDisplayList();
+	ZDisplayList(const std::vector<uint8_t> &nRawData, int rawDataIndex, int rawDataSize);
 
-	static ZDisplayList* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, int rawDataSize, std::string nRelPath);
-	static ZDisplayList* BuildFromXML(tinyxml2::XMLElement* reader, std::string inFolder, bool readFile);
+	static std::shared_ptr<ZDisplayList> ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, int rawDataSize, std::string nRelPath);
+	static std::shared_ptr<ZDisplayList> BuildFromXML(tinyxml2::XMLElement* reader, std::string inFolder, bool readFile);
 
 	void TextureGenCheck(std::string prefix);
-	static bool TextureGenCheck(std::vector<uint8_t> fileData, std::map<uint32_t, ZTexture*>& textures, ZRoom* scene, ZFile* parent, std::string prefix, uint32_t texWidth, uint32_t texHeight, uint32_t texAddr, uint32_t texSeg, F3DZEXTexFormats texFmt, F3DZEXTexSizes texSiz, bool texLoaded, bool texIsPalette);
+	static bool TextureGenCheck(std::vector<uint8_t> fileData, std::map<uint32_t, std::shared_ptr<ZTexture>>& textures, std::shared_ptr<ZRoom> scene, ZFile* parent, std::string prefix, uint32_t texWidth, uint32_t texHeight, uint32_t texAddr, uint32_t texSeg, F3DZEXTexFormats texFmt, F3DZEXTexSizes texSiz, bool texLoaded, bool texIsPalette);
 	static int GetDListLength(std::vector<uint8_t> rawData, int rawDataIndex, DListType dListType);
 
 	std::vector<uint8_t> GetRawData();

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -82,11 +82,11 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 	{
 		if (string(gameStr) == "MM")
 		{
-			Globals::Instance->game = ZGame::MM_RETAIL;
+			Globals::Instance.game = ZGame::MM_RETAIL;
 		}
 		else if (string(gameStr) == "SW97" || string(gameStr) == "OOTSW97")
 		{
-			Globals::Instance->game = ZGame::OOT_SW97;
+			Globals::Instance.game = ZGame::OOT_SW97;
 		}
 		else
 		{
@@ -109,7 +109,7 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 	if (segment != -1)
 	{
 		//printf("Adding Segment %i\n", segment);
-		Globals::Instance->AddSegment(segment);
+		Globals::Instance.AddSegment(segment);
 	}
 
 	string folderName = basePath + "/" + Path::GetFileNameWithoutExtension(name);
@@ -129,7 +129,7 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 		if (child->Attribute("Offset") != NULL)
 			rawDataIndex = strtol(StringHelper::Split(child->Attribute("Offset"), "0x")[1].c_str(), NULL, 16);
 
-		if (Globals::Instance->verbosity >= VERBOSITY_INFO)
+		if (Globals::Instance.verbosity >= VERBOSITY_INFO)
 			printf("%s: 0x%06X\n", child->Attribute("Name"), rawDataIndex);
 
 		if (string(child->Name()) == "Texture")
@@ -168,7 +168,7 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 			ZResource* dList = nullptr;
 
 			if (mode == ZFileMode::Extract)
-				dList = ZDisplayList::ExtractFromXML(child, rawData, rawDataIndex, ZDisplayList::GetDListLength(rawData, rawDataIndex, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX), folderName);
+				dList = ZDisplayList::ExtractFromXML(child, rawData, rawDataIndex, ZDisplayList::GetDListLength(rawData, rawDataIndex, Globals::Instance.game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX), folderName);
 			//else
 				//dList = ZDisplayList::BuildFromXML(child, folderName, mode == ZFileMode::Build);
 			else
@@ -185,11 +185,11 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 			ZRoom* room = nullptr;
 
 			if (mode == ZFileMode::Extract)
-				room = ZRoom::ExtractFromXML(child, rawData, rawDataIndex, folderName, this, Globals::Instance->lastScene);
+				room = ZRoom::ExtractFromXML(child, rawData, rawDataIndex, folderName, this, Globals::Instance.lastScene);
 
 			if (string(child->Name()) == "Scene")
 			{
-				Globals::Instance->lastScene = room;
+				Globals::Instance.lastScene = room;
 
 				if (segment == -1)
 					segment = SEGMENT_SCENE;
@@ -201,7 +201,7 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 			}
 
 			if (segment != -1)
-				Globals::Instance->AddSegment(segment);
+				Globals::Instance.AddSegment(segment);
 
 			resources.push_back(room);
 
@@ -295,7 +295,7 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 			}
 			else
 			{
-				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
+				if (Globals::Instance.verbosity >= VERBOSITY_DEBUG)
 					printf("No ZScalar created!!");
 			}
 		}
@@ -315,7 +315,7 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 			}
 			else
 			{
-				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
+				if (Globals::Instance.verbosity >= VERBOSITY_DEBUG)
 					printf("No ZVector created!!");
 			}
 		}
@@ -335,7 +335,7 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 			}
 			else
 			{
-				if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
+				if (Globals::Instance.verbosity >= VERBOSITY_DEBUG)
 					printf("No ZVtx created!!");
 			}
 		}
@@ -441,19 +441,19 @@ void ZFile::ExtractResources(string outputDir)
 	for (ZResource* res : resources)
 		res->PreGenSourceFiles();
 
-	if (Globals::Instance->genSourceFile)
+	if (Globals::Instance.genSourceFile)
 		GenerateSourceFiles(outputDir);
 
 	for (ZResource* res : resources)
 	{
-		if (Globals::Instance->verbosity >= VERBOSITY_INFO)
+		if (Globals::Instance.verbosity >= VERBOSITY_INFO)
 			printf("Saving resource %s\n", res->GetName().c_str());
 		
 		res->CalcHash(); // TEST
 		res->Save(outputPath);
 	}
 
-	if (Globals::Instance->testMode)
+	if (Globals::Instance.testMode)
 		GenerateHLIntermediette();
 }
 

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -57,8 +57,12 @@ ZFile::ZFile(ZFileMode mode, XMLElement* reader, string nBasePath, string nOutPa
 
 ZFile::~ZFile()
 {
-	for (ZResource* res : resources)
-		delete res;
+	for (ZResource* res : resources) {
+		if (res != nullptr) {
+			delete res;
+		}
+	}
+	resources.clear();
 	for (auto& decl: declarations)
 		delete decl.second;
 }
@@ -469,6 +473,10 @@ Declaration* ZFile::AddDeclaration(uint32_t address, DeclarationAlignment alignm
 
 	AddDeclarationDebugChecks(address);
 
+	if (declarations.find(address) != declarations.end()) {
+		delete declarations[address];
+	}
+
 	Declaration* decl = new Declaration(alignment, size, varType, varName, false, body);
 	declarations[address] = decl;
 	return decl;
@@ -485,6 +493,10 @@ Declaration* ZFile::AddDeclaration(uint32_t address, DeclarationAlignment alignm
 
 	AddDeclarationDebugChecks(address);
 
+	if (declarations.find(address) != declarations.end()) {
+		delete declarations[address];
+	}
+
 	declarations[address] = new Declaration(alignment, padding, size, varType, varName, false, body);
 	return declarations[address];
 }
@@ -499,6 +511,10 @@ Declaration* ZFile::AddDeclarationArray(uint32_t address, DeclarationAlignment a
 #endif
 
 	AddDeclarationDebugChecks(address);
+
+	if (declarations.find(address) != declarations.end()) {
+		delete declarations[address];
+	}
 
 	declarations[address] = new Declaration(alignment, size, varType, varName, true, arrayItemCnt, body);
 	return declarations[address];
@@ -515,6 +531,10 @@ Declaration* ZFile::AddDeclarationArray(uint32_t address, DeclarationAlignment a
 #endif
 
 	AddDeclarationDebugChecks(address);
+
+	if (declarations.find(address) != declarations.end()) {
+		delete declarations[address];
+	}
 
 	declarations[address] = new Declaration(alignment, padding, size, varType, varName, true, arrayItemCnt, body);
 	return declarations[address];
@@ -566,6 +586,11 @@ Declaration* ZFile::AddDeclarationIncludeArray(uint32_t address, std::string inc
 
 	decl->isArray = true;
 	decl->arrayItemCnt = arrayItemCnt;
+
+	// check if the address is not already being used
+	if (declarations.find(address) != declarations.end()) {
+		delete declarations[address];
+	}
 
 	declarations[address] = decl;
 	return declarations[address];

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -402,9 +402,9 @@ void ZFile::ExtractResources(string outputDir)
 		GenerateHLIntermediette();
 }
 
-void ZFile::AddResource(std::shared_ptr<ZResource>&& res)
+void ZFile::AddResource(std::shared_ptr<ZResource> res)
 {
-	resources.push_back(std::move(res));
+	resources.push_back(res);
 }
 
 Declaration* ZFile::AddDeclaration(uint32_t address, DeclarationAlignment alignment, uint32_t size, std::string varType, std::string varName, std::string body)

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -59,6 +59,8 @@ ZFile::~ZFile()
 {
 	for (ZResource* res : resources)
 		delete res;
+	for (auto& decl: declarations)
+		delete decl.second;
 }
 
 void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, bool placeholderMode)
@@ -712,16 +714,16 @@ void ZFile::GenerateSourceFiles(string outputDir)
 void ZFile::GenerateHLIntermediette()
 {
 	// This is kinda hacky but it gets the job done for now...
-	HLModelIntermediette* mdl = new HLModelIntermediette();
+	HLModelIntermediette mdl;
 
 	for (ZResource* res : resources)
 	{
 		if (typeid(ZDisplayList) == typeid(*res) || typeid(ZSkeleton) == typeid(*res))
-			res->GenerateHLIntermediette(*mdl);
+			res->GenerateHLIntermediette(mdl);
 	}
 
-	std::string test = mdl->ToOBJFile();
-	std::string test2 = mdl->ToFBXFile();
+	std::string test = mdl.ToOBJFile();
+	std::string test2 = mdl.ToFBXFile();
 }
 
 std::string ZFile::GetHeaderInclude()

--- a/ZAPD/ZFile.h
+++ b/ZAPD/ZFile.h
@@ -30,7 +30,7 @@ class ZFile
 public:
 	std::map<int32_t, Declaration*> declarations;
 	std::string defines;
-	std::vector<ZResource*> resources;
+	std::vector<std::shared_ptr<ZResource>> resources;
 	uint32_t baseAddress, rangeStart, rangeEnd;
 
 	ZFile(std::string nOutPath, std::string nName);
@@ -42,7 +42,7 @@ public:
 	void ExtractResources(std::string outputDir);
 	void BuildResources();
 	void BuildSourceFile(std::string outputDir);
-	void AddResource(ZResource* res);
+	void AddResource(std::shared_ptr<ZResource>&& res);
 
 	Declaration* AddDeclaration(uint32_t address, DeclarationAlignment alignment, uint32_t size, std::string varType, std::string varName, std::string body);
 	Declaration* AddDeclaration(uint32_t address, DeclarationAlignment alignment, DeclarationPadding padding, uint32_t size, std::string varType, std::string varName, std::string body);

--- a/ZAPD/ZFile.h
+++ b/ZAPD/ZFile.h
@@ -42,7 +42,7 @@ public:
 	void ExtractResources(std::string outputDir);
 	void BuildResources();
 	void BuildSourceFile(std::string outputDir);
-	void AddResource(std::shared_ptr<ZResource>&& res);
+	void AddResource(std::shared_ptr<ZResource> res);
 
 	Declaration* AddDeclaration(uint32_t address, DeclarationAlignment alignment, uint32_t size, std::string varType, std::string varName, std::string body);
 	Declaration* AddDeclaration(uint32_t address, DeclarationAlignment alignment, DeclarationPadding padding, uint32_t size, std::string varType, std::string varName, std::string body);

--- a/ZAPD/ZResource.cpp
+++ b/ZAPD/ZResource.cpp
@@ -14,6 +14,13 @@ ZResource::ZResource()
 	outputDeclaration = true;
 }
 
+ZResource::~ZResource()
+{
+	if (parent != nullptr) {
+		//delete parent;
+	}
+}
+
 void ZResource::ParseXML(tinyxml2::XMLElement* reader)
 {
 	if (reader->Attribute("Name") != nullptr)

--- a/ZAPD/ZResource.cpp
+++ b/ZAPD/ZResource.cpp
@@ -9,16 +9,8 @@ ZResource::ZResource()
 	outName = "";
 	relativePath = "";
 	sourceOutput = "";
-	rawData = vector<uint8_t>();
 	rawDataIndex = 0;
 	outputDeclaration = true;
-}
-
-ZResource::~ZResource()
-{
-	if (parent != nullptr) {
-		//delete parent;
-	}
 }
 
 void ZResource::ParseXML(tinyxml2::XMLElement* reader)

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <stdint.h>
 #include "tinyxml2.h"
+#include <memory>
 
 #define SEGMENT_SCENE 2
 #define SEGMENT_ROOM 3

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -50,7 +50,6 @@ public:
 	bool outputDeclaration;
 
 	ZResource();
-	~ZResource();
 	virtual void ParseXML(tinyxml2::XMLElement* reader);
 	virtual void Save(const std::string& outFolder);
 	virtual void PreGenSourceFiles();

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -49,6 +49,7 @@ public:
 	bool outputDeclaration;
 
 	ZResource();
+	~ZResource();
 	virtual void ParseXML(tinyxml2::XMLElement* reader);
 	virtual void Save(const std::string& outFolder);
 	virtual void PreGenSourceFiles();

--- a/ZAPD/ZRoom/Commands/SetActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetActorList.cpp
@@ -67,13 +67,13 @@ string SetActorList::GenerateSourceCodePass2(string roomName, int baseAddress)
 		uint16_t actorNum = entry->actorNum;
 
 		// SW97 Actor 0x22 was removed, so we want to not output a working actor.
-		if (actorNum == 0x22 && Globals::Instance->game == ZGame::OOT_SW97)
+		if (actorNum == 0x22 && Globals::Instance.game == ZGame::OOT_SW97)
 			declaration += StringHelper::Sprintf("\t//{ %s, %i, %i, %i, %i, %i, %i, 0x%04X }, //0x%06X", /*StringHelper::Sprintf("SW_REMOVED_0x%04X", actorNum).c_str()*/ "ACTOR_DUNGEON_KEEP", entry->posX, entry->posY, entry->posZ, entry->rotX, entry->rotY, entry->rotZ, (uint16_t)entry->initVar, segmentOffset + (index * 16));
 		else
 		{
 			// SW97 Actor 0x23 and above are shifted up by one because 0x22 was removed between SW97 and retail.
 			// We need to shift down by one
-			if (Globals::Instance->game == ZGame::OOT_SW97 && actorNum >= 0x23)
+			if (Globals::Instance.game == ZGame::OOT_SW97 && actorNum >= 0x23)
 				actorNum--;
 
 			if (actorNum < sizeof(ActorList) / sizeof(ActorList[0]))
@@ -105,7 +105,7 @@ int SetActorList::GetActorListArraySize()
 
 	// Doing an else-if here so we only do the loop when the game is SW97.
 	// Actor 0x22 is removed from SW97, so we need to ensure that we don't increment the actor count for it.
-	if (Globals::Instance->game == ZGame::OOT_SW97)
+	if (Globals::Instance.game == ZGame::OOT_SW97)
 	{
 		actorCount = 0;
 

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -295,8 +295,8 @@ void SetMesh::GenDListDeclarations(std::vector<uint8_t> rawData, ZDisplayList* d
 
 	//zRoom->parent->AddDeclarationArray(dList->GetRawDataIndex(), DeclarationAlignment::None, dList->GetRawDataSize(), "static Gfx", srcVarName, dList->GetRawDataSize() / 8, sourceOutput);
 
-	for (ZDisplayList& otherDList : dList->otherDLists)
-		GenDListDeclarations(rawData, &otherDList);
+	for (auto& otherDList : dList->otherDLists)
+		GenDListDeclarations(rawData, otherDList.get());
 
 	for (pair<uint32_t, string> vtxEntry : dList->vtxDeclarations)
 	{
@@ -328,8 +328,8 @@ std::string SetMesh::GenDListExterns(ZDisplayList* dList)
 	else
 		sourceOutput += StringHelper::Sprintf("extern Gfx dlist0x%06X[];\n", dList->GetRawDataIndex());
 
-	for (ZDisplayList& otherDList : dList->otherDLists)
-		sourceOutput += GenDListExterns(&otherDList);
+	for (auto& otherDList : dList->otherDLists)
+		sourceOutput += GenDListExterns(otherDList.get());
 
 	for (pair<uint32_t, string> texEntry : dList->texDeclarations)
 		sourceOutput += StringHelper::Sprintf("extern u64 %sTex_%06X[];\n", zRoom->GetName().c_str(), texEntry.first);

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -61,7 +61,7 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 
 			if (entry->opaqueDListAddr != 0)
 			{
-				entry->opaqueDList = new ZDisplayList(rawData, entry->opaqueDListAddr, ZDisplayList::GetDListLength(rawData, entry->opaqueDListAddr, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
+				entry->opaqueDList = new ZDisplayList(rawData, entry->opaqueDListAddr, ZDisplayList::GetDListLength(rawData, entry->opaqueDListAddr, Globals::Instance.game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
 				entry->opaqueDList->scene = zRoom->scene;
 				entry->opaqueDList->parent = zRoom->parent;
 				GenDListDeclarations(rawData, entry->opaqueDList);
@@ -69,7 +69,7 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 
 			if (entry->translucentDListAddr != 0)
 			{
-				entry->translucentDList = new ZDisplayList(rawData, entry->translucentDListAddr, ZDisplayList::GetDListLength(rawData, entry->translucentDListAddr, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
+				entry->translucentDList = new ZDisplayList(rawData, entry->translucentDListAddr, ZDisplayList::GetDListLength(rawData, entry->translucentDListAddr, Globals::Instance.game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
 				entry->translucentDList->scene = zRoom->scene;
 				entry->translucentDList->parent = zRoom->parent;
 				GenDListDeclarations(rawData, entry->translucentDList);
@@ -174,7 +174,7 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 		}
 		else // UH OH
 		{
-			if (Globals::Instance->verbosity >= VERBOSITY_INFO)
+			if (Globals::Instance.verbosity >= VERBOSITY_INFO)
 				printf("WARNING: MeshHeader FMT %i not implemented!\n", fmt);
 		}
 
@@ -211,7 +211,7 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 
 			if (entry->opaqueDListAddr != 0)
 			{
-				entry->opaqueDList = new ZDisplayList(rawData, entry->opaqueDListAddr, ZDisplayList::GetDListLength(rawData, entry->opaqueDListAddr, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
+				entry->opaqueDList = new ZDisplayList(rawData, entry->opaqueDListAddr, ZDisplayList::GetDListLength(rawData, entry->opaqueDListAddr, Globals::Instance.game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
 				entry->opaqueDList->scene = zRoom->scene;
 				entry->opaqueDList->parent = zRoom->parent;
 				GenDListDeclarations(rawData, entry->opaqueDList); // HOTSPOT
@@ -219,7 +219,7 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 
 			if (entry->translucentDListAddr != 0)
 			{
-				entry->translucentDList = new ZDisplayList(rawData, entry->translucentDListAddr, ZDisplayList::GetDListLength(rawData, entry->translucentDListAddr, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
+				entry->translucentDList = new ZDisplayList(rawData, entry->translucentDListAddr, ZDisplayList::GetDListLength(rawData, entry->translucentDListAddr, Globals::Instance.game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
 				entry->translucentDList->scene = zRoom->scene;
 				entry->translucentDList->parent = zRoom->parent;
 				GenDListDeclarations(rawData, entry->translucentDList); // HOTSPOT
@@ -285,7 +285,7 @@ void SetMesh::GenDListDeclarations(std::vector<uint8_t> rawData, ZDisplayList* d
 {
 	string srcVarName = "";
 
-	//if (Globals::Instance->includeFilePrefix)
+	//if (Globals::Instance.includeFilePrefix)
 		srcVarName = StringHelper::Sprintf("%s%s", zRoom->GetName().c_str(), dList->GetName().c_str());
 	//else
 		//srcVarName = StringHelper::Sprintf("%s", dList->GetName().c_str());
@@ -295,8 +295,8 @@ void SetMesh::GenDListDeclarations(std::vector<uint8_t> rawData, ZDisplayList* d
 
 	//zRoom->parent->AddDeclarationArray(dList->GetRawDataIndex(), DeclarationAlignment::None, dList->GetRawDataSize(), "static Gfx", srcVarName, dList->GetRawDataSize() / 8, sourceOutput);
 
-	for (ZDisplayList* otherDList : dList->otherDLists)
-		GenDListDeclarations(rawData, otherDList);
+	for (ZDisplayList& otherDList : dList->otherDLists)
+		GenDListDeclarations(rawData, &otherDList);
 
 	for (pair<uint32_t, string> vtxEntry : dList->vtxDeclarations)
 	{
@@ -308,13 +308,13 @@ void SetMesh::GenDListDeclarations(std::vector<uint8_t> rawData, ZDisplayList* d
 	{
 		zRoom->textures[texEntry.first] = dList->textures[texEntry.first];
 
-		if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
-			printf("SAVING IMAGE TO %s\n", Globals::Instance->outputPath.c_str());
+		if (Globals::Instance.verbosity >= VERBOSITY_DEBUG)
+			printf("SAVING IMAGE TO %s\n", Globals::Instance.outputPath.c_str());
 		
-		zRoom->textures[texEntry.first]->Save(Globals::Instance->outputPath);
+		zRoom->textures[texEntry.first]->Save(Globals::Instance.outputPath);
 
 		zRoom->parent->AddDeclarationIncludeArray(texEntry.first, StringHelper::Sprintf("%s/%s.%s.inc.c",
-			Globals::Instance->outputPath.c_str(), Path::GetFileNameWithoutExtension(zRoom->textures[texEntry.first]->GetName()).c_str(), zRoom->textures[texEntry.first]->GetExternalExtension().c_str()), 
+			Globals::Instance.outputPath.c_str(), Path::GetFileNameWithoutExtension(zRoom->textures[texEntry.first]->GetName()).c_str(), zRoom->textures[texEntry.first]->GetExternalExtension().c_str()), 
 			zRoom->textures[texEntry.first]->GetRawDataSize(), "u64", StringHelper::Sprintf("%s", zRoom->textures[texEntry.first]->GetName().c_str(), texEntry.first), 0);
 	}
 }
@@ -323,13 +323,13 @@ std::string SetMesh::GenDListExterns(ZDisplayList* dList)
 {
 	string sourceOutput = "";
 	
-	if (Globals::Instance->includeFilePrefix)
+	if (Globals::Instance.includeFilePrefix)
 		sourceOutput += StringHelper::Sprintf("extern Gfx %sDlist0x%06X[];\n", zRoom->GetName().c_str(), dList->GetRawDataIndex());
 	else
 		sourceOutput += StringHelper::Sprintf("extern Gfx dlist0x%06X[];\n", dList->GetRawDataIndex());
 
-	for (ZDisplayList* otherDList : dList->otherDLists)
-		sourceOutput += GenDListExterns(otherDList);
+	for (ZDisplayList& otherDList : dList->otherDLists)
+		sourceOutput += GenDListExterns(&otherDList);
 
 	for (pair<uint32_t, string> texEntry : dList->texDeclarations)
 		sourceOutput += StringHelper::Sprintf("extern u64 %sTex_%06X[];\n", zRoom->GetName().c_str(), texEntry.first);

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -8,6 +8,24 @@
 
 using namespace std;
 
+MeshEntry0::MeshEntry0()
+{
+	opaqueDList = nullptr;
+	translucentDList = nullptr;
+}
+
+MeshEntry0::~MeshEntry0()
+{
+	if (opaqueDList != nullptr) delete opaqueDList;
+	if (translucentDList != nullptr) delete translucentDList;
+}
+
+MeshHeader0::~MeshHeader0()
+{
+	for (MeshEntry0* entry: entries)
+		delete entry;
+}
+
 SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, int segAddressOffset) : ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
 	data = rawData[rawDataIndex + 1];
@@ -20,7 +38,7 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 	{
 		MeshHeader0* meshHeader0 = new MeshHeader0();
 		meshHeader0->headerType = 0;
-		meshHeader0->entries = vector<MeshEntry0*>();
+		//meshHeader0->entries = vector<MeshEntry0*>();
 
 		meshHeader0->dListStart = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, segmentOffset + 4));
 		meshHeader0->dListEnd = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, segmentOffset + 8));

--- a/ZAPD/ZRoom/Commands/SetMesh.h
+++ b/ZAPD/ZRoom/Commands/SetMesh.h
@@ -17,6 +17,9 @@ public:
 
 	ZDisplayList* opaqueDList;
 	ZDisplayList* translucentDList;
+
+	MeshEntry0();
+	~MeshEntry0();
 };
 
 class MeshHeader0 : public MeshHeaderBase
@@ -25,6 +28,8 @@ public:
 	std::vector<MeshEntry0*> entries;
 	uint32_t dListStart;
 	uint32_t dListEnd;
+
+	~MeshHeader0();
 };
 
 class MeshHeader1Base : public MeshHeaderBase

--- a/ZAPD/ZRoom/Commands/SetRoomList.cpp
+++ b/ZAPD/ZRoom/Commands/SetRoomList.cpp
@@ -12,23 +12,14 @@ SetRoomList::SetRoomList(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDat
 	int numRooms = rawData[rawDataIndex + 1];
 	segmentOffset = BitConverter::ToInt32BE(rawData, rawDataIndex + 4) & 0x00FFFFFF;
 
-	rooms = vector<RoomEntry*>();
-
 	int32_t currentPtr = segmentOffset;
 
 	for (int i = 0; i < numRooms; i++)
 	{
-		RoomEntry* entry = new RoomEntry(rawData, currentPtr);
-		rooms.push_back(entry);
+		rooms.emplace_back(rawData, currentPtr);
 
 		currentPtr += 8;
 	}
-}
-
-SetRoomList::~SetRoomList()
-{
-	for (RoomEntry* entry : rooms)
-		delete entry;
 }
 
 string SetRoomList::GenerateSourceCodePass1(string roomName, int baseAddress)
@@ -60,11 +51,11 @@ std::string SetRoomList::PreGenSourceFiles()
 {
 	string declaration = "";
 
-	for (ZFile* file : Globals::Instance.files)
+	for (auto& file : Globals::Instance.files)
 	{
-		for (ZResource* res : file->resources)
+		for (auto& res : file->resources)
 		{
-			if (res->GetResourceType() == ZResourceType::Room && res != zRoom)
+			if (res->GetResourceType() == ZResourceType::Room && res.get() != zRoom)
 			{
 				string roomName = res->GetName();
 				declaration += StringHelper::Sprintf("\t{ (u32)_%sSegmentRomStart, (u32)_%sSegmentRomEnd },\n", roomName.c_str(), roomName.c_str());

--- a/ZAPD/ZRoom/Commands/SetRoomList.cpp
+++ b/ZAPD/ZRoom/Commands/SetRoomList.cpp
@@ -60,7 +60,7 @@ std::string SetRoomList::PreGenSourceFiles()
 {
 	string declaration = "";
 
-	for (ZFile* file : Globals::Instance->files)
+	for (ZFile* file : Globals::Instance.files)
 	{
 		for (ZResource* res : file->resources)
 		{

--- a/ZAPD/ZRoom/Commands/SetRoomList.h
+++ b/ZAPD/ZRoom/Commands/SetRoomList.h
@@ -16,7 +16,6 @@ class SetRoomList : public ZRoomCommand
 {
 public:
 	SetRoomList(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex);
-	~SetRoomList();
 
 	virtual std::string GenerateSourceCodePass1(std::string roomName, int baseAddress);
 	virtual std::string GenerateSourceCodePass2(std::string roomName, int baseAddress);
@@ -27,6 +26,6 @@ public:
 	virtual std::string Save();
 
 private:
-	std::vector<RoomEntry*> rooms;
+	std::vector<RoomEntry> rooms;
 	uint32_t segmentOffset;
 };

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -113,15 +113,14 @@ std::shared_ptr<ZRoom> ZRoom::ExtractFromXML(XMLElement* reader, vector<uint8_t>
 			string sizeStr = child->Attribute("Size");
 			int size = strtol(StringHelper::Split(sizeStr, "0x")[1].c_str(), NULL, 16);
 
-			ZBlob* blob = new ZBlob(room->rawData, address, size, StringHelper::Sprintf("%sBlob0x%06X", room->name.c_str(), address));
+			ZBlob blob(room->rawData, address, size, StringHelper::Sprintf("%sBlob0x%06X", room->name.c_str(), address));
 			
 			if (child->Attribute("Name") != NULL)
 				name = string(child->Attribute("Name"));
 			else
-				name = StringHelper::Sprintf("%s_%s", room->name.c_str(), blob->GetName().c_str());
+				name = StringHelper::Sprintf("%s_%s", room->name.c_str(), blob.GetName().c_str());
 			
-			room->parent->AddDeclarationArray(address, DeclarationAlignment::None, blob->GetRawDataSize(), "u8", name, 0, blob->GetSourceOutputCode(room->name));
-			delete blob;
+			room->parent->AddDeclarationArray(address, DeclarationAlignment::None, blob.GetRawDataSize(), "u8", name, 0, blob.GetSourceOutputCode(room->name));
 		}
 		else if (string(child->Name()) == "CutsceneHint")
 		{
@@ -134,16 +133,15 @@ std::shared_ptr<ZRoom> ZRoom::ExtractFromXML(XMLElement* reader, vector<uint8_t>
 			string addressStr = child->Attribute("Offset");
 			int address = strtol(StringHelper::Split(addressStr, "0x")[1].c_str(), NULL, 16);
 
-			ZCutscene* cutscene = new ZCutscene(room->rawData, address, 9999);
+			ZCutscene cutscene(room->rawData, address, 9999);
 
 			if (child->Attribute("Name") != NULL)
 				name = string(child->Attribute("Name"));
 			else
-				name = StringHelper::Sprintf("%sCutsceneData0x%06X", room->name.c_str(), cutscene->segmentOffset);
+				name = StringHelper::Sprintf("%sCutsceneData0x%06X", room->name.c_str(), cutscene.segmentOffset);
 
-			room->parent->AddDeclarationArray(address, DeclarationAlignment::None, DeclarationPadding::Pad16, cutscene->GetRawDataSize(), "s32",
-				name, 0, cutscene->GetSourceOutputCode(room->name));
-			delete cutscene;
+			room->parent->AddDeclarationArray(address, DeclarationAlignment::None, DeclarationPadding::Pad16, cutscene.GetRawDataSize(), "s32",
+				name, 0, cutscene.GetSourceOutputCode(room->name));
 		}
 		else if (string(child->Name()) == "AltHeaderHint")
 		{

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -50,8 +50,15 @@ ZRoom::ZRoom() : ZResource()
 
 ZRoom::~ZRoom()
 {
-	for (ZRoomCommand* cmd : commands)
+	if (scene != nullptr) {
+		delete scene;
+	}
+	for (ZRoomCommand* cmd : commands) {
 		delete cmd;
+	}
+	for (auto& tex: textures) {
+		delete tex.second;
+	}
 }
 
 ZRoom* ZRoom::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int rawDataIndex, string nRelPath, ZFile* nParent, ZRoom* nScene)
@@ -99,15 +106,14 @@ ZRoom* ZRoom::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int r
 			string addressStr = child->Attribute("Offset");
 			int address = strtol(StringHelper::Split(addressStr, "0x")[1].c_str(), NULL, 16);
 
-			ZDisplayList* dList = new ZDisplayList(room->rawData, address, ZDisplayList::GetDListLength(room->rawData, address, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
+			ZDisplayList dList(room->rawData, address, ZDisplayList::GetDListLength(room->rawData, address, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
 
 			if (child->Attribute("Name") != NULL)
 				name = string(child->Attribute("Name"));
 			else
 				name = room->name;
 
-			dList->GetSourceOutputCode(name);
-			delete dList;
+			dList.GetSourceOutputCode(name);
 		}
 		else if (string(child->Name()) == "BlobHint")
 		{

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -76,11 +76,11 @@ ZRoom* ZRoom::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int r
 	if (string(reader->Name()) == "Scene")
 	{
 		room->scene = room;
-		Globals::Instance->lastScene = room;
+		Globals::Instance.lastScene = room;
 	}
 
-	Globals::Instance->AddSegment(SEGMENT_ROOM);
-	Globals::Instance->AddSegment(SEGMENT_SCENE);
+	Globals::Instance.AddSegment(SEGMENT_ROOM);
+	Globals::Instance.AddSegment(SEGMENT_SCENE);
 
 	//GenDefinitions();
 
@@ -106,7 +106,7 @@ ZRoom* ZRoom::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int r
 			string addressStr = child->Attribute("Offset");
 			int address = strtol(StringHelper::Split(addressStr, "0x")[1].c_str(), NULL, 16);
 
-			ZDisplayList dList(room->rawData, address, ZDisplayList::GetDListLength(room->rawData, address, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
+			ZDisplayList dList(room->rawData, address, ZDisplayList::GetDListLength(room->rawData, address, Globals::Instance.game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
 
 			if (child->Attribute("Name") != NULL)
 				name = string(child->Attribute("Name"));
@@ -281,7 +281,7 @@ void ZRoom::ParseCommands(std::vector<ZRoomCommand*>& commandList, CommandSet co
 		auto end = chrono::steady_clock::now();
 		auto diff = chrono::duration_cast<chrono::milliseconds>(end - start).count();
 
-		if (Globals::Instance->profile)
+		if (Globals::Instance.profile)
 		{
 			if (diff > 50)
 				printf("OP: %s, TIME: %lims\n", cmd->GetCommandCName().c_str(), diff);
@@ -507,13 +507,13 @@ string ZRoom::GetSourceOutputCode(const std::string& prefix)
 
 		declaration += item.second->GetSourceOutputCode(prefix);
 
-		if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
-			printf("SAVING IMAGE TO %s\n", Globals::Instance->outputPath.c_str());
+		if (Globals::Instance.verbosity >= VERBOSITY_DEBUG)
+			printf("SAVING IMAGE TO %s\n", Globals::Instance.outputPath.c_str());
 
-		item.second->Save(Globals::Instance->outputPath);
+		item.second->Save(Globals::Instance.outputPath);
 
 		parent->AddDeclarationIncludeArray(item.first, StringHelper::Sprintf("%s/%s.%s.inc.c",
-			Globals::Instance->outputPath.c_str(), Path::GetFileNameWithoutExtension(item.second->GetName()).c_str(), item.second->GetExternalExtension().c_str()), item.second->GetRawDataSize(),
+			Globals::Instance.outputPath.c_str(), Path::GetFileNameWithoutExtension(item.second->GetName()).c_str(), item.second->GetExternalExtension().c_str()), item.second->GetRawDataSize(),
 			"u64", StringHelper::Sprintf("%sTex_%06X", prefix.c_str(), item.first), 0);
 	}
 

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -45,7 +45,7 @@ ZRoom::ZRoom() : ZResource()
 	scene = nullptr;
 }
 
-std::shared_ptr<ZRoom> ZRoom::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int rawDataIndex, string nRelPath, ZFile* nParent, std::shared_ptr<ZRoom>& nScene)
+std::shared_ptr<ZRoom> ZRoom::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int rawDataIndex, string nRelPath, ZFile* nParent, std::shared_ptr<ZRoom> nScene)
 {
 	std::shared_ptr<ZRoom> room = std::make_shared<ZRoom>();
 

--- a/ZAPD/ZRoom/ZRoom.h
+++ b/ZAPD/ZRoom/ZRoom.h
@@ -20,7 +20,6 @@ protected:
 	void SyotesRoomHack();
 
 	ZRoom();
-	~ZRoom();
 
 public:
 	ZRoom* scene;
@@ -28,6 +27,8 @@ public:
 	std::vector<CommandSet> commandSets;
 
 	std::string extDefines;
+
+	~ZRoom();
 
 	static ZRoom* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* nParent, ZRoom* nScene);
 	void ParseCommands(std::vector<ZRoomCommand*>& commandList, CommandSet commandSet);

--- a/ZAPD/ZRoom/ZRoom.h
+++ b/ZAPD/ZRoom/ZRoom.h
@@ -28,7 +28,7 @@ public:
 
 	ZRoom();
 
-	static std::shared_ptr<ZRoom> ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* nParent, std::shared_ptr<ZRoom>& nScene);
+	static std::shared_ptr<ZRoom> ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* nParent, std::shared_ptr<ZRoom> nScene);
 	void ParseCommands(std::vector<std::shared_ptr<ZRoomCommand>>& commandList, CommandSet commandSet);
 	size_t GetDeclarationSizeFromNeighbor(int declarationAddress);
 	size_t GetCommandSizeFromNeighbor(ZRoomCommand* cmd);

--- a/ZAPD/ZRoom/ZRoom.h
+++ b/ZAPD/ZRoom/ZRoom.h
@@ -12,29 +12,27 @@
 class ZRoom : public ZResource
 {
 protected:
-	std::vector<ZRoomCommand*> commands;
+	std::vector<std::shared_ptr<ZRoomCommand>> commands;
 
 	std::string GetSourceOutputHeader(const std::string& prefix);
 	std::string GetSourceOutputCode(const std::string& prefix);
 	void ProcessCommandSets();
 	void SyotesRoomHack();
 
-	ZRoom();
-
 public:
-	ZRoom* scene;
-	std::map<int32_t, ZTexture*> textures;
+	std::shared_ptr<ZRoom> scene;
+	std::map<int32_t, std::shared_ptr<ZTexture>> textures;
 	std::vector<CommandSet> commandSets;
 
 	std::string extDefines;
 
-	~ZRoom();
+	ZRoom();
 
-	static ZRoom* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* nParent, ZRoom* nScene);
-	void ParseCommands(std::vector<ZRoomCommand*>& commandList, CommandSet commandSet);
+	static std::shared_ptr<ZRoom> ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* nParent, std::shared_ptr<ZRoom>& nScene);
+	void ParseCommands(std::vector<std::shared_ptr<ZRoomCommand>>& commandList, CommandSet commandSet);
 	size_t GetDeclarationSizeFromNeighbor(int declarationAddress);
 	size_t GetCommandSizeFromNeighbor(ZRoomCommand* cmd);
-	ZRoomCommand* FindCommandOfType(RoomCommand cmdType);
+	std::shared_ptr<ZRoomCommand> FindCommandOfType(RoomCommand cmdType);
 	std::vector<uint8_t> GetRawData();
 	int GetRawDataSize();
 	virtual ZResourceType GetResourceType();

--- a/ZAPD/ZScalar.cpp
+++ b/ZAPD/ZScalar.cpp
@@ -5,9 +5,9 @@
 #include "File.h"
 #include "Globals.h"
 
-ZScalar* ZScalar::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath)
+std::shared_ptr<ZScalar> ZScalar::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath)
 {
-	ZScalar* scalar = new ZScalar();
+	std::shared_ptr<ZScalar> scalar = std::make_shared<ZScalar>();
 	scalar->rawData = nRawData;
 	scalar->rawDataIndex = rawDataIndex;
 	scalar->ParseXML(reader);

--- a/ZAPD/ZScalar.h
+++ b/ZAPD/ZScalar.h
@@ -52,7 +52,7 @@ public:
 	bool DoesSupportArray() override;
 	void ParseRawData() override;
 
-	static ZScalar* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath);
+	static std::shared_ptr<ZScalar> ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath);
 	static int MapTypeToSize(const ZScalarType scalarType);
 	static ZScalarType MapOutputTypeToScalarType(const std::string& type);
 	static std::string MapScalarTypeToOutputType(const ZScalarType scalarType);

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -187,7 +187,7 @@ std::string ZSkeleton::GetSourceOutputCode(const std::string& prefix)
 
 			if (limb->dListPtr != 0 && parent->GetDeclaration(limb->dListPtr) == nullptr)
 			{
-				ZDisplayList dList(rawData, limb->dListPtr, ZDisplayList::GetDListLength(rawData, limb->dListPtr, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
+				ZDisplayList dList(rawData, limb->dListPtr, ZDisplayList::GetDListLength(rawData, limb->dListPtr, Globals::Instance.game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
 				dList.parent = parent;
 				dList.SetName(StringHelper::Sprintf("%sLimbDL_%06X", defaultPrefix.c_str(), limb->dListPtr));
 				dList.GetSourceOutputCode(defaultPrefix);
@@ -204,7 +204,7 @@ std::string ZSkeleton::GetSourceOutputCode(const std::string& prefix)
 
 				if (limbLOD->farDListPtr != 0 && parent->GetDeclaration(limbLOD->farDListPtr) == nullptr)
 				{
-					ZDisplayList dList(rawData, limbLOD->farDListPtr, ZDisplayList::GetDListLength(rawData, limbLOD->farDListPtr, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
+					ZDisplayList dList(rawData, limbLOD->farDListPtr, ZDisplayList::GetDListLength(rawData, limbLOD->farDListPtr, Globals::Instance.game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
 					dList.parent = parent;
 					dList.SetName(StringHelper::Sprintf("%s_farLimbDlist_%06X", defaultPrefix.c_str(), limbLOD->farDListPtr));
 					dList.GetSourceOutputCode(defaultPrefix);

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -74,7 +74,7 @@ string ZLimbStandard::GetSourceOutputCode(const std::string& prefix)
 	string entryStr = StringHelper::Sprintf("{ %i, %i, %i }, %i, %i, %s",
 		transX, transY, transZ, childIndex, siblingIndex, dListStr.c_str());
 
-	Declaration* decl = parent->GetDeclaration(address);
+	auto decl = parent->GetDeclaration(address);
 	decl->text = entryStr;
 
 	return "";

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -20,6 +20,13 @@ ZLimbStandard::ZLimbStandard()
 	children = vector<ZLimbStandard*>();
 }
 
+ZLimbStandard::~ZLimbStandard()
+{
+	for (ZLimbStandard* limb: children) {
+		delete limb;
+	}
+}
+
 ZLimbStandard* ZLimbStandard::FromXML(XMLElement* reader, vector<uint8_t> nRawData, int rawDataIndex, string nRelPath, ZFile* parent)
 {
 	ZLimbType limbType = ZLimbType::Standard;
@@ -81,9 +88,18 @@ int ZLimbStandard::GetRawDataSize()
 ZSkeleton::ZSkeleton() : ZResource()
 {
 	type = ZSkeletonType::Normal;
-	limbs = vector<ZLimbStandard*>();
 	rootLimb = nullptr;
 	dListCount = 0;
+}
+
+ZSkeleton::~ZSkeleton()
+{
+	for (ZLimbStandard* limb: limbs) {
+		delete limb;
+	}
+	if (rootLimb != nullptr) {
+		delete rootLimb;
+	}
 }
 
 void ZSkeleton::GenerateHLIntermediette(HLFileIntermediette& hlFile)
@@ -171,10 +187,10 @@ std::string ZSkeleton::GetSourceOutputCode(const std::string& prefix)
 
 			if (limb->dListPtr != 0 && parent->GetDeclaration(limb->dListPtr) == nullptr)
 			{
-				ZDisplayList* dList = new ZDisplayList(rawData, limb->dListPtr, ZDisplayList::GetDListLength(rawData, limb->dListPtr, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
-				dList->parent = parent;
-				dList->SetName(StringHelper::Sprintf("%sLimbDL_%06X", defaultPrefix.c_str(), limb->dListPtr));
-				dList->GetSourceOutputCode(defaultPrefix);
+				ZDisplayList dList(rawData, limb->dListPtr, ZDisplayList::GetDListLength(rawData, limb->dListPtr, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
+				dList.parent = parent;
+				dList.SetName(StringHelper::Sprintf("%sLimbDL_%06X", defaultPrefix.c_str(), limb->dListPtr));
+				dList.GetSourceOutputCode(defaultPrefix);
 			}
 
 			string entryStr = "";
@@ -188,10 +204,10 @@ std::string ZSkeleton::GetSourceOutputCode(const std::string& prefix)
 
 				if (limbLOD->farDListPtr != 0 && parent->GetDeclaration(limbLOD->farDListPtr) == nullptr)
 				{
-					ZDisplayList* dList = new ZDisplayList(rawData, limbLOD->farDListPtr, ZDisplayList::GetDListLength(rawData, limbLOD->farDListPtr, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
-					dList->parent = parent;
-					dList->SetName(StringHelper::Sprintf("%s_farLimbDlist_%06X", defaultPrefix.c_str(), limbLOD->farDListPtr));
-					dList->GetSourceOutputCode(defaultPrefix);
+					ZDisplayList dList(rawData, limbLOD->farDListPtr, ZDisplayList::GetDListLength(rawData, limbLOD->farDListPtr, Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX));
+					dList.parent = parent;
+					dList.SetName(StringHelper::Sprintf("%s_farLimbDlist_%06X", defaultPrefix.c_str(), limbLOD->farDListPtr));
+					dList.GetSourceOutputCode(defaultPrefix);
 				}
 
 				entryType = "LodLimb";

--- a/ZAPD/ZSkeleton.h
+++ b/ZAPD/ZSkeleton.h
@@ -23,6 +23,7 @@ struct ZLimbStandard : public ZResource
 	std::vector<ZLimbStandard*> children;
 
 	ZLimbStandard();
+	~ZLimbStandard();
 	static ZLimbStandard* FromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* parent);
 	static ZLimbStandard* FromRawData(std::vector<uint8_t> nRawData, int rawDataIndex);
 	std::string GetSourceOutputCode(const std::string& prefix) override;
@@ -56,6 +57,7 @@ public:
 	uint8_t dListCount; // FLEX SKELETON ONLY
 
 	ZSkeleton();
+	~ZSkeleton();
 	virtual void GenerateHLIntermediette(HLFileIntermediette& hlFile);
 	static ZSkeleton* FromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* nParent);
 	void Save(const std::string& outFolder) override;

--- a/ZAPD/ZSkeleton.h
+++ b/ZAPD/ZSkeleton.h
@@ -24,8 +24,8 @@ struct ZLimbStandard : public ZResource
 
 	ZLimbStandard();
 	~ZLimbStandard();
-	static ZLimbStandard* FromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* parent);
-	static ZLimbStandard* FromRawData(std::vector<uint8_t> nRawData, int rawDataIndex);
+	static std::shared_ptr<ZLimbStandard> FromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* parent);
+	static std::shared_ptr<ZLimbStandard> FromRawData(std::vector<uint8_t> nRawData, int rawDataIndex);
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 	int GetRawDataSize() override;
 };
@@ -35,8 +35,8 @@ struct ZLimbLOD : ZLimbStandard
 	uint32_t farDListPtr;
 
 	ZLimbLOD();
-	//static ZLimbLOD* FromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* parent);
-	static ZLimbLOD* FromRawData(std::vector<uint8_t> nRawData, int rawDataIndex);
+	//static std::shared_ptr<ZLimbLOD> FromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* parent);
+	static std::shared_ptr<ZLimbLOD> FromRawData(std::vector<uint8_t> nRawData, int rawDataIndex);
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 	int GetRawDataSize() override;
 };
@@ -52,14 +52,14 @@ class ZSkeleton : public ZResource
 {
 public:
 	ZSkeletonType type;
-	std::vector<ZLimbStandard*> limbs;
+	std::vector<std::shared_ptr<ZLimbStandard>> limbs;
 	ZLimbStandard* rootLimb;
 	uint8_t dListCount; // FLEX SKELETON ONLY
 
 	ZSkeleton();
 	~ZSkeleton();
 	virtual void GenerateHLIntermediette(HLFileIntermediette& hlFile);
-	static ZSkeleton* FromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* nParent);
+	static std::shared_ptr<ZSkeleton> FromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath, ZFile* nParent);
 	void Save(const std::string& outFolder) override;
 	ZResourceType GetResourceType() override;
 

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -54,9 +54,9 @@ ZTexture::~ZTexture()
 }
 
 // EXTRACT MODE
-ZTexture* ZTexture::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int nRawDataIndex, string nRelPath)
+std::shared_ptr<ZTexture> ZTexture::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData, int nRawDataIndex, string nRelPath)
 {
-	ZTexture* tex = new ZTexture();
+	auto tex = std::make_shared<ZTexture>();
 
 	tex->ParseXML(reader);
 	tex->rawDataIndex = nRawDataIndex;
@@ -70,9 +70,9 @@ ZTexture* ZTexture::ExtractFromXML(XMLElement* reader, vector<uint8_t> nRawData,
 	return tex;
 }
 
-ZTexture* ZTexture::FromBinary(TextureType nType, std::vector<uint8_t> nRawData, int nRawDataIndex, std::string nName, int nWidth, int nHeight)
+std::shared_ptr<ZTexture> ZTexture::FromBinary(TextureType nType, std::vector<uint8_t> nRawData, int nRawDataIndex, std::string nName, int nWidth, int nHeight)
 {
-	ZTexture* tex = new ZTexture();
+	auto tex = std::make_shared<ZTexture>();
 
 	tex->width = nWidth;
 	tex->height = nHeight;
@@ -91,9 +91,9 @@ ZTexture* ZTexture::FromBinary(TextureType nType, std::vector<uint8_t> nRawData,
 }
 
 // BUILD MODE
-ZTexture* ZTexture::BuildFromXML(XMLElement* reader, string inFolder, bool readFile)
+std::shared_ptr<ZTexture> ZTexture::BuildFromXML(XMLElement* reader, string inFolder, bool readFile)
 {
-	ZTexture* tex = new ZTexture();
+	auto tex = std::make_shared<ZTexture>();
 
 	tex->ParseXML(reader);
 
@@ -103,10 +103,10 @@ ZTexture* ZTexture::BuildFromXML(XMLElement* reader, string inFolder, bool readF
 	return tex;
 }
 
-ZTexture* ZTexture::FromPNG(string pngFilePath, TextureType texType)
+std::shared_ptr<ZTexture> ZTexture::FromPNG(string pngFilePath, TextureType texType)
 {
 	int comp;
-	ZTexture* tex = new ZTexture();
+	auto tex = std::make_shared<ZTexture>();
 	tex->type = texType;
 	tex->name = StringHelper::Split(Path::GetFileNameWithoutExtension(pngFilePath), ".")[0];
 	
@@ -133,9 +133,9 @@ ZTexture* ZTexture::FromPNG(string pngFilePath, TextureType texType)
 	return tex;
 }
 
-ZTexture* ZTexture::FromHLTexture(HLTexture* hlTex)
+std::shared_ptr<ZTexture> ZTexture::FromHLTexture(HLTexture* hlTex)
 {
-	ZTexture* tex = new ZTexture();
+	auto tex = std::make_shared<ZTexture>();
 
 	tex->width = hlTex->width;
 	tex->height = hlTex->height;

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -18,6 +18,8 @@ ZTexture::ZTexture() : ZResource()
 {
 	bmpRgb = nullptr;
 	bmpRgba = nullptr;
+	isStbi = false;
+	isStbia = false;
 	width = 0;
 	height = 0;
 	type = TextureType::Error;
@@ -28,13 +30,21 @@ ZTexture::~ZTexture()
 {
 	if (bmpRgb != nullptr)
 	{
-		stbi_image_free(bmpRgb);
+		if (isStbi) {
+			stbi_image_free(bmpRgb);
+		} else {
+			delete[] bmpRgb;
+		}
 		bmpRgb = nullptr;
 	}
 
 	if (bmpRgba != nullptr)
 	{
-		stbi_image_free(bmpRgba);
+		if (isStbia) {
+			stbi_image_free(bmpRgba);
+		} else {
+			delete[] bmpRgba;
+		}
 		bmpRgba = nullptr;
 	}
 
@@ -178,6 +188,8 @@ void ZTexture::PrepareBitmap()
 {
 	bmpRgb = new uint8_t[width * height * 3];
 	bmpRgba = new uint8_t[width * height * 4];
+	isStbi = false;
+	isStbia = false;
 
 	switch (type)
 	{
@@ -399,6 +411,7 @@ void ZTexture::PrepareRawDataRGBA16(string rgbaPath)
 	int comp;
 
 	bmpRgba = (uint8_t*)stbi_load(rgbaPath.c_str(), &width, &height, &comp, STBI_rgb_alpha);
+	isStbia = true;
 
 	for (int y = 0; y < height; y++)
 	{
@@ -427,6 +440,7 @@ void ZTexture::PrepareRawDataRGBA32(string rgbaPath)
 	int comp;
 
 	bmpRgba = (uint8_t*)stbi_load(rgbaPath.c_str(), &width, &height, &comp, STBI_rgb_alpha);
+	isStbia = true;
 
 	for (int y = 0; y < height; y++)
 	{
@@ -449,6 +463,7 @@ void ZTexture::PrepareRawDataGrayscale4(string grayPath)
 	int comp;
 
 	bmpRgb = (uint8_t*)stbi_load(grayPath.c_str(), &width, &height, &comp, STBI_rgb);
+	isStbi = true;
 
 	for (int y = 0; y < height; y++)
 	{
@@ -470,6 +485,7 @@ void ZTexture::PrepareRawDataGrayscale8(string grayPath)
 	int comp;
 
 	bmpRgb = (uint8_t*)stbi_load(grayPath.c_str(), &width, &height, &comp, STBI_rgb);
+	isStbi = true;
 
 	for (int y = 0; y < height; y++)
 	{
@@ -488,6 +504,7 @@ void ZTexture::PrepareRawDataGrayscaleAlpha4(string grayAlphaPath)
 	int comp;
 
 	bmpRgba = (uint8_t*)stbi_load(grayAlphaPath.c_str(), &width, &height, &comp, STBI_rgb_alpha);
+	isStbia = true;
 
 	for (int y = 0; y < height; y++)
 	{
@@ -519,6 +536,7 @@ void ZTexture::PrepareRawDataGrayscaleAlpha8(string grayAlphaPath)
 	int comp;
 
 	bmpRgba = (uint8_t*)stbi_load(grayAlphaPath.c_str(), &width, &height, &comp, STBI_rgb_alpha);
+	isStbia = true;
 
 	for (int y = 0; y < height; y++)
 	{
@@ -541,6 +559,7 @@ void ZTexture::PrepareRawDataGrayscaleAlpha16(string grayAlphaPath)
 	int comp;
 
 	bmpRgba = (uint8_t*)stbi_load(grayAlphaPath.c_str(), &width, &height, &comp, STBI_rgb_alpha);
+	isStbia = true;
 
 	for (int y = 0; y < height; y++)
 	{
@@ -564,6 +583,7 @@ void ZTexture::PrepareRawDataPalette4(string palPath)
 	int comp;
 
 	bmpRgb = (uint8_t*)stbi_load(palPath.c_str(), &width, &height, &comp, STBI_rgb);
+	isStbi = true;
 
 	for (int y = 0; y < height; y++)
 	{
@@ -586,6 +606,7 @@ void ZTexture::PrepareRawDataPalette8(string palPath)
 	int comp;
 
 	bmpRgb = (uint8_t*)stbi_load(palPath.c_str(), &width, &height, &comp, STBI_rgb);
+	isStbi = true;
 
 	for (int y = 0; y < height; y++)
 	{

--- a/ZAPD/ZTexture.h
+++ b/ZAPD/ZTexture.h
@@ -28,6 +28,8 @@ protected:
 
 	uint8_t* bmpRgb;
 	uint8_t* bmpRgba;
+	bool isStbi;
+	bool isStbia;
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void FixRawData();

--- a/ZAPD/ZTexture.h
+++ b/ZAPD/ZTexture.h
@@ -64,11 +64,11 @@ public:
 
 	bool isPalette;
 
-	static ZTexture* BuildFromXML(tinyxml2::XMLElement* reader, std::string inFolder, bool readFile);
-	static ZTexture* ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath);
-	static ZTexture* FromBinary(TextureType nType, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nName, int nWidth, int nHeight);
-	static ZTexture* FromPNG(std::string pngFilePath, TextureType texType);
-	static ZTexture* FromHLTexture(HLTexture* hlTex);
+	static std::shared_ptr<ZTexture> BuildFromXML(tinyxml2::XMLElement* reader, std::string inFolder, bool readFile);
+	static std::shared_ptr<ZTexture> ExtractFromXML(tinyxml2::XMLElement* reader, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nRelPath);
+	static std::shared_ptr<ZTexture> FromBinary(TextureType nType, std::vector<uint8_t> nRawData, int rawDataIndex, std::string nName, int nWidth, int nHeight);
+	static std::shared_ptr<ZTexture> FromPNG(std::string pngFilePath, TextureType texType);
+	static std::shared_ptr<ZTexture> FromHLTexture(HLTexture* hlTex);
 	static TextureType GetTextureTypeFromString(std::string str);
 
 	std::string GetSourceOutputCode(const std::string& prefix) override;

--- a/ZAPD/ZVector.cpp
+++ b/ZAPD/ZVector.cpp
@@ -12,9 +12,9 @@ ZVector::ZVector() : ZResource()
 	this->dimensions = 0;
 }
 
-ZVector* ZVector::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath)
+std::shared_ptr<ZVector> ZVector::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath)
 {
-	ZVector* vector = new ZVector();
+	std::shared_ptr<ZVector> vector = std::make_shared<ZVector>();
 	vector->rawData = nRawData;
 	vector->rawDataIndex = rawDataIndex;
 	vector->ParseXML(reader);

--- a/ZAPD/ZVector.cpp
+++ b/ZAPD/ZVector.cpp
@@ -8,7 +8,6 @@
 
 ZVector::ZVector() : ZResource()
 {
-	scalars = std::vector<ZScalar*>();
 	this->scalarType = ZSCALAR_NONE;
 	this->dimensions = 0;
 }
@@ -43,13 +42,14 @@ void ZVector::ParseRawData()
 
 	for (int i = 0; i < this->dimensions; i++) 
 	{
-		ZScalar* scalar = new ZScalar(this->scalarType);
-		scalar->rawDataIndex = currentRawDataIndex;
-		scalar->rawData = this->rawData;
-		scalar->ParseRawData();
-		currentRawDataIndex += scalar->GetRawDataSize();
+		this->scalars.emplace_back(this->scalarType);
+		ZScalar& scalar = this->scalars.back();
 
-		this->scalars.push_back(scalar);
+		scalar.rawDataIndex = currentRawDataIndex;
+		scalar.rawData = this->rawData;
+		scalar.ParseRawData();
+		currentRawDataIndex += scalar.GetRawDataSize();
+
 	}
 
 	// Ensure the scalars vector has the same number of elements as the vector dimension.
@@ -60,7 +60,7 @@ int ZVector::GetRawDataSize()
 {
 	int size = 0;
 	for (int i = 0; i < this->scalars.size(); i++)
-		size += this->scalars[i]->GetRawDataSize();
+		size += this->scalars[i].GetRawDataSize();
 	return size;
 }
 
@@ -98,7 +98,7 @@ std::string ZVector::GetSourceValue()
 {
 	std::vector<std::string> strings = std::vector<std::string>();
 	for (int i = 0; i < this->scalars.size(); i++)
-		strings.push_back(scalars[i]->GetSourceValue());
+		strings.push_back(scalars[i].GetSourceValue());
 	return "{ " + StringHelper::Implode(strings, ", ") + " }";
 }
 

--- a/ZAPD/ZVector.cpp
+++ b/ZAPD/ZVector.cpp
@@ -87,7 +87,7 @@ std::string ZVector::GetSourceTypeName()
 	{
 		std::string output = StringHelper::Sprintf("Encountered unsupported vector type: %d dimensions, %s type", dimensions, ZScalar::MapScalarTypeToOutputType(scalarType).c_str());
 
-		if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
+		if (Globals::Instance.verbosity >= VERBOSITY_DEBUG)
 			printf("%s\n", output.c_str());
 
 		throw output;

--- a/ZAPD/ZVector.h
+++ b/ZAPD/ZVector.h
@@ -21,7 +21,7 @@ public:
 	bool DoesSupportArray() override;
 	ZResourceType GetResourceType();
 
-	static ZVector* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath);
+	static std::shared_ptr<ZVector> ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath);
 
 private:
 	std::vector<ZScalar> scalars;

--- a/ZAPD/ZVector.h
+++ b/ZAPD/ZVector.h
@@ -10,10 +10,6 @@
 class ZVector : public ZResource
 {
 public:
-	std::vector<ZScalar*> scalars;
-	ZScalarType scalarType;
-	uint32_t dimensions;
-
 	ZVector();
 
 	void ParseXML(tinyxml2::XMLElement* reader);
@@ -27,5 +23,8 @@ public:
 
 	static ZVector* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath);
 
-protected:
+private:
+	std::vector<ZScalar> scalars;
+	ZScalarType scalarType;
+	uint32_t dimensions;
 };

--- a/ZAPD/ZVtx.cpp
+++ b/ZAPD/ZVtx.cpp
@@ -67,9 +67,9 @@ ZResourceType ZVtx::GetResourceType()
     return ZResourceType::Vertex;
 }
 
-ZVtx* ZVtx::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath)
+std::shared_ptr<ZVtx> ZVtx::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath)
 {
-    ZVtx* vtx = new ZVtx();
+    std::shared_ptr<ZVtx> vtx = std::make_shared<ZVtx>();
 	vtx->rawData = nRawData;
 	vtx->rawDataIndex = rawDataIndex;
     vtx->ParseRawData();

--- a/ZAPD/ZVtx.h
+++ b/ZAPD/ZVtx.h
@@ -25,7 +25,7 @@ public:
 	bool DoesSupportArray() override;
 	ZResourceType GetResourceType();
 
-	static ZVtx* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath);
+	static std::shared_ptr<ZVtx> ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, const int rawDataIndex, const std::string& nRelPath);
 
 protected:
 };


### PR DESCRIPTION
I mainly changed a lot of raw pointers into `shared_ptr`, so that object deallocates itself when it is no longer used. I tried finding the places where the memory was leaking and adding `delete`s, but they were too much places and also it somehow randomly crashed during my testing, so I just went with the `shared_ptr` solution.

There were also a lot of places where a heap allocation (`new`) was used when it wasn't necessary, and for some reason the object wasn't being `delete`d, so it just leaked...

I would suggest to avoid using pointers unless it is really neaded (like storing a bunch of objects of different types using inheritance). And even in that case, try to use smart pointers so you don't have to worry about deallocating that memory.

This should fix almost all the problems listed in #52 (except the last one).

And for some numbers, this should fix around 50% of leaked memory. 
To get this number, I measured the leaked memory when running `extract_assets.py` with and without this change. It went down from `1254.07 MiB` leaked to `619.66 MiB` leaked.

There are still things to fix in `HighLevel` and `ZRoom` folders. I tried to fix stuff there, but it exploded in my face... Maybe I'll try to fix them later.