### PR TITLE
Fix collision extraction from actor's data

### DIFF
--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -183,6 +183,6 @@ void ZLinkAnimation::ParseRawData()
 
 	const uint8_t* data = rawData.data();
 
-	//segmentAddress = SEG2FILESPACE(BitConverter::ToInt32BE(data, rawDataIndex + 4));
+	//segmentAddress = GETSEGOFFSET(BitConverter::ToInt32BE(data, rawDataIndex + 4));
 	segmentAddress = (BitConverter::ToInt32BE(data, rawDataIndex + 4));
 }

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -35,30 +35,10 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 	numWaterBoxes = BitConverter::ToInt16BE(data, rawDataIndex + 36);
 	waterBoxSegmentOffset = BitConverter::ToInt32BE(data, rawDataIndex + 40) & 0x00FFFFFF;
 
-	uint32_t vtxAddr = SEG2FILESPACE(vtxSegmentOffset);
-	uint32_t polyAddr = SEG2FILESPACE(polySegmentOffset);
-	uint32_t polyTypeDefAddr = SEG2FILESPACE(polyTypeDefSegmentOffset);
-	uint32_t camDataAddr = SEG2FILESPACE(camDataSegmentOffset);
-
-	int segmentNumber = GETSEGNUM(vtxSegmentOffset);
-	if (segmentNumber == 0x80) { // Is defined in code?
-		vtxAddr -= SEG2FILESPACE(parent->baseAddress);
-	}
-
-	segmentNumber = GETSEGNUM(polySegmentOffset);
-	if (segmentNumber == 0x80) { // Is defined in code?
-		polyAddr -= SEG2FILESPACE(parent->baseAddress);
-	}
-
-	segmentNumber = GETSEGNUM(polyTypeDefSegmentOffset);
-	if (segmentNumber == 0x80) { // Is defined in code?
-		polyTypeDefAddr -= SEG2FILESPACE(parent->baseAddress);
-	}
-
-	segmentNumber = GETSEGNUM(camDataSegmentOffset);
-	if (segmentNumber == 0x80) { // Is defined in code?
-		camDataAddr -= SEG2FILESPACE(parent->baseAddress);
-	}
+	uint32_t vtxAddr = Seg2Filespace(vtxSegmentOffset, parent->baseAddress);
+	uint32_t polyAddr = Seg2Filespace(polySegmentOffset, parent->baseAddress);
+	uint32_t polyTypeDefAddr = Seg2Filespace(polyTypeDefSegmentOffset, parent->baseAddress);
+	uint32_t camDataAddr = Seg2Filespace(camDataSegmentOffset, parent->baseAddress);
 
 	// HOTSPOT
 	for (int i = 0; i < numVerts; i++)

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -25,28 +25,29 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 	absMaxZ = BitConverter::ToInt16BE(data, rawDataIndex + 10);
 
 	numVerts = BitConverter::ToInt16BE(data, rawDataIndex + 12);
-	vtxSegmentOffset = BitConverter::ToInt32BE(data, rawDataIndex + 16);
+	vtxAddress = BitConverter::ToInt32BE(data, rawDataIndex + 16);
 
 	numPolygons = BitConverter::ToInt16BE(data, rawDataIndex + 20);
-	polySegmentOffset = BitConverter::ToInt32BE(data, rawDataIndex + 24);
-	polyTypeDefSegmentOffset = BitConverter::ToInt32BE(data, rawDataIndex + 28);
-	camDataSegmentOffset = BitConverter::ToInt32BE(data, rawDataIndex + 32);
+	polyAddress = BitConverter::ToInt32BE(data, rawDataIndex + 24);
+	polyTypeDefAddress = BitConverter::ToInt32BE(data, rawDataIndex + 28);
+	camDataAddress = BitConverter::ToInt32BE(data, rawDataIndex + 32);
 
 	numWaterBoxes = BitConverter::ToInt16BE(data, rawDataIndex + 36);
