### PR TITLE
Add missing `#include`

### DIFF
--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <stdexcept>
 #include <stdint.h>
 #include "tinyxml2.h"
 


### PR DESCRIPTION
Adds a missing `#include`. Without it, ZAPD will not compile on some g++ implementations.