### PR TITLE
Add support to `SkelCurve` and its animation type

### DIFF
--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -234,26 +234,29 @@ ZCurveAnimation::ZCurveAnimation(tinyxml2::XMLElement* reader, const std::vector
 	skel = new ZSkeleton(ZSkeletonType::Curve, ZLimbType::Curve, "CurveAnim", 
 		nRawData, Seg2Filespace(skelOffset, parent->baseAddress), nParent);
 
+	size_t transformDataSize = 0;
 	if (refIndex != 0) {
 		uint32_t refIndexOffset = Seg2Filespace(refIndex, parent->baseAddress);
 		size_t i = 0;
-		for (; i < 3 * 3 * skel->GetLimbCount(); i++) { // TODO: Figure out how big is this array
-			refIndexArr.emplace_back(BitConverter::ToUInt8BE(nRawData, refIndexOffset + i));
+		for (; i < 3 * 3 * skel->GetLimbCount(); i++) {
+			uint8_t ref = BitConverter::ToUInt8BE(nRawData, refIndexOffset + i);
+			transformDataSize += ref;
+			refIndexArr.emplace_back(ref);
 		}
 	}
 
 	if (transformData != 0) {
 		uint32_t transformDataOffset = Seg2Filespace(transformData, parent->baseAddress);
 		size_t i = 0;
-		//for () { // TODO: Figure out how big is this array
+		for (; i < transformDataSize; i++) { // TODO: Figure out how big is this array
 			transformDataArr.emplace_back(parent, nRawData, transformDataOffset, i);
-		//}
+		}
 	}
 
 	if (copyValues != 0) {
 		uint32_t copyValuesOffset = Seg2Filespace(copyValues, parent->baseAddress);
 		size_t i = 0;
-		//for () { // TODO: Figure out how big is this array
+		//for (; i < ; i++) { // TODO: Figure out how big is this array
 			copyValuesArr.emplace_back(BitConverter::ToInt16BE(nRawData, copyValuesOffset + i*2));
 		//}
 	}
@@ -270,7 +273,7 @@ void ZCurveAnimation::ParseXML(tinyxml2::XMLElement* reader)
 
     const char* skelOffsetXml = reader->Attribute("SkelOffset");
     if (skelOffsetXml == nullptr) {
-        throw std::runtime_error("ZCurveAnimation::ParseXML: Fatal error in '%s'. Missing 'SkelOffset' attribute in xml.");
+        throw std::runtime_error("ZCurveAnimation::ParseXML: Fatal error in '%s'. Missing 'SkelOffset' attribute in xml. You need to provide the offset of the curve skeleton.");
     }
 	skelOffset = std::strtoul(skelOffsetXml, nullptr, 0);
 }

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -316,7 +316,7 @@ void ZCurveAnimation::PreGenValues(const std::string& prefix)
 		for (auto& child: refIndexArr) {
 			entryStr += StringHelper::Sprintf("0x%02X, %s", 
 				child, 
-				(++i % 8 == 7) ? "\n    " : "");
+				(i++ % 8 == 7) ? "\n    " : "");
 		}
 
 		Declaration* decl = parent->GetDeclaration(refIndexOffset);
@@ -368,7 +368,7 @@ void ZCurveAnimation::PreGenValues(const std::string& prefix)
 		for (auto& child: copyValuesArr) {
 			entryStr += StringHelper::Sprintf("%i, %s", 
 				child, 
-				(++i % 8 == 7) ? "\n    " : "");
+				(i++ % 8 == 7) ? "\n    " : "");
 		}
 
 		Declaration* decl = parent->GetDeclaration(copyValuesOffset);

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -229,6 +229,20 @@ int ZCurveAnimation::GetRawDataSize()
 
 std::string ZCurveAnimation::GetSourceOutputCode(const std::string& prefix)
 {
+	string bodyStr = "";
+	uint32_t address = Seg2Filespace(rawDataIndex, parent->baseAddress);
+
+	bodyStr = StringHelper::Sprintf("0x%08X, 0x%08X, 0x%08X, %i, %i", refIndex, transformData, copyValues, unk_0C, unk_10);
+
+	Declaration* decl = parent->GetDeclaration(address);
+	if (decl == nullptr) {
+		parent->AddDeclaration(address, DeclarationAlignment::None, 
+			GetRawDataSize(), GetSourceTypeName(), name, bodyStr);
+	}
+	else {
+		decl->text = bodyStr;
+	}
+
 	return "";
 }
 

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -186,3 +186,53 @@ void ZLinkAnimation::ParseRawData()
 	//segmentAddress = GETSEGOFFSET(BitConverter::ToInt32BE(data, rawDataIndex + 4));
 	segmentAddress = (BitConverter::ToInt32BE(data, rawDataIndex + 4));
 }
