### PR TITLE
Fix CutsceneHint being ignored in xml in some cases

### DIFF
--- a/ZAPD/ZRoom/Commands/SetCutscenes.cpp
+++ b/ZAPD/ZRoom/Commands/SetCutscenes.cpp
@@ -41,8 +41,9 @@ SetCutscenes::~SetCutscenes()
 string SetCutscenes::GenerateSourceCodePass1(string roomName, int baseAddress)
 {
 	string pass1 = ZRoomCommand::GenerateSourceCodePass1(roomName, baseAddress);
-	if (name != "") {
-		return StringHelper::Sprintf("%s 0, (u32)%s", pass1.c_str(), name.c_str());
+	Declaration* decl = zRoom->parent->GetDeclaration(segmentOffset);
+	if (decl != nullptr) {
+		return StringHelper::Sprintf("%s 0, (u32)%s", pass1.c_str(), decl->varName.c_str());
 	}
 	return StringHelper::Sprintf("%s 0, (u32)%sCutsceneData0x%06X", pass1.c_str(), zRoom->GetName().c_str(), segmentOffset);
 }

--- a/ZAPD/ZRoom/Commands/SetCutscenes.cpp
+++ b/ZAPD/ZRoom/Commands/SetCutscenes.cpp
@@ -17,9 +17,16 @@ SetCutscenes::SetCutscenes(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawD
 
 	output += cutscene->GetSourceOutputCode(zRoom->GetName());
 
-	if (segmentOffset != 0)
-		zRoom->parent->AddDeclarationArray(segmentOffset, DeclarationAlignment::None, DeclarationPadding::Pad16, cutscene->GetRawDataSize(), "s32", 
-			StringHelper::Sprintf("%sCutsceneData0x%06X", zRoom->GetName().c_str(), segmentOffset), 0, output);
+	if (segmentOffset != 0) {
+		Declaration* decl = zRoom->parent->GetDeclaration(segmentOffset);
+		if (decl == nullptr) {
+			zRoom->parent->AddDeclarationArray(segmentOffset, DeclarationAlignment::None, DeclarationPadding::Pad16, cutscene->GetRawDataSize(), "s32", 
+				StringHelper::Sprintf("%sCutsceneData0x%06X", zRoom->GetName().c_str(), segmentOffset), 0, output);
+		}
+		else if (decl->text == "") {
+			decl->text = output;
+		}
+	}
 }
 
 SetCutscenes::~SetCutscenes()
@@ -33,7 +40,11 @@ SetCutscenes::~SetCutscenes()
 
 string SetCutscenes::GenerateSourceCodePass1(string roomName, int baseAddress)
 {
-	return StringHelper::Sprintf("%s 0, (u32)%sCutsceneData0x%06X", ZRoomCommand::GenerateSourceCodePass1(roomName, baseAddress).c_str(), zRoom->GetName().c_str(), segmentOffset);
+	string pass1 = ZRoomCommand::GenerateSourceCodePass1(roomName, baseAddress);
+	if (name != "") {
+		return StringHelper::Sprintf("%s 0, (u32)%s", pass1.c_str(), name.c_str());
+	}
+	return StringHelper::Sprintf("%s 0, (u32)%sCutsceneData0x%06X", pass1.c_str(), zRoom->GetName().c_str(), segmentOffset);
 }
 
 int32_t SetCutscenes::GetRawDataSize()
@@ -43,7 +54,10 @@ int32_t SetCutscenes::GetRawDataSize()
 
 string SetCutscenes::GenerateExterns()
 {
-	return  StringHelper::Sprintf("extern s32 %sCutsceneData0x%06X[];\n", zRoom->GetName().c_str(), segmentOffset);
+	if (name != "") {
+		return StringHelper::Sprintf("extern s32 %s[];\n", name.c_str());
+	}
+	return StringHelper::Sprintf("extern s32 %sCutsceneData0x%06X[];\n", zRoom->GetName().c_str(), segmentOffset);
 }
 
 string SetCutscenes::GetCommandCName()

--- a/ZAPD/ZRoom/Commands/SetCutscenes.cpp
+++ b/ZAPD/ZRoom/Commands/SetCutscenes.cpp
@@ -55,8 +55,9 @@ int32_t SetCutscenes::GetRawDataSize()
 
 string SetCutscenes::GenerateExterns()
 {
-	if (name != "") {
-		return StringHelper::Sprintf("extern s32 %s[];\n", name.c_str());
+	Declaration* decl = zRoom->parent->GetDeclaration(segmentOffset);
+	if (decl != nullptr && decl->varName != "") {
+		return StringHelper::Sprintf("extern s32 %s[];\n", decl->varName.c_str());
 	}
 	return StringHelper::Sprintf("extern s32 %sCutsceneData0x%06X[];\n", zRoom->GetName().c_str(), segmentOffset);
 }

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -279,6 +279,11 @@ void ZRoom::ParseCommands(std::vector<ZRoomCommand*>& commandList, CommandSet co
 				printf("OP: %s, TIME: %lims\n", cmd->GetCommandCName().c_str(), diff);
 		}
 
+		Declaration* decl = parent->GetDeclaration(rawDataIndex);
+		if (decl != nullptr) {
+			cmd->name = decl->varName;
+		}
+
 		//printf("OP: %s\n", cmd->GetCommandCName().c_str());
 
 		cmd->cmdIndex = currentIndex;

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -238,12 +238,6 @@ void ZRoom::ParseCommands(std::vector<ZRoomCommand*>& commandList, CommandSet co
 
 		ZRoomCommand* cmd = nullptr;
 
-		string declName = "";
-		Declaration* decl = parent->GetDeclaration(rawDataIndex);
-		if (decl != nullptr) {
-			declName = decl->varName;
-		}
-
 		auto start = chrono::steady_clock::now();
 
 		switch (opcode)
@@ -285,10 +279,6 @@ void ZRoom::ParseCommands(std::vector<ZRoomCommand*>& commandList, CommandSet co
 				printf("OP: %s, TIME: %lims\n", cmd->GetCommandCName().c_str(), diff);
 		}
 
-		if (declName != "") {
-			cmd->name = declName;
-		}
-
 		//printf("OP: %s\n", cmd->GetCommandCName().c_str());
 
 		cmd->cmdIndex = currentIndex;
@@ -321,7 +311,6 @@ void ZRoom::ProcessCommandSets()
 			ZRoomCommand* cmd = setCommands[i];
 			cmd->commandSet = commandSet & 0x00FFFFFF;
 			string pass1 = cmd->GenerateSourceCodePass1(name, cmd->commandSet);
-
 
 			Declaration* decl = parent->AddDeclaration(cmd->cmdAddress, 
 				i == 0 ? DeclarationAlignment::Align16 : DeclarationAlignment::None, 8, 

--- a/ZAPD/ZRoom/ZRoomCommand.h
+++ b/ZAPD/ZRoom/ZRoomCommand.h
@@ -47,6 +47,7 @@ public:
 	int32_t cmdIndex;
 	int32_t cmdSet;
 	uint32_t commandSet;
+	std::string name = "";
 
 	ZRoomCommand(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex);
 

--- a/ZAPD/ZRoom/ZRoomCommand.h
+++ b/ZAPD/ZRoom/ZRoomCommand.h
@@ -47,7 +47,6 @@ public:
 	int32_t cmdIndex;
 	int32_t cmdSet;
 	uint32_t commandSet;
-	std::string name = "";
 
 	ZRoomCommand(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex);
 


### PR DESCRIPTION
Fixes the problem when a `CutsceneHint` is declared in the xml file, but the name is ignored and the autogenerated name is used instead.
The issue was caused by `SetCutscenes` not checking for variables already declared with that offset.
An example of this issue can be seen in this [PR](https://github.com/zeldaret/oot/pull/693) ([this file](https://github.com/zeldaret/oot/blob/33cc2f84d4cfbf90e240b1cbcf91b4d2bd5b7c34/assets/xml/scenes/overworld/spot18.xml#L7)) of the OoT repo.