-	waterBoxSegmentOffset = BitConverter::ToInt32BE(data, rawDataIndex + 40) & 0x00FFFFFF;
+	waterBoxAddress = BitConverter::ToInt32BE(data, rawDataIndex + 40);
 
-	uint32_t vtxAddr = Seg2Filespace(vtxSegmentOffset, parent->baseAddress);
-	uint32_t polyAddr = Seg2Filespace(polySegmentOffset, parent->baseAddress);
-	uint32_t polyTypeDefAddr = Seg2Filespace(polyTypeDefSegmentOffset, parent->baseAddress);
-	uint32_t camDataAddr = Seg2Filespace(camDataSegmentOffset, parent->baseAddress);
+	uint32_t vtxSegmentOffset = Seg2Filespace(vtxAddress, parent->baseAddress);
+	uint32_t polySegmentOffset = Seg2Filespace(polyAddress, parent->baseAddress);
+	uint32_t polyTypeDefSegmentOffset = Seg2Filespace(polyTypeDefAddress, parent->baseAddress);
+	uint32_t camDataSegmentOffset = Seg2Filespace(camDataAddress, parent->baseAddress);
+	uint32_t waterBoxSegmentOffset = Seg2Filespace(waterBoxAddress, parent->baseAddress);
 
 	// HOTSPOT
 	for (int i = 0; i < numVerts; i++)
-		vertices.push_back(new VertexEntry(rawData, vtxAddr + (i * 6)));
+		vertices.push_back(new VertexEntry(rawData, vtxSegmentOffset + (i * 6)));
 
 	// HOTSPOT
 	for (int i = 0; i < numPolygons; i++)
-		polygons.push_back(new PolygonEntry(rawData, polyAddr + (i * 16)));
+		polygons.push_back(new PolygonEntry(rawData, polySegmentOffset + (i * 16)));
 
 	int highestPolyType = 0;
 
@@ -59,7 +60,7 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 	//if (highestPolyType > 0)
 	{
 		for (int i = 0; i < highestPolyType + 1; i++)
-			polygonTypes.push_back(BitConverter::ToUInt64BE(data, polyTypeDefAddr + (i * 8)));
+			polygonTypes.push_back(BitConverter::ToUInt64BE(data, polyTypeDefSegmentOffset + (i * 8)));
 	}
 	//else
 	//{
@@ -69,8 +70,8 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 			//polygonTypes.push_back(BitConverter::ToUInt64BE(data, polyTypeDefSegmentOffset + (i * 8)));
 	//}
 
-	if (camDataSegmentOffset != 0)
-		camData = new CameraDataList(parent, prefix, rawData, camDataAddr, polyTypeDefAddr, polygonTypes.size());
+	if (camDataAddress != 0)
+		camData = new CameraDataList(parent, prefix, rawData, camDataSegmentOffset, polyTypeDefSegmentOffset, polygonTypes.size());
 
 	for (int i = 0; i < numWaterBoxes; i++)
 		waterBoxes.push_back(new WaterBoxHeader(rawData, waterBoxSegmentOffset + (i * (Globals::Instance->game == ZGame::OOT_SW97 ? 12 : 16))));
@@ -87,7 +88,7 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 		}
 	}
 
-	if (waterBoxSegmentOffset != 0)
+	if (waterBoxAddress != 0)
 		parent->AddDeclarationArray(waterBoxSegmentOffset, DeclarationAlignment::None, 16 * waterBoxes.size(), "WaterBox",
 			StringHelper::Sprintf("%s_waterBoxes_%08X", prefix.c_str(), waterBoxSegmentOffset), 0, declaration);
 
