### PR TITLE
Fix `make setup`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,15 @@ genbuildinfo:
 
 clean:
 	rm -f $(O_FILES) ZAPD.out
-	rm -f lib/libgfxd/libgfxd.a
+	cd lib/libgfxd && $(MAKE) clean
 
 rebuild: clean all
 
 %.o: %.cpp
 	$(CC) $(CFLAGS) -c $< -o $@
 
-libgfxd:
-	cd lib/libgfxd && $(MAKE) -j
+lib/libgfxd/libgfxd.a:
+	$(MAKE) -C lib/libgfxd -j
 
-ZAPD.out: $(O_FILES) libgfxd
+ZAPD.out: $(O_FILES) lib/libgfxd/libgfxd.a
 	$(CC) $(CFLAGS) $(O_FILES) lib/libgfxd/libgfxd.a -o $@ $(FS_INC)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ genbuildinfo:
 
 clean:
 	rm -f $(O_FILES) ZAPD.out
-	cd lib/libgfxd && $(MAKE) clean
+	$(MAKE) -C lib/libgfxd clean
 
 rebuild: clean all
 

--- a/lib/libgfxd/Makefile
+++ b/lib/libgfxd/Makefile
@@ -7,7 +7,7 @@ CPPFLAGS-$(MT) += -DCONFIG_MT
 CPPFLAGS += $(CPPFLAGS-y)
 
 .PHONY: all
-all: $(LIB)($(OBJ))
+all: $(OBJ) $(LIB)
 
 .PHONY: clean
 clean:
@@ -15,5 +15,7 @@ clean:
 
 .INTERMEDIATE: $(OBJ)
 
-$(OBJ): gbi.h gfxd.h priv.h
-$(UC_OBJ): uc.c uc_argfn.c uc_argtbl.c uc_macrofn.c uc_macrotbl.c
+$(LIB): $(OBJ)
+	ar rcsv $@ $^
+%.o: %.c
+	$(CC) $(CFLAGS) -c $^

--- a/lib/libgfxd/Makefile
+++ b/lib/libgfxd/Makefile
@@ -7,7 +7,7 @@ CPPFLAGS-$(MT) += -DCONFIG_MT
 CPPFLAGS += $(CPPFLAGS-y)
 
 .PHONY: all
-all: $(OBJ) $(LIB)
+all: $(LIB)
 
 .PHONY: clean
 clean:
@@ -15,7 +15,11 @@ clean:
 
 .INTERMEDIATE: $(OBJ)
 
+$(OBJ): gbi.h gfxd.h priv.h
+$(UC_OBJ): uc.c uc_argfn.c uc_argtbl.c uc_macrofn.c uc_macrotbl.c
+
 $(LIB): $(OBJ)
-	ar rcsv $@ $^
+	$(AR) rcs $@ $^
+
 %.o: %.c
-	$(CC) $(CFLAGS) -c $^
+	$(COMPILE.c) $(OUTPUT_OPTION) $<


### PR DESCRIPTION
Fixes the compilation problem when trying to compile ZAPD in the OoT repo by doing `make setup`.