### PR TITLE
Unmangle backtrace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,11 @@ rebuild: clean all
 %.o: %.cpp
 	$(CC) $(CFLAGS) $(INC) -c $< -o $@ $(LDFLAGS)
 
+ZAPD/Main.o: genbuildinfo ZAPD/Main.cpp
+	$(CC) $(CFLAGS) $(INC) -c ZAPD/Main.cpp -o $@ $(LDFLAGS)
+
 lib/libgfxd/libgfxd.a:
 	$(MAKE) -C lib/libgfxd -j
 
-ZAPD.out: genbuildinfo $(O_FILES) lib/libgfxd/libgfxd.a
+ZAPD.out: $(O_FILES) lib/libgfxd/libgfxd.a
 	$(CC) $(CFLAGS) $(INC) $(O_FILES) lib/libgfxd/libgfxd.a -o $@ $(FS_INC) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ O_FILES   := $(CPP_FILES:.cpp=.o)
 
 all: ZAPD.out
 
-genbuildinfo:
+ZAPD/BuildInfo.h:
 	python3 ZAPD/genbuildinfo.py
 
 clean:
@@ -25,7 +25,7 @@ clean:
 
 rebuild: clean all
 
-%.o: %.cpp genbuildinfo
+%.o: %.cpp ZAPD/BuildInfo.h
 	$(CC) $(CFLAGS) -c $< -o $@ $(LDFLAGS)
 
 lib/libgfxd/libgfxd.a:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 CC := g++
-CFLAGS := -g -std=c++17 -I ZAPD -I lib/assimp/include -I lib/elfio -I lib/json/include -I lib/stb -I lib/tinygltf -I lib/libgfxd -I lib/tinyxml2 -O2 -rdynamic
+CFLAGS := -g  -fpic -Wl,-export-dynamic -std=c++17 -I ZAPD -I lib/assimp/include -I lib/elfio -I lib/json/include -I lib/stb -I lib/tinygltf -I lib/libgfxd -I lib/tinyxml2 -O0 -rdynamic
+LDFLAGS := -ldl -export-dynamic
 UNAME := $(shell uname)
 
 FS_INC =
@@ -25,10 +26,10 @@ clean:
 rebuild: clean all
 
 %.o: %.cpp genbuildinfo
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@ $(LDFLAGS)
 
 lib/libgfxd/libgfxd.a:
 	$(MAKE) -C lib/libgfxd -j
 
 ZAPD.out: $(O_FILES) lib/libgfxd/libgfxd.a
-	$(CC) $(CFLAGS) $(O_FILES) lib/libgfxd/libgfxd.a -o $@ $(FS_INC)
+	$(CC) $(CFLAGS) $(O_FILES) lib/libgfxd/libgfxd.a -o $@ $(FS_INC) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CC := g++
-CFLAGS := -g  -fpic -Wl,-export-dynamic -std=c++17 -I ZAPD -I lib/assimp/include -I lib/elfio -I lib/json/include -I lib/stb -I lib/tinygltf -I lib/libgfxd -I lib/tinyxml2 -O0 -rdynamic
-LDFLAGS := -ldl -export-dynamic
+INC := -I ZAPD -I lib/assimp/include -I lib/elfio -I lib/json/include -I lib/stb -I lib/tinygltf -I lib/libgfxd -I lib/tinyxml2
+CFLAGS := -g -g3 -fpic -Wl,-export-dynamic -std=c++17 -O2 -rdynamic
+LDFLAGS := -ldl
 UNAME := $(shell uname)
 
 FS_INC =
@@ -16,7 +17,7 @@ O_FILES   := $(CPP_FILES:.cpp=.o)
 
 all: ZAPD.out
 
-ZAPD/BuildInfo.h:
+genbuildinfo:
 	python3 ZAPD/genbuildinfo.py
 
 clean:
@@ -25,11 +26,11 @@ clean:
 
 rebuild: clean all
 
-%.o: %.cpp ZAPD/BuildInfo.h
-	$(CC) $(CFLAGS) -c $< -o $@ $(LDFLAGS)
+%.o: %.cpp
+	$(CC) $(CFLAGS) $(INC) -c $< -o $@ $(LDFLAGS)
 
 lib/libgfxd/libgfxd.a:
 	$(MAKE) -C lib/libgfxd -j
 
-ZAPD.out: $(O_FILES) lib/libgfxd/libgfxd.a
-	$(CC) $(CFLAGS) $(O_FILES) lib/libgfxd/libgfxd.a -o $@ $(FS_INC) $(LDFLAGS)
+ZAPD.out: genbuildinfo $(O_FILES) lib/libgfxd/libgfxd.a
+	$(CC) $(CFLAGS) $(INC) $(O_FILES) lib/libgfxd/libgfxd.a -o $@ $(FS_INC) $(LDFLAGS)

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -12,11 +12,11 @@
 #include "ZTexture.h"
 
 #if !defined(_MSC_VER) && !defined(__CYGWIN__)
-#include <execinfo.h>
 #include <csignal>
+#include <cxxabi.h>  // for __cxa_demangle
+#include <dlfcn.h>   // for dladdr
+#include <execinfo.h>
 #include <unistd.h>
-#include <dlfcn.h>     // for dladdr
-#include <cxxabi.h>    // for __cxa_demangle
 #endif
 
 #include <string>
@@ -50,16 +50,19 @@ void ErrorHandler(int sig)
 		int gotAddress = dladdr(array[i], &info);
 		string functionName(symbols[i]);
 
-		if (gotAddress != 0 && info.dli_sname != nullptr) {
+		if (gotAddress != 0 && info.dli_sname != nullptr)
+		{
 			int status;
 			char* demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &status);
 			const char* nameFound = info.dli_sname;
 
-			if (status == 0) {
+			if (status == 0)
+			{
 				nameFound = demangled;
 			}
 
-			functionName = StringHelper::Sprintf("%s (+0x%X)", nameFound, (char *)array[i] - (char *)info.dli_saddr);
+			functionName = StringHelper::Sprintf("%s (+0x%X)", nameFound,
+			                                     (char*)array[i] - (char*)info.dli_saddr);
 			free(demangled);
 		}
 

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -15,6 +15,8 @@
 #include <execinfo.h>
 #include <signal.h>
 #include <unistd.h>
+#include <dlfcn.h>     // for dladdr
+#include <cxxabi.h>    // for __cxa_demangle
 #endif
 
 #include <string>
@@ -38,16 +40,48 @@ int NewMain(int argc, char* argv[]);
 void ErrorHandler(int sig)
 {
 	void* array[4096];
+	const int nMaxFrames = sizeof(array) / sizeof(array[0]);
+	char buf[1024];
 	char** symbols;
 	size_t size;
 	size = backtrace(array, 4096);
 	symbols = backtrace_symbols(array, 4096);
 
+	std::ostringstream trace_buf;
 	for (size_t i = 1; i < size; i++)
 	{
+		Dl_info info;
+		if (dladdr(array[i], &info)) {
+			char *demangled = NULL;
+			int status;
+			demangled = abi::__cxa_demangle(info.dli_sname, NULL, 0, &status);
+			/*snprintf(buf, sizeof(buf), "%-3d %*0p %s + %zd\n",
+					 i,
+					 2 + sizeof(void*) * 2, 
+					 array[i],
+					 status == 0 ? demangled : info.dli_sname,
+					 (char *)array[i] - (char *)info.dli_saddr);*/
+			printf("%i: %s\n", i, demangled);
+			printf("\t%0p\n", array[i]);
+			printf("\t%s\n", info.dli_sname);
+			printf("\t%zd\n", (char *)array[i] - (char *)info.dli_saddr);
+			free(demangled);
+		}
+		else {
+			snprintf(buf, sizeof(buf), "%-3d %*0p\n",
+					 i, 2 + sizeof(void*) * 2, array[i]);
+		}
+
+		trace_buf << buf;
+
+		snprintf(buf, sizeof(buf), "%s\n", symbols[i]);
+		trace_buf << buf;
+
 		// size_t len = strlen(symbols[i]);
-		cout << symbols[i] << "\n";
+		//cout << symbols[i] << "\n";
 	}
+
+	//cout << trace_buf.str() << "\n";
 
 	// cout << "Error: signal " << sig << ":\n";
 	backtrace_symbols_fd(array, size, STDERR_FILENO);

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -69,7 +69,7 @@ void ErrorHandler(int sig)
 		fprintf(stderr, "%-3zd %s\n", i, functionName.c_str());
 	}
 
-	backtrace_symbols_fd(array, size, STDERR_FILENO);
+	//backtrace_symbols_fd(array, size, STDERR_FILENO);
 	free(symbols);
 	exit(1);
 }

--- a/ZAPD/Overlays/ZOverlay.cpp
+++ b/ZAPD/Overlays/ZOverlay.cpp
@@ -75,7 +75,7 @@ ZOverlay* ZOverlay::FromBuild(string buildPath, string cfgFolderPath)
 				SectionType sectionType = GetSectionTypeFromStr(pSec->get_name());
 
 				if (sectionType == SectionType::ERROR)
-					printf("WARNING: One of the section types returned ERROR\n");
+					fprintf(stderr, "WARNING: One of the section types returned ERROR\n");
 
 				relocation_section_accessor relocs(*curReader, pSec);
 				for (Elf_Xword j = 0; j < relocs.get_entries_num(); j++)

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -66,8 +66,9 @@ std::string ZNormalAnimation::GetSourceOutputCode(const std::string& prefix)
 		string headerStr =
 			StringHelper::Sprintf("{ %i }, %sFrameData, %sJointIndices, %i", frameCount,
 		                          defaultPrefix.c_str(), defaultPrefix.c_str(), limit);
-		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(), GetSourceTypeName(),
-		                       StringHelper::Sprintf("%s", name.c_str()), headerStr);
+		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
+		                       GetSourceTypeName(), StringHelper::Sprintf("%s", name.c_str()),
+		                       headerStr);
 
 		string indicesStr = "";
 		string valuesStr = "    ";
@@ -175,8 +176,9 @@ std::string ZLinkAnimation::GetSourceOutputCode(const std::string& prefix)
 								   segmentAddress, StringHelper::Sprintf("%sSeg%06X", name.c_str(),
 		                                                                 segmentAddress));
 		string headerStr = StringHelper::Sprintf("{ %i }, 0x%08X", frameCount, segmentAddress);
-		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(), GetSourceTypeName(),
-		                       StringHelper::Sprintf("%s", name.c_str()), headerStr);
+		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
+		                       GetSourceTypeName(), StringHelper::Sprintf("%s", name.c_str()),
+		                       headerStr);
 	}
 
 	return "";
@@ -314,10 +316,10 @@ void ZCurveAnimation::ParseXML(tinyxml2::XMLElement* reader)
 	const char* skelOffsetXml = reader->Attribute("SkelOffset");
 	if (skelOffsetXml == nullptr)
 	{
-		throw std::runtime_error(
-			StringHelper::Sprintf(
-				"ZCurveAnimation::ParseXML: Fatal error in '%s'. Missing 'SkelOffset' attribute in "
-		    	"ZCurveAnimation. You need to provide the offset of the curve skeleton.", name.c_str()));
+		throw std::runtime_error(StringHelper::Sprintf(
+			"ZCurveAnimation::ParseXML: Fatal error in '%s'. Missing 'SkelOffset' attribute in "
+			"ZCurveAnimation. You need to provide the offset of the curve skeleton.",
+			name.c_str()));
 	}
 	skelOffset = std::strtoul(skelOffsetXml, nullptr, 0);
 }

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -305,8 +305,9 @@ void ZCurveAnimation::ParseXML(tinyxml2::XMLElement* reader)
 	if (skelOffsetXml == nullptr)
 	{
 		throw std::runtime_error(
-			"ZCurveAnimation::ParseXML: Fatal error in '%s'. Missing 'SkelOffset' attribute in "
-		    "xml. You need to provide the offset of the curve skeleton.");
+			StringHelper::Sprintf(
+				"ZCurveAnimation::ParseXML: Fatal error in '%s'. Missing 'SkelOffset' attribute in "
+		    	"ZCurveAnimation. You need to provide the offset of the curve skeleton.", name.c_str()));
 	}
 	skelOffset = std::strtoul(skelOffsetXml, nullptr, 0);
 }