@@ -99,12 +100,12 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 		{
 			sprintf(line, "   { 0x%04X, 0x%04X, 0x%04X, 0x%04X, 0x%04X, 0x%04X, 0x%04X, 0x%04X }, // 0x%08X\n",
 				(uint16_t)polygons[i]->type, (uint16_t)polygons[i]->vtxA, (uint16_t)polygons[i]->vtxB, (uint16_t)polygons[i]->vtxC,
-				(uint16_t)polygons[i]->a, (uint16_t)polygons[i]->b, (uint16_t)polygons[i]->c, (uint16_t)polygons[i]->d, polyAddr + (i * 16));
+				(uint16_t)polygons[i]->a, (uint16_t)polygons[i]->b, (uint16_t)polygons[i]->c, (uint16_t)polygons[i]->d, polySegmentOffset + (i * 16));
 			declaration += line;
 		}
 
-		if (polySegmentOffset != 0) {
-			parent->AddDeclarationArray(polyAddr, DeclarationAlignment::None, polygons.size() * 16, "CollisionPoly", StringHelper::Sprintf("%s_polygons_%08X", prefix.c_str(), polyAddr), 0, declaration);
+		if (polyAddress != 0) {
+			parent->AddDeclarationArray(polySegmentOffset, DeclarationAlignment::None, polygons.size() * 16, "CollisionPoly", StringHelper::Sprintf("%s_polygons_%08X", prefix.c_str(), polySegmentOffset), 0, declaration);
 		}
 	}
 
@@ -117,9 +118,9 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 			declaration += "\n";
 	}
 
-	if (polyTypeDefSegmentOffset != 0)
-		parent->AddDeclarationArray(polyTypeDefAddr, DeclarationAlignment::None, polygonTypes.size() * 8,
-			"u32", StringHelper::Sprintf("%s_polygonTypes_%08X", prefix.c_str(), polyTypeDefAddr), 0, declaration);
+	if (polyTypeDefAddress != 0)
+		parent->AddDeclarationArray(polyTypeDefSegmentOffset, DeclarationAlignment::None, polygonTypes.size() * 8,
+			"u32", StringHelper::Sprintf("%s_polygonTypes_%08X", prefix.c_str(), polyTypeDefSegmentOffset), 0, declaration);
 
 	declaration = "";
 
@@ -129,15 +130,15 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 
 		for (int i = 0; i < vertices.size(); i++)
 		{
-			declaration += StringHelper::Sprintf("   { %i, %i, %i }, // 0x%08X", vertices[i]->x, vertices[i]->y, vertices[i]->z, vtxAddr + (i * 6));
+			declaration += StringHelper::Sprintf("   { %i, %i, %i }, // 0x%08X", vertices[i]->x, vertices[i]->y, vertices[i]->z, vtxSegmentOffset + (i * 6));
 
 			if (i < vertices.size() - 1)
 				declaration += "\n";
 		}
 
-		if (vtxSegmentOffset != 0)
-			parent->AddDeclarationArray(vtxAddr, DeclarationAlignment::None, vertices.size() * 6,
-				"Vec3s", StringHelper::Sprintf("%s_vtx_%08X", prefix.c_str(), vtxAddr), 0, declaration);
+		if (vtxAddress != 0)
+			parent->AddDeclarationArray(vtxSegmentOffset, DeclarationAlignment::None, vertices.size() * 6,
+				"Vec3s", StringHelper::Sprintf("%s_vtx_%08X", prefix.c_str(), vtxSegmentOffset), 0, declaration);
 
 		declaration = "";
 	}
@@ -145,17 +146,21 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix, con
 	declaration = "";
 	char waterBoxStr[2048];
 
-	if (waterBoxSegmentOffset != 0)
+	if (waterBoxAddress != 0)
 		sprintf(waterBoxStr, "%s_waterBoxes_%08X", prefix.c_str(), waterBoxSegmentOffset);
 	else
-		sprintf(waterBoxStr, "0");
+		sprintf(waterBoxStr, "NULL");
 
-	declaration += StringHelper::Sprintf("%i, %i, %i, %i, %i, %i, %i, %s_vtx_%08X, %i, %s_polygons_%08X, %s_polygonTypes_%08X, &%s_camDataList_%08X, %i, %s",
+	declaration += "\n";
+
+	declaration += StringHelper::Sprintf("    { %i, %i, %i },\n    { %i, %i, %i },\n",
 		absMinX, absMinY, absMinZ,
-		absMaxX, absMaxY, absMaxZ,
-		numVerts, prefix.c_str(), vtxAddr, numPolygons,
-		prefix.c_str(), polyAddr, prefix.c_str(), polyTypeDefAddr,
-		prefix.c_str(), camDataAddr, numWaterBoxes, waterBoxStr);
+		absMaxX, absMaxY, absMaxZ);
+
+	declaration += StringHelper::Sprintf("    %i,\n    %s_vtx_%08X,\n    %i,\n    %s_polygons_%08X,\n    %s_polygonTypes_%08X,\n    &%s_camDataList_%08X,\n    %i,\n    %s\n",
+		numVerts, prefix.c_str(), vtxSegmentOffset, numPolygons,
+		prefix.c_str(), polySegmentOffset, prefix.c_str(), polyTypeDefSegmentOffset,
+		prefix.c_str(), camDataSegmentOffset, numWaterBoxes, waterBoxStr);
 
 	parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, DeclarationPadding::Pad16, 44, "CollisionHeader",
 		StringHelper::Sprintf("%s", prefix.c_str(), rawDataIndex), declaration);

--- a/ZAPD/ZCollision.h
+++ b/ZAPD/ZCollision.h
@@ -67,14 +67,14 @@ public:
 	int16_t absMinX, absMinY, absMinZ;
 	int16_t absMaxX, absMaxY, absMaxZ;
 	int16_t numVerts;
-	segptr_t vtxSegmentOffset;
+	segptr_t vtxAddress;
 	int16_t numPolygons;
-	segptr_t polySegmentOffset;
-	segptr_t polyTypeDefSegmentOffset;
-	segptr_t camDataSegmentOffset;
+	segptr_t polyAddress;
+	segptr_t polyTypeDefAddress;
+	segptr_t camDataAddress;
 
 	int32_t numWaterBoxes;