+
+
+
+ZCurveAnimation::ZCurveAnimation(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent)
+{
+	rawData.assign(nRawData.begin(), nRawData.end());
+	rawDataIndex = nRawDataIndex;
+	parent = nParent;
+
+	ParseXML(reader);
+	ParseRawData();
+}
+
+void ZCurveAnimation::ParseRawData()
+{
+	ZAnimation::ParseRawData();
+
+	refIndex = BitConverter::ToUInt32BE(rawData, rawDataIndex + 0);
+	transformData = BitConverter::ToUInt32BE(rawData, rawDataIndex + 4);
+	copyValues = BitConverter::ToUInt32BE(rawData, rawDataIndex + 8);
+	unk_0C = BitConverter::ToInt16BE(rawData, rawDataIndex + 12);
+	unk_10 = BitConverter::ToInt16BE(rawData, rawDataIndex + 14);
+}
+
+ZCurveAnimation* ZCurveAnimation::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex, std::string nRelPath, ZFile* nParent)
+{
+	ZCurveAnimation* curve = new ZCurveAnimation(reader, nRawData, nRawDataIndex, nParent);
+	curve->relativePath = std::move(nRelPath);
+
+	curve->parent->AddDeclaration(
+		curve->rawDataIndex, DeclarationAlignment::Align16, curve->GetRawDataSize(), 
+		curve->GetSourceTypeName(), curve->name, "");
+
+	return curve;
+}
+
+int ZCurveAnimation::GetRawDataSize()
+{
+	return 0x10;
+}
+
+std::string ZCurveAnimation::GetSourceOutputCode(const std::string& prefix)
+{
+	return "";
+}
+
+std::string ZCurveAnimation::GetSourceTypeName()
+{
+	return "TransformUpdateIndex";
+}

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -235,30 +235,33 @@ ZCurveAnimation::ZCurveAnimation(tinyxml2::XMLElement* reader, const std::vector
 		nRawData, Seg2Filespace(skelOffset, parent->baseAddress), nParent);
 
 	size_t transformDataSize = 0;
+	size_t copyValuesSize = 0;
 	if (refIndex != 0) {
 		uint32_t refIndexOffset = Seg2Filespace(refIndex, parent->baseAddress);
-		size_t i = 0;
-		for (; i < 3 * 3 * skel->GetLimbCount(); i++) {
+		for (size_t i = 0; i < 3 * 3 * skel->GetLimbCount(); i++) {
 			uint8_t ref = BitConverter::ToUInt8BE(nRawData, refIndexOffset + i);
-			transformDataSize += ref;
+			if (ref == 0) {
+				copyValuesSize++;
+			}
+			else {
+				transformDataSize += ref;
+			}
 			refIndexArr.emplace_back(ref);
 		}
 	}
 
 	if (transformData != 0) {
 		uint32_t transformDataOffset = Seg2Filespace(transformData, parent->baseAddress);
-		size_t i = 0;
-		for (; i < transformDataSize; i++) { // TODO: Figure out how big is this array
+		for (size_t i = 0; i < transformDataSize; i++) {
 			transformDataArr.emplace_back(parent, nRawData, transformDataOffset, i);
 		}
 	}
 
 	if (copyValues != 0) {
 		uint32_t copyValuesOffset = Seg2Filespace(copyValues, parent->baseAddress);
-		size_t i = 0;
-		//for (; i < ; i++) { // TODO: Figure out how big is this array
+		for (size_t i = 0; i < copyValuesSize; i++) {
 			copyValuesArr.emplace_back(BitConverter::ToInt16BE(nRawData, copyValuesOffset + i*2));
-		//}
+		}
 	}
 }
 
@@ -369,7 +372,7 @@ void ZCurveAnimation::PreGenValues(const std::string& prefix)
 
 		size_t i = 0;
 		for (auto& child: copyValuesArr) {
-			entryStr += StringHelper::Sprintf("%i, %s", 
+			entryStr += StringHelper::Sprintf("% 6i, %s", 
 				child, 
 				(i++ % 8 == 7) ? "\n    " : "");
 		}

--- a/ZAPD/ZAnimation.h
+++ b/ZAPD/ZAnimation.h
@@ -112,9 +112,9 @@ protected:
     ///* 0x000E */ s16 unk_10;
 	int16_t unk_10;
 
-	// std::vector<uint8_t> refIndexArr;
+	std::vector<uint8_t> refIndexArr;
 	std::vector<TransformData> transformDataArr;
-	// std::vector<int16_t> copyValues;
+	std::vector<int16_t> copyValuesArr;
 
 public:
 	ZCurveAnimation(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent);

--- a/ZAPD/ZAnimation.h
+++ b/ZAPD/ZAnimation.h
@@ -67,3 +67,30 @@ public:
 protected:
 	virtual void ParseRawData();
 };
+
+
+class ZCurveAnimation : public ZAnimation
+{
+protected:
+    ///* 0x0000 */ u8* refIndex;
+	segptr_t refIndex;
+    ///* 0x0004 */ TransformData* transformData;
+	segptr_t transformData;
+    ///* 0x0008 */ s16* copyValues;
+	segptr_t copyValues;
+    ///* 0x000C */ s16 unk_0C;
+	int16_t unk_0C;
+    ///* 0x000E */ s16 unk_10;
+	int16_t unk_10;
+
+public:
+	ZCurveAnimation(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent);
+	void ParseRawData() override;
+	static ZCurveAnimation* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex, std::string nRelPath, ZFile* nParent);
+
+	int GetRawDataSize() override;
+	std::string GetSourceOutputCode(const std::string& prefix) override;
+
+	std::string GetSourceTypeName() override;
+};
+// TransformUpdateIndex

--- a/ZAPD/ZAnimation.h
+++ b/ZAPD/ZAnimation.h
@@ -6,6 +6,7 @@
 #include "ZResource.h"
 #include "Vec3s.h"
 #include "tinyxml2.h"
+#include "ZSkeleton.h"
 
 struct RotationIndex
 {
@@ -101,6 +102,8 @@ public:
 class ZCurveAnimation : public ZAnimation
 {
 protected:
+	segptr_t skelOffset = 0;
+
     ///* 0x0000 */ u8* refIndex;
 	segptr_t refIndex = 0;
     ///* 0x0004 */ TransformData* transformData;
@@ -112,12 +115,17 @@ protected:
     ///* 0x000E */ s16 unk_10;
 	int16_t unk_10;
 
+	ZSkeleton* skel;
+
 	std::vector<uint8_t> refIndexArr;
 	std::vector<TransformData> transformDataArr;
 	std::vector<int16_t> copyValuesArr;
 
 public:
+	ZCurveAnimation() = default;
 	ZCurveAnimation(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent);
+	~ZCurveAnimation();
+	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;
 	static ZCurveAnimation* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex, std::string nRelPath, ZFile* nParent);
 

--- a/ZAPD/ZAnimation.h
+++ b/ZAPD/ZAnimation.h
@@ -69,25 +69,59 @@ protected:
 };
 
 
+class TransformData
+{
+protected:
+	ZFile* parent;
+
+    ///* 0x0000 */ u16 unk_00; // appears to be flags
+	uint16_t unk_00;
+    ///* 0x0002 */ s16 unk_02;
+	int16_t unk_02;
+    ///* 0x0004 */ s16 unk_04;
+	int16_t unk_04;
+    ///* 0x0006 */ s16 unk_06;
+	int16_t unk_06;
+    ///* 0x0008 */ f32 unk_08;
+	float unk_08;
+
+public:
+	TransformData() = default;
+	TransformData(ZFile* parent, const std::vector<uint8_t>& rawData, uint32_t fileOffset);
+	TransformData(ZFile* parent, const std::vector<uint8_t>& rawData, uint32_t fileOffset, size_t index);
+
+	[[nodiscard]]
+	std::string GetBody(const std::string& prefix) const;
+
+	static size_t GetRawDataSize();
+	static std::string GetSourceTypeName();
+};
+
+
 class ZCurveAnimation : public ZAnimation
 {
 protected:
     ///* 0x0000 */ u8* refIndex;
-	segptr_t refIndex;
+	segptr_t refIndex = 0;
     ///* 0x0004 */ TransformData* transformData;
-	segptr_t transformData;
+	segptr_t transformData = 0;
     ///* 0x0008 */ s16* copyValues;
-	segptr_t copyValues;
+	segptr_t copyValues = 0;
     ///* 0x000C */ s16 unk_0C;
 	int16_t unk_0C;
     ///* 0x000E */ s16 unk_10;
 	int16_t unk_10;
+
+	// std::vector<uint8_t> refIndexArr;
+	std::vector<TransformData> transformDataArr;
+	// std::vector<int16_t> copyValues;
 
 public:
 	ZCurveAnimation(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent);
 	void ParseRawData() override;
 	static ZCurveAnimation* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex, std::string nRelPath, ZFile* nParent);
 
+	void PreGenValues(const std::string& prefix);
 	int GetRawDataSize() override;
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -227,6 +227,20 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 
 			rawDataIndex += anim->GetRawDataSize();
 		}
+		else if (string(child->Name()) == "CurveAnimation")
+		{
+			ZCurveAnimation* anim = nullptr;
+
+			if (mode == ZFileMode::Extract) {
+				anim = ZCurveAnimation::ExtractFromXML(child, rawData, rawDataIndex, folderName, this);
+			}
+
+			if (anim == nullptr) {
+				throw std::runtime_error("Couldn't create ZCurveAnimation.");
+			}
+			resources.push_back(anim);
+			rawDataIndex += anim->GetRawDataSize();
+		}
 		else if (string(child->Name()) == "Skeleton")
 		{
 			ZSkeleton* skeleton = nullptr;
@@ -234,6 +248,9 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 			if (mode == ZFileMode::Extract)
 				skeleton = ZSkeleton::FromXML(child, rawData, rawDataIndex, folderName, this);
 
+			if (skeleton == nullptr) {
+				throw std::runtime_error("Couldn't create ZSkeleton.");
+			}
 			resources.push_back(skeleton);
 			rawDataIndex += skeleton->GetRawDataSize();
 		}
@@ -244,8 +261,10 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 			if (mode == ZFileMode::Extract)
 				limb = ZLimb::FromXML(child, rawData, rawDataIndex, folderName, this);
 
+			if (limb == nullptr) {
+				throw std::runtime_error("Couldn't create ZLimb.");
+			}
 			resources.push_back(limb);
-
 			rawDataIndex += limb->GetRawDataSize();
 		}
 		else if (string(child->Name()) == "Symbol")
@@ -256,9 +275,10 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 				symbol = ZSymbol::ExtractFromXML(child, rawData, rawDataIndex, this);
 			}
 
-			if (symbol != nullptr) {
-				resources.push_back(symbol);
+			if (symbol == nullptr) {
+				throw std::runtime_error("Couldn't create ZSymbol.");
 			}
+			resources.push_back(symbol);
 		}
 		else if (string(child->Name()) == "Collision")
 		{

--- a/ZAPD/ZLimb.cpp
+++ b/ZAPD/ZLimb.cpp
@@ -388,7 +388,7 @@ void ZLimb::ParseRawData()
 
 	switch (type) {
 	case ZLimbType::LOD:
-		farDListPtr = BitConverter::ToUInt32BE(rawData, rawDataIndex + 12);
+		dList2Ptr = BitConverter::ToUInt32BE(rawData, rawDataIndex + 12);
 	case ZLimbType::Standard:
 		dListPtr = BitConverter::ToUInt32BE(rawData, rawDataIndex + 8);
 		break;
@@ -416,12 +416,11 @@ int ZLimb::GetRawDataSize()
 {
 	switch (type) {
 	case ZLimbType::Standard:
+	case ZLimbType::Curve:
 		return 0x0C;
 	case ZLimbType::LOD:
 	case ZLimbType::Skin:
 		return 0x10;
-	case ZLimbType::Curve:
-		return 0x08; // size >= 0x8
 	}
 	return 0x0C;
 }
@@ -435,9 +434,9 @@ string ZLimb::GetSourceOutputCode(const std::string& prefix)
 		string limbPrefix = type == ZLimbType::Curve ? "Curve" : "";
 		dListStr = GetLimbDListSourceOutputCode(prefix, limbPrefix, dListPtr);
 	}
-	if (farDListPtr != 0) {
+	if (dList2Ptr != 0) {
 		string limbPrefix = type == ZLimbType::Curve ? "Curve" : "Far";
-		dListStr2 = GetLimbDListSourceOutputCode(prefix, limbPrefix, farDListPtr);
+		dListStr2 = GetLimbDListSourceOutputCode(prefix, limbPrefix, dList2Ptr);
 	}
 
 	string entryStr = "";

--- a/ZAPD/ZLimb.h
+++ b/ZAPD/ZLimb.h
@@ -137,13 +137,11 @@ protected:
 
 	std::vector<ZDisplayList> dLists;
 
-	segptr_t farDListPtr = 0; // LOD only
+	segptr_t dList2Ptr = 0; // LOD and Curve only
 
 	ZLimbSkinType skinSegmentType = ZLimbSkinType::SkinType_0; // Skin only
 	segptr_t skinSegment = 0; // Skin only
 	Struct_800A5E28 segmentStruct; // Skin only
-
-	segptr_t dList2Ptr = 0; // Curve only
 
 	std::string GetLimbDListSourceOutputCode(const std::string& prefix, const std::string& limbPrefix, segptr_t dListPtr);
 

--- a/ZAPD/ZLimb.h
+++ b/ZAPD/ZLimb.h
@@ -11,7 +11,8 @@ enum class ZLimbType
 {
 	Standard,
 	LOD,
-	Skin
+	Skin,
+	Curve,
 };
 
 // TODO: check if more types exists

--- a/ZAPD/ZLimb.h
+++ b/ZAPD/ZLimb.h
@@ -143,6 +143,8 @@ protected:
 	segptr_t skinSegment = 0; // Skin only
 	Struct_800A5E28 segmentStruct; // Skin only
 
+	segptr_t dList2Ptr = 0; // Curve only
+
 	std::string GetLimbDListSourceOutputCode(const std::string& prefix, const std::string& limbPrefix, segptr_t dListPtr);
 
 	std::string GetSourceOutputCodeSkin(const std::string& prefix);

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -51,6 +51,9 @@ void ZSkeleton::ParseXML(tinyxml2::XMLElement* reader)
 		if (skelTypeStr == "Flex") {
 			type = ZSkeletonType::Flex;
 		}
+		else if (skelTypeStr == "Curve") {
+			type = ZSkeletonType::Curve;
+		}
 		else if (skelTypeStr != "Normal") {
 			fprintf(stderr, "ZSkeleton::ParseXML: Warning in '%s'.\n\t Invalid Type found: '%s'. Defaulting to 'Normal'.\n", name.c_str(), skelTypeXml);
 			type = ZSkeletonType::Normal;
@@ -72,6 +75,9 @@ void ZSkeleton::ParseXML(tinyxml2::XMLElement* reader)
 		}
 		else if (limbTypeStr == "Skin") {
 			limbType = ZLimbType::Skin;
+		}
+		else if (limbTypeStr == "Curve") {
+			limbType = ZLimbType::Curve;
 		}
 		else {
 			fprintf(stderr, "ZSkeleton::ParseXML: Warning in '%s'.\n\t Invalid LimbType found: '%s'. Defaulting to 'Standard'.\n", name.c_str(), limbTypeXml);
@@ -115,10 +121,10 @@ void ZSkeleton::GenerateHLIntermediette(HLFileIntermediette& hlFile)
 int ZSkeleton::GetRawDataSize()
 {
 	switch (type) {
-	case ZSkeletonType::Normal:
-		return 0x8;
 	case ZSkeletonType::Flex:
 		return 0xC;
+	case ZSkeletonType::Normal:
+	case ZSkeletonType::Curve:
 	default:
 		return 0x8;
 	}
@@ -163,6 +169,7 @@ std::string ZSkeleton::GetSourceOutputCode(const std::string& prefix)
 	string headerStr;
 	switch (type) {
 	case ZSkeletonType::Normal:
+	case ZSkeletonType::Curve:
 		headerStr = StringHelper::Sprintf("%sLimbs, %i", defaultPrefix.c_str(), limbCount);
 		break;
 	case ZSkeletonType::Flex:
@@ -189,6 +196,8 @@ std::string ZSkeleton::GetSourceTypeName()
 		return "SkeletonHeader";
 	case ZSkeletonType::Flex:
 		return "FlexSkeletonHeader";
+	case ZSkeletonType::Curve:
+		return "SkelCurveLimbList";
 	}
 	return "SkeletonHeader";
 }

--- a/ZAPD/ZSkeleton.h
+++ b/ZAPD/ZSkeleton.h
@@ -10,7 +10,8 @@
 enum ZSkeletonType
 {
 	Normal,
-	Flex
+	Flex,
+	Curve,
 };
 
 class ZSkeleton : public ZResource

--- a/ZAPD/ZSkeleton.h
+++ b/ZAPD/ZSkeleton.h
@@ -24,7 +24,9 @@ public:
 	uint8_t limbCount;
 	uint8_t dListCount; // FLEX SKELETON ONLY
 
+	ZSkeleton() = default;
 	ZSkeleton(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent);
+	ZSkeleton(ZSkeletonType nType, ZLimbType nLimbType, const std::string& prefix, const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent);
 	~ZSkeleton();
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;
@@ -39,4 +41,5 @@ public:
 	ZResourceType GetResourceType() override;
 
 	segptr_t GetAddress();
+	uint8_t GetLimbCount();
 };


### PR DESCRIPTION
This adds a new `ZSkeleton` type (`Type="Curve"`), a new limb type (`LimbType="Curve"`)  and a new ZResource with its tag (`<CurveAnimation/>`).

The `CurveAnimation` requires 3 attributes in the xml, the `Name`, `Offset` and a `SkelOffset`. The `SkelOffset` attribute is the offset of the SkelCurve related to this animation.