--- a/ZAPD/ZArray.cpp
+++ b/ZAPD/ZArray.cpp
@@ -23,7 +23,7 @@ std::string ZArray::GetSourceOutputCode(const std::string& prefix)
 
 	if (testFile->resources.size() <= 0)
 	{
-		throw StringHelper::Sprintf("Error! Array needs at least one sub-element.\n");
+		throw std::runtime_error("Error! Array needs at least one sub-element.\n");
 	}
 
 	ZResource* res = testFile->resources[0];

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -180,7 +180,7 @@ ZCollisionHeader::ZCollisionHeader(ZFile* parent, const std::string& prefix,
 
 	declaration += StringHelper::Sprintf(
 		"    %i,\n    %s_vtx_%08X,\n    %i,\n    %s_polygons_%08X,\n    %s_surfaceType_%08X,\n    "
-	    "%s_camDataList_%08X,\n    %i,\n    %s\n",
+		"%s_camDataList_%08X,\n    %i,\n    %s\n",
 		numVerts, prefix.c_str(), vtxSegmentOffset, numPolygons, prefix.c_str(), polySegmentOffset,
 		prefix.c_str(), polyTypeDefSegmentOffset, prefix.c_str(), camDataSegmentOffset,
 		numWaterBoxes, waterBoxStr);

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -356,7 +356,7 @@ CutsceneCommands ZCutscene::GetCommandFromID(int id)
 		return CutsceneCommands::Unknown;
 	}
 
-	printf("WARNING: Could not identify cutscene command ID 0x%04X\n", id);
+	fprintf(stderr, "WARNING: Could not identify cutscene command ID 0x%04X\n", id);
 
 	return CutsceneCommands::Error;
 }

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -1106,7 +1106,7 @@ string CutsceneCommandSpecialAction::GenerateSourceCode(const std::string& roomN
 	{
 		result += StringHelper::Sprintf(
 			"\t\tCS_MISC(0x%04X, %i, %i, 0x%04X, 0x%04X, 0x%04X, %i, %i, %i, %i, %i, %i, %i, "
-		    "%i),\n",
+			"%i),\n",
 			entries[i]->base, entries[i]->startFrame, entries[i]->endFrame, entries[i]->unused0,
 			entries[i]->unused1, entries[i]->unused2, entries[i]->unused3, entries[i]->unused4,
 			entries[i]->unused5, entries[i]->unused6, entries[i]->unused7, entries[i]->unused8,

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -119,8 +119,8 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 	if (mode == ZFileMode::Extract)
 	{
 		if (!File::Exists(basePath + "/" + name))
-			throw StringHelper::Sprintf("Error! File %s does not exist.",
-			                            (basePath + "/" + name).c_str());
+			throw std::runtime_error(StringHelper::Sprintf("Error! File %s does not exist.",
+			                            (basePath + "/" + name).c_str()));
 
 		rawData = File::ReadAllBytes(basePath + "/" + name);
 	}
@@ -939,7 +939,7 @@ string ZFile::ProcessDeclarations()
 			if (lastAddr != 0 && declarations.find(lastAddr) != declarations.end() &&
 			    lastAddr + declarations[lastAddr]->size > item.first)
 			{
-				printf("WARNING: Intersection detected from 0x%06X:0x%06X, conflicts with 0x%06X\n",
+				fprintf(stderr, "WARNING: Intersection detected from 0x%06X:0x%06X, conflicts with 0x%06X\n",
 				       lastAddr, lastAddr + declarations[lastAddr]->size, item.first);
 			}
 

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -120,7 +120,7 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 	{
 		if (!File::Exists(basePath + "/" + name))
 			throw std::runtime_error(StringHelper::Sprintf("Error! File %s does not exist.",
-			                            (basePath + "/" + name).c_str()));
+			                                               (basePath + "/" + name).c_str()));
 
 		rawData = File::ReadAllBytes(basePath + "/" + name);
 	}
@@ -939,8 +939,11 @@ string ZFile::ProcessDeclarations()
 			if (lastAddr != 0 && declarations.find(lastAddr) != declarations.end() &&
 			    lastAddr + declarations[lastAddr]->size > item.first)
 			{
-				fprintf(stderr, "WARNING: Intersection detected from 0x%06X:0x%06X, conflicts with 0x%06X (%s)\n",
-				       lastAddr, lastAddr + declarations[lastAddr]->size, item.first, item.second->varName.c_str());
+				fprintf(stderr,
+				        "WARNING: Intersection detected from 0x%06X:0x%06X, conflicts with 0x%06X "
+				        "(%s)\n",
+				        lastAddr, lastAddr + declarations[lastAddr]->size, item.first,
+				        item.second->varName.c_str());
 			}
 
 			uint8_t* rawDataArr = rawData.data();

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -939,8 +939,8 @@ string ZFile::ProcessDeclarations()
 			if (lastAddr != 0 && declarations.find(lastAddr) != declarations.end() &&
 			    lastAddr + declarations[lastAddr]->size > item.first)
 			{
-				fprintf(stderr, "WARNING: Intersection detected from 0x%06X:0x%06X, conflicts with 0x%06X\n",
-				       lastAddr, lastAddr + declarations[lastAddr]->size, item.first);
+				fprintf(stderr, "WARNING: Intersection detected from 0x%06X:0x%06X, conflicts with 0x%06X (%s)\n",
+				       lastAddr, lastAddr + declarations[lastAddr]->size, item.first, item.second->varName.c_str());
 			}
 
 			uint8_t* rawDataArr = rawData.data();

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -201,7 +201,7 @@ SetMesh::SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, int rawDataIndex,
 		else  // UH OH
 		{
 			if (Globals::Instance->verbosity >= VERBOSITY_INFO)
-				printf("WARNING: MeshHeader FMT %i not implemented!\n", fmt);
+				fprintf(stderr, "WARNING: MeshHeader FMT %i not implemented!\n", fmt);
 		}
 
 		meshHeader1->headerType = 1;

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -208,8 +208,10 @@ std::string ZSkeleton::GetSourceOutputCode(const std::string& prefix)
 		// Table
 		string tblStr = "";
 		string limbArrTypeStr = "static void*";
-		if (limbType == ZLimbType::Curve) {
-			limbArrTypeStr = StringHelper::Sprintf("static %s*", ZLimb::GetSourceTypeName(limbType));
+		if (limbType == ZLimbType::Curve)
+		{
+			limbArrTypeStr =
+				StringHelper::Sprintf("static %s*", ZLimb::GetSourceTypeName(limbType));
 		}
 
 		for (size_t i = 0; i < limbs.size(); i++)

--- a/ZAPD/ZVector.cpp
+++ b/ZAPD/ZVector.cpp
@@ -93,7 +93,7 @@ std::string ZVector::GetSourceTypeName()
 		if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
 			printf("%s\n", output.c_str());
 
-		throw output;
+		throw std::runtime_error(output);
 	}
 }
 


### PR DESCRIPTION
Change the backtrace when ZAPD crashes into something more readable.

For example, if ZAPD crashes a backtrace like this will be printed:

<details>
<summary>
    Large code block, click to show.
</summary>

```
/lib/x86_64-linux-gnu/libc.so.6(+0x41950) [0x7f503632a950]
tools/ZAPD/ZAPD.out(_ZN9ZSkeletonC2EPN8tinyxml210XMLElementERKSt6vectorIhSaIhEEiP5ZFile+0x17f) [0x563c2e111f8f]
tools/ZAPD/ZAPD.out(_ZN9ZSkeleton7FromXMLEPN8tinyxml210XMLElementESt6vectorIhSaIhEEiNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEP5ZFile+0x5f) [0x563c2e11213f]
tools/ZAPD/ZAPD.out(_ZN5ZFile8ParseXMLE9ZFileModePN8tinyxml210XMLElementENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEb+0x2817) [0x563c2e101627]
tools/ZAPD/ZAPD.out(_ZN5ZFileC1E9ZFileModePN8tinyxml210XMLElementENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_S9_b+0x2aa) [0x563c2e1021ba]
tools/ZAPD/ZAPD.out(_Z5ParseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES6_S6_9ZFileMode+0x1c7) [0x563c2e0dc8c7]
tools/ZAPD/ZAPD.out(_Z7NewMainiPPc+0x34c) [0x563c2e0dd0dc]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf2) [0x7f5036311cb2]
tools/ZAPD/ZAPD.out(_start+0x2e) [0x563c2e0d755e]
tools/ZAPD/ZAPD.out(_Z12ErrorHandleri+0x50)[0x563c2e0dab70]
/lib/x86_64-linux-gnu/libc.so.6(+0x41950)[0x7f503632a950]
tools/ZAPD/ZAPD.out(_ZN9ZSkeletonC2EPN8tinyxml210XMLElementERKSt6vectorIhSaIhEEiP5ZFile+0x17f)[0x563c2e111f8f]
tools/ZAPD/ZAPD.out(_ZN9ZSkeleton7FromXMLEPN8tinyxml210XMLElementESt6vectorIhSaIhEEiNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEP5ZFile+0x5f)[0x563c2e11213f]
tools/ZAPD/ZAPD.out(_ZN5ZFile8ParseXMLE9ZFileModePN8tinyxml210XMLElementENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEb+0x2817)[0x563c2e101627]
tools/ZAPD/ZAPD.out(_ZN5ZFileC1E9ZFileModePN8tinyxml210XMLElementENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES9_S9_b+0x2aa)[0x563c2e1021ba]
tools/ZAPD/ZAPD.out(_Z5ParseRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES6_S6_9ZFileMode+0x1c7)[0x563c2e0dc8c7]
tools/ZAPD/ZAPD.out(_Z7NewMainiPPc+0x34c)[0x563c2e0dd0dc]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf2)[0x7f5036311cb2]
tools/ZAPD/ZAPD.out(_start+0x2e)[0x563c2e0d755e]
```

</details>

With this change, the crash backtrace would look like:

<details>
<summary>
    Large code block, click to show.
</summary>

```
1   /lib/x86_64-linux-gnu/libc.so.6(+0x41950) [0x7f7d86241950]
2   ZSkeleton::ZSkeleton(tinyxml2::XMLElement*, std::vector<unsigned char, std::allocator<unsigned char> > const&, int, ZFile*) (+0x17F)
3   ZSkeleton::FromXML(tinyxml2::XMLElement*, std::vector<unsigned char, std::allocator<unsigned char> >, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ZFile*) (+0x5F)
4   ZFile::ParseXML(ZFileMode, tinyxml2::XMLElement*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool) (+0x2896)
5   ZFile::ZFile(ZFileMode, tinyxml2::XMLElement*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool) (+0x2AA)
6   Parse(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, ZFileMode) (+0x1A1)
7   NewMain(int, char**) (+0x350)
8   __libc_start_main (+0xF2)
9   _start (+0x2E)
```

</details>

I don't know how portable this change is. We would need to test it in Mac, ARM, WSL, etc. 
Tested architectures:
- [X] Linux x86-64
- [X] Linux ARM aarch64 (thanks @louist103)
- [ ] Mac
- [ ] Mac ARM (?)
- [ ] WSL
- [ ] ~Mips3~

This change would also fix the problem of `make` doing a full compile of ZAPD each the command is run.
Lastly, I changed the remaining `throw`s that threw an string instead of an exception. Also changes the warnings to be printed to `stderr` instead of normal `stdout` for consistency sake.