-	int32_t waterBoxSegmentOffset;
+	segptr_t waterBoxAddress;
 
 	std::vector<VertexEntry*> vertices;
 	std::vector<PolygonEntry*> polygons;

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -509,11 +509,8 @@ int ZDisplayList::OptimizationCheck_LoadTextureBlock(int startIndex, string& out
 
 			fmt = (__ & 0xE0) >> 5;
 			siz = (__ & 0x18) >> 3;
-			texAddr = SEG2FILESPACE(data);
-			int segmentNumber = (data & 0xFF000000) >> 24;
-
-			if (segmentNumber == 0x80) // Is this texture defined in code?
-				texAddr -= SEG2FILESPACE(parent->baseAddress);
+			texAddr = Seg2Filespace(data, parent->baseAddress);
+			int segmentNumber = GETSEGNUM(data);
 
 			lastTexSeg = (data & 0xFF000000);
 
@@ -664,12 +661,12 @@ int ZDisplayList::OptimizationCheck_LoadTextureBlock(int startIndex, string& out
 void ZDisplayList::Opcode_G_DL(uint64_t data, int i, std::string prefix, char* line)
 {
 	int pp = (data & 0x00FF000000000000) >> 56;
-	int segNum = (data & 0xFF000000) >> 24;
+	int segNum = GETSEGNUM(data);
 
 	Declaration* dListDecl = nullptr;
 
 	if (parent != nullptr)
-		dListDecl = parent->GetDeclaration(SEG2FILESPACE(data));
+		dListDecl = parent->GetDeclaration(GETSEGOFFSET(data));
 
 	if (pp != 0)
 	{
@@ -678,7 +675,7 @@ void ZDisplayList::Opcode_G_DL(uint64_t data, int i, std::string prefix, char* l
 		else if (dListDecl != nullptr)
 			sprintf(line, "gsSPBranchList(%s),", dListDecl->varName.c_str());
 		else
-			sprintf(line, "gsSPBranchList(%sDlist0x%06lX),", prefix.c_str(), SEG2FILESPACE(data));
+			sprintf(line, "gsSPBranchList(%sDlist0x%06lX),", prefix.c_str(), GETSEGOFFSET(data));
 	}
 	else
 	{
@@ -687,10 +684,11 @@ void ZDisplayList::Opcode_G_DL(uint64_t data, int i, std::string prefix, char* l
 		else if (dListDecl != nullptr)
 			sprintf(line, "gsSPDisplayList(%s),", dListDecl->varName.c_str());
 		else
-			sprintf(line, "gsSPDisplayList(%sDlist0x%06lX),", prefix.c_str(), SEG2FILESPACE(data));
+			sprintf(line, "gsSPDisplayList(%sDlist0x%06lX),", prefix.c_str(), GETSEGOFFSET(data));
 	}
 
-	int segmentNumber = (data & 0xFF000000) >> 24;
+	// TODO: This is the same as `segNum`. Consider resuing that variable instead of making a new one.
+	int segmentNumber = GETSEGNUM(data);
 
 	if (segmentNumber == 8 || segmentNumber == 9 || segmentNumber == 10 || segmentNumber == 11 || segmentNumber == 12 || segmentNumber == 13) // Used for runtime-generated display lists
 	{
@@ -796,10 +794,7 @@ void ZDisplayList::Opcode_G_VTX(uint64_t data, int i, std::string prefix, char* 
 	int nn = (data & 0x000FF00000000000ULL) >> 44;
 	int aa = (data & 0x000000FF00000000ULL) >> 32;
 
-	uint32_t vtxAddr = SEG2FILESPACE(data);
-
-	if (GETSEGNUM(data) == 0x80) // Are these vertices defined in code?
-		vtxAddr -= SEG2FILESPACE(parent->baseAddress);
+	uint32_t vtxAddr = Seg2Filespace(data, parent->baseAddress);
 
 	if (dListType == DListType::F3DZEX)
 		sprintf(line, "gsSPVertex(@r, %i, %i),", nn, ((aa >> 1) - nn));
@@ -818,10 +813,7 @@ void ZDisplayList::Opcode_G_VTX(uint64_t data, int i, std::string prefix, char* 
 	references.push_back(vtxAddr);
 
 	{
-		uint32_t currentPtr = SEG2FILESPACE(data);
-
-		if (GETSEGNUM(data) == 0x80) // Are these vertices defined in code?
-			currentPtr -= SEG2FILESPACE(parent->baseAddress);
+		uint32_t currentPtr = Seg2Filespace(data, parent->baseAddress);
 
 		// Check for vertex intersections from other display lists
 		// TODO: These two could probably be condenced to one...
@@ -900,21 +892,15 @@ void ZDisplayList::Opcode_G_SETTIMG(uint64_t data, int i, std::string prefix, ch
 	lastTexFmt = (F3DZEXTexFormats)fmt;
 	lastTexSiz = (F3DZEXTexSizes)siz;
 	lastTexSeg = data;
-	lastTexAddr = data & 0x00FFFFFF;
+	lastTexAddr = Seg2Filespace(data, parent->baseAddress);
 
-	if (GETSEGNUM(lastTexSeg) == 0x80) // Is this texture defined in code?
-		lastTexAddr -= SEG2FILESPACE(parent->baseAddress);
-
-	int segmentNumber = (data >> 24) & 0xFF;
+	int segmentNumber = GETSEGNUM(data);
 
 	if (segmentNumber != 2)
 	{
 		char texStr[2048];
-		int32_t texAddress = SEG2FILESPACE(data);
+		int32_t texAddress = Seg2Filespace(data, parent->baseAddress);
 		Declaration* texDecl = nullptr;
-
-		if (segmentNumber == 0x80) // Is this texture defined in code?
-			texAddress -= SEG2FILESPACE(parent->baseAddress);
 
 		if (parent != nullptr)
 		{
@@ -948,7 +934,7 @@ void ZDisplayList::Opcode_G_SETTIMG(uint64_t data, int i, std::string prefix, ch
 	else
 	{
 		//sprintf(line, "gsDPSetTextureImage(%s, %s, %i, 0x%08X),", fmtTbl[fmt].c_str(), sizTbl[siz].c_str(), www + 1, data & 0xFFFFFFFF);
-		sprintf(line, "gsDPSetTextureImage(%s, %s, %i, %sTex_%06lX),", fmtTbl[fmt].c_str(), sizTbl[siz].c_str(), www + 1, scene->GetName().c_str(), SEG2FILESPACE(data));
+		sprintf(line, "gsDPSetTextureImage(%s, %s, %i, %sTex_%06lX),", fmtTbl[fmt].c_str(), sizTbl[siz].c_str(), www + 1, scene->GetName().c_str(), GETSEGOFFSET(data));
 	}
 }
 
@@ -1674,7 +1660,7 @@ void ZDisplayList::TextureGenCheck(string prefix)
 // HOTSPOT
 bool ZDisplayList::TextureGenCheck(vector<uint8_t> fileData, map<uint32_t, ZTexture*>& textures, ZRoom* scene, ZFile* parent, string prefix, uint32_t texWidth, uint32_t texHeight, uint32_t texAddr, uint32_t texSeg, F3DZEXTexFormats texFmt, F3DZEXTexSizes texSiz, bool texLoaded, bool texIsPalette)
 {
-	int segmentNumber = (texSeg & 0xFF000000) >> 24;
+	int segmentNumber = GETSEGNUM(texSeg);
 
 	if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 		printf("TextureGenCheck seg=%i width=%i height=%i ispal=%i addr=0x%06X\n", segmentNumber, texWidth, texHeight, texIsPalette, texAddr);

--- a/ZAPD/ZResource.cpp
+++ b/ZAPD/ZResource.cpp
@@ -124,3 +124,14 @@ void ZResource::CalcHash()
 {
 	hash = 0;
 }
+
+
+uint32_t Seg2Filespace(segptr_t segmentedAddress, uint32_t parentBaseAddress)
+{
+	uint32_t currentPtr = GETSEGOFFSET(segmentedAddress);
+
+	if (GETSEGNUM(segmentedAddress) == 0x80) // Is defined in code?
+		currentPtr -= GETSEGOFFSET(parentBaseAddress);
+
+	return currentPtr;
+}

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -13,7 +13,7 @@
 #define SEGMENT_OBJECT 6
 #define SEGMENT_LINKANIMETION 7
 
-#define SEG2FILESPACE(x) (x & 0x00FFFFFF)
+#define GETSEGOFFSET(x) (x & 0x00FFFFFF)
 #define GETSEGNUM(x) ((x >> 24) & 0xFF)
 
 typedef uint32_t segptr_t;
@@ -125,3 +125,6 @@ public:
 protected:
 	Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding, uint32_t nSize, std::string nText);
 };
+
+
+uint32_t Seg2Filespace(segptr_t segmentedAddress, uint32_t parentBaseAddress);

--- a/ZAPD/ZRoom/Commands/SetActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetActorList.cpp
@@ -11,7 +11,7 @@ using namespace std;
 SetActorList::SetActorList(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex) : ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
 	numActors = rawData[rawDataIndex + 1];
-	segmentOffset = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
+	segmentOffset = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
 
 	_rawData = rawData;
 	_rawDataIndex = rawDataIndex;

--- a/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
+++ b/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 SetAlternateHeaders::SetAlternateHeaders(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex) : ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
-	segmentOffset = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
+	segmentOffset = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
 
 	if (segmentOffset != 0)
 		zRoom->parent->AddDeclarationPlaceholder(segmentOffset);

--- a/ZAPD/ZRoom/Commands/SetCollisionHeader.cpp
+++ b/ZAPD/ZRoom/Commands/SetCollisionHeader.cpp
@@ -8,7 +8,7 @@ using namespace std;
 
 SetCollisionHeader::SetCollisionHeader(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex) : ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
-	segmentOffset = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
+	segmentOffset = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
 	collisionHeader = ZCollisionHeader(nZRoom->parent, StringHelper::Sprintf("%sCollisionHeader0x%06X", nZRoom->GetName().c_str(), segmentOffset), rawData, segmentOffset);
 }
 

--- a/ZAPD/ZRoom/Commands/SetExitList.cpp
+++ b/ZAPD/ZRoom/Commands/SetExitList.cpp
@@ -8,7 +8,7 @@ using namespace std;
 
 SetExitList::SetExitList(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex) : ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
-	segmentOffset = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
+	segmentOffset = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
 	exits = vector<uint16_t>();
 
 	if (segmentOffset != 0)

--- a/ZAPD/ZRoom/Commands/SetLightingSettings.cpp
+++ b/ZAPD/ZRoom/Commands/SetLightingSettings.cpp
@@ -9,7 +9,7 @@ using namespace std;
 SetLightingSettings::SetLightingSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex) : ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
 	uint8_t numLights = rawData[rawDataIndex + 1];
-	segmentOffset = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
+	segmentOffset = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
 
 	for (int i = 0; i < numLights; i++)
 		settings.push_back(new LightingSettings(rawData, segmentOffset + (i * 22)));

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -11,7 +11,7 @@ using namespace std;
 SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, int segAddressOffset) : ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
 	data = rawData[rawDataIndex + 1];
-	segmentOffset = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
+	segmentOffset = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
 
 	string declaration = "";
 	int8_t meshHeaderType = rawData[segmentOffset + 0];
@@ -22,8 +22,8 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 		meshHeader0->headerType = 0;
 		meshHeader0->entries = vector<MeshEntry0*>();
 
-		meshHeader0->dListStart = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, segmentOffset + 4));
-		meshHeader0->dListEnd = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, segmentOffset + 8));
+		meshHeader0->dListStart = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, segmentOffset + 4));
+		meshHeader0->dListEnd = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, segmentOffset + 8));
 
 		int8_t numEntries = rawData[segmentOffset + 1];
 		uint32_t currentPtr = meshHeader0->dListStart;
@@ -38,8 +38,8 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 		for (int i = 0; i < numEntries; i++)
 		{
 			MeshEntry0* entry = new MeshEntry0();
-			entry->opaqueDListAddr = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, currentPtr + 0));
-			entry->translucentDListAddr = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, currentPtr + 4));
+			entry->opaqueDListAddr = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, currentPtr + 0));
+			entry->translucentDListAddr = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, currentPtr + 4));
 
 			if (entry->opaqueDListAddr != 0)
 			{
@@ -134,7 +134,7 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 				StringHelper::Sprintf("%sMeshHeader0x%06X", zRoom->GetName().c_str(), segmentOffset), declaration);
 
 			meshHeader1 = headerSingle;
-;		}
+		}
 		else if (fmt == 2) // Multi-Format
 		{
 			MeshHeader1Multi* headerMulti = new MeshHeader1Multi();
@@ -173,8 +173,8 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex, 
 		meshHeader2->headerType = 2;
 		
 		meshHeader2->entries = vector<MeshEntry2*>();
-		meshHeader2->dListStart = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, segmentOffset + 4));
-		meshHeader2->dListEnd = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, segmentOffset + 8));
+		meshHeader2->dListStart = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, segmentOffset + 4));
+		meshHeader2->dListEnd = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, segmentOffset + 8));
 
 		int8_t numEntries = rawData[segmentOffset + 1];
 		uint32_t currentPtr = meshHeader2->dListStart;

--- a/ZAPD/ZRoom/Commands/SetObjectList.cpp
+++ b/ZAPD/ZRoom/Commands/SetObjectList.cpp
@@ -11,7 +11,7 @@ SetObjectList::SetObjectList(ZRoom* nZRoom, std::vector<uint8_t> rawData, int ra
 {
 	objects = vector<uint16_t>();
 	uint8_t objectCnt = rawData[rawDataIndex + 1];
-	segmentOffset = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
+	segmentOffset = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
 	uint32_t currentPtr = segmentOffset;
 
 	for (int i = 0; i < objectCnt; i++)

--- a/ZAPD/ZRoom/Commands/SetPathways.cpp
+++ b/ZAPD/ZRoom/Commands/SetPathways.cpp
@@ -14,7 +14,7 @@ SetPathways::SetPathways(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDat
 	segmentOffset = 0;
 	listSegmentOffset = 0;
 
-	InitList(SEG2FILESPACE(BitConverter::ToInt32BE(rawData, rawDataIndex + 4)));
+	InitList(GETSEGOFFSET(BitConverter::ToInt32BE(rawData, rawDataIndex + 4)));
 
 	uint32_t currentPtr = listSegmentOffset;
 
@@ -31,7 +31,7 @@ SetPathways::~SetPathways()
 void SetPathways::InitList(uint32_t address)
 {
 	segmentOffset = address;
-	listSegmentOffset = SEG2FILESPACE(BitConverter::ToInt32BE(_rawData, address + 4));
+	listSegmentOffset = GETSEGOFFSET(BitConverter::ToInt32BE(_rawData, address + 4));
 	numPoints = _rawData[address + 0];
 }
 

--- a/ZAPD/ZRoom/Commands/SetStartPositionList.cpp
+++ b/ZAPD/ZRoom/Commands/SetStartPositionList.cpp
@@ -10,7 +10,7 @@ using namespace std;
 SetStartPositionList::SetStartPositionList(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex) : ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
 	int numActors = rawData[rawDataIndex + 1];
-	segmentOffset = SEG2FILESPACE(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
+	segmentOffset = GETSEGOFFSET(BitConverter::ToInt32BE(rawData, rawDataIndex + 4));
 	
 	if (segmentOffset != 0)
 		zRoom->parent->AddDeclarationPlaceholder(segmentOffset);

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -225,10 +225,8 @@ void ZRoom::ParseCommands(std::vector<ZRoomCommand*>& commandList, CommandSet co
 {
 	bool shouldContinue = true;
 	int currentIndex = 0;
-	int rawDataIndex = commandSet.address;
-	int8_t segmentNumber = rawDataIndex >> 24;
+	int rawDataIndex = commandSet.address & 0x00FFFFFF;
 
-	rawDataIndex &= 0x00FFFFFF;
 	int32_t commandsLeft = commandSet.commandCount;
 
 	while (shouldContinue)
@@ -305,7 +303,6 @@ void ZRoom::ProcessCommandSets()
 		std::vector<ZRoomCommand*> setCommands = std::vector<ZRoomCommand*>();
 
 		int32_t commandSet = commandSets[0].address;
-		int8_t segmentNumber = commandSet >> 24;
 		ParseCommands(setCommands, commandSets[0]);
 		commandSets.erase(commandSets.begin());
 


### PR DESCRIPTION
Fixes a crash when ZAPD tries to extract a CollisionHeader from overlay's data. 

The issue was caused because ZAPD didn't account the base address of the overlay.

The issue can be replicated creating an xml for the overlay `ovl_En_Jsjutan` and the following:
- `BaseAddress="0x80A897A0" RangeStart="0x12F8" RangeEnd="0x4C88" Segment="128"`
- `<Collision Name="D_80A8E400" Offset="0x4C60"/>`