### PR TITLE
Add Mtx extraction

### DIFF
--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -1784,9 +1784,24 @@ static int GfxdCallback_DisplayList(uint32_t seg)
 static int GfxdCallback_Matrix(uint32_t seg)
 {
 	string mtxName = "";
+	ZDisplayList* instance = ZDisplayList::static_instance;
 
 	if (Globals::Instance->symbolMap.find(seg) != Globals::Instance->symbolMap.end())
 		mtxName = StringHelper::Sprintf("&%s", Globals::Instance->symbolMap[seg].c_str());
+	else if (Globals::Instance->HasSegment(GETSEGNUM(seg)))
+	{
+		Declaration* decl = instance->parent->GetDeclaration(Seg2Filespace(seg, instance->parent->baseAddress));
+		if (decl == nullptr)
+		{
+			ZMtx mtx(instance->GetName(), instance->fileData, Seg2Filespace(seg, instance->parent->baseAddress), instance->parent);
+			mtx.GetSourceOutputCode(instance->GetName());
+			instance->mtxList.push_back(mtx);
+			mtxName = "&" + mtx.GetName();
+		}
+		else{
+			mtxName = "&" + decl->varName;
+		}
+	}
 	else
 		mtxName = StringHelper::Sprintf("0x%08X", seg);
 

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -1790,15 +1790,18 @@ static int GfxdCallback_Matrix(uint32_t seg)
 		mtxName = StringHelper::Sprintf("&%s", Globals::Instance->symbolMap[seg].c_str());
 	else if (Globals::Instance->HasSegment(GETSEGNUM(seg)))
 	{
-		Declaration* decl = instance->parent->GetDeclaration(Seg2Filespace(seg, instance->parent->baseAddress));
+		Declaration* decl =
+			instance->parent->GetDeclaration(Seg2Filespace(seg, instance->parent->baseAddress));
 		if (decl == nullptr)
 		{
-			ZMtx mtx(instance->GetName(), instance->fileData, Seg2Filespace(seg, instance->parent->baseAddress), instance->parent);
+			ZMtx mtx(instance->GetName(), instance->fileData,
+			         Seg2Filespace(seg, instance->parent->baseAddress), instance->parent);
 			mtx.GetSourceOutputCode(instance->GetName());
 			instance->mtxList.push_back(mtx);
 			mtxName = "&" + mtx.GetName();
 		}
-		else{
+		else
+		{
 			mtxName = "&" + decl->varName;
 		}
 	}

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -3,6 +3,7 @@
 #include "ZResource.h"
 #include "ZRoom/ZRoom.h"
 #include "ZTexture.h"
+#include "ZMtx.h"
 #include "tinyxml2.h"
 
 #include <map>
@@ -360,6 +361,7 @@ public:
 
 	std::string defines;  // Hack for special cases where vertex arrays intersect...
 	std::vector<uint8_t> fileData;
+	std::vector<ZMtx> mtxList;
 
 	ZDisplayList();
 	ZDisplayList(std::vector<uint8_t> nRawData, int rawDataIndex, int rawDataSize);

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -1,9 +1,9 @@
 #pragma once
 
+#include "ZMtx.h"
 #include "ZResource.h"
 #include "ZRoom/ZRoom.h"
 #include "ZTexture.h"
-#include "ZMtx.h"
 #include "tinyxml2.h"
 
 #include <map>

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -13,6 +13,7 @@
 #include "ZCutscene.h"
 #include "ZDisplayList.h"
 #include "ZLimb.h"
+#include "ZMtx.h"
 #include "ZRoom/ZRoom.h"
 #include "ZScalar.h"
 #include "ZSkeleton.h"
@@ -402,6 +403,21 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 				resources.push_back(array);
 				rawDataIndex += array->GetRawDataSize();
 			}
+		}
+		else if (string(child->Name()) == "Mtx")
+		{
+			ZMtx* mtx = nullptr;
+
+			if (mode == ZFileMode::Extract)
+			{
+				mtx = ZMtx::ExtractFromXML(child, rawData, rawDataIndex, this);
+			}
+
+			if (mtx == nullptr)
+			{
+				throw std::runtime_error("Couldn't create ZMtx.");
+			}
+			resources.push_back(mtx);
 		}
 		else
 		{

--- a/ZAPD/ZMtx.cpp
+++ b/ZAPD/ZMtx.cpp
@@ -70,12 +70,12 @@ std::string ZMtx::GetBodySourceCode()
 	std::string bodyStr = "\n";
     for (const auto& row: mtx)
     {
-        bodyStr += "    { ";
+        bodyStr += "    ";
         for (int32_t val: row)
         {
             bodyStr += StringHelper::Sprintf("%-11i, ", val);
         }
-        bodyStr += "},\n";
+        bodyStr += "\n";
     }
     return bodyStr;
 }

--- a/ZAPD/ZMtx.cpp
+++ b/ZAPD/ZMtx.cpp
@@ -3,8 +3,8 @@
 #include "StringHelper.h"
 #include "ZFile.h"
 
-
-ZMtx::ZMtx(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent)
+ZMtx::ZMtx(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex,
+           ZFile* nParent)
 {
 	rawData.assign(nRawData.begin(), nRawData.end());
 	rawDataIndex = nRawDataIndex;
@@ -14,7 +14,8 @@ ZMtx::ZMtx(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, i
 	ParseRawData();
 }
 
-ZMtx::ZMtx(const std::string& prefix, const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent)
+ZMtx::ZMtx(const std::string& prefix, const std::vector<uint8_t>& nRawData, int nRawDataIndex,
+           ZFile* nParent)
 {
 	rawData.assign(nRawData.begin(), nRawData.end());
 	rawDataIndex = nRawDataIndex;
@@ -29,86 +30,84 @@ void ZMtx::ParseRawData()
 {
 	ZResource::ParseRawData();
 
-    for (size_t i = 0; i < 4; ++i)
-    {
-        for (size_t j = 0; j < 4; ++j)
-        {
-            mtx[i][j] = BitConverter::ToInt32BE(rawData, rawDataIndex + (i*4 + j) * 4);
-        }
-    }
+	for (size_t i = 0; i < 4; ++i)
+	{
+		for (size_t j = 0; j < 4; ++j)
+		{
+			mtx[i][j] = BitConverter::ToInt32BE(rawData, rawDataIndex + (i * 4 + j) * 4);
+		}
+	}
 }
 
-ZMtx* ZMtx::ExtractFromXML(tinyxml2::XMLElement* reader,
-            const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent)
+ZMtx* ZMtx::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
+                           int nRawDataIndex, ZFile* nParent)
 {
 	ZMtx* mtx = new ZMtx(reader, nRawData, nRawDataIndex, nParent);
 
-    mtx->DeclareVar("", "");
+	mtx->DeclareVar("", "");
 
 	return mtx;
 }
 
 int ZMtx::GetRawDataSize()
 {
-    return 64;
+	return 64;
 }
 
 void ZMtx::DeclareVar(const std::string& prefix, const std::string& bodyStr)
 {
-    std::string auxName = name;
-    if (name == "")
-    {
-        auxName = GetDefaultName(prefix, rawDataIndex);
-    }
-    parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align8, GetRawDataSize(),
-                            GetSourceTypeName(), auxName, bodyStr);
+	std::string auxName = name;
+	if (name == "")
+	{
+		auxName = GetDefaultName(prefix, rawDataIndex);
+	}
+	parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align8, GetRawDataSize(),
+	                       GetSourceTypeName(), auxName, bodyStr);
 }
-
 
 std::string ZMtx::GetBodySourceCode()
 {
 	std::string bodyStr = "\n";
-    for (const auto& row: mtx)
-    {
-        bodyStr += "    ";
-        for (int32_t val: row)
-        {
-            bodyStr += StringHelper::Sprintf("%-11i, ", val);
-        }
-        bodyStr += "\n";
-    }
-    return bodyStr;
+	for (const auto& row : mtx)
+	{
+		bodyStr += "    ";
+		for (int32_t val : row)
+		{
+			bodyStr += StringHelper::Sprintf("%-11i, ", val);
+		}
+		bodyStr += "\n";
+	}
+	return bodyStr;
 }
 
 std::string ZMtx::GetSourceOutputCode(const std::string& prefix)
 {
-    std::string bodyStr = GetBodySourceCode();
+	std::string bodyStr = GetBodySourceCode();
 
 	Declaration* decl = parent->GetDeclaration(rawDataIndex);
 	if (decl == nullptr)
 	{
-        DeclareVar(prefix, bodyStr);
+		DeclareVar(prefix, bodyStr);
 	}
 	else
 	{
 		decl->text = bodyStr;
 	}
 
-    return "";
+	return "";
 }
 
 std::string ZMtx::GetDefaultName(const std::string& prefix, uint32_t address)
 {
-    return StringHelper::Sprintf("%sMtx_%06X", prefix.c_str(), address);
+	return StringHelper::Sprintf("%sMtx_%06X", prefix.c_str(), address);
 }
 
 std::string ZMtx::GetSourceTypeName()
 {
-    return "Mtx";
+	return "Mtx";
 }
 
 ZResourceType ZMtx::GetResourceType()
 {
-    return ZResourceType::Mtx;
+	return ZResourceType::Mtx;
 }
-

--- a/ZAPD/ZMtx.cpp
+++ b/ZAPD/ZMtx.cpp
@@ -1,0 +1,114 @@
+#include "ZMtx.h"
+#include "BitConverter.h"
+#include "StringHelper.h"
+#include "ZFile.h"
+
+
+ZMtx::ZMtx(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent)
+{
+	rawData.assign(nRawData.begin(), nRawData.end());
+	rawDataIndex = nRawDataIndex;
+	parent = nParent;
+
+	ParseXML(reader);
+	ParseRawData();
+}
+
+ZMtx::ZMtx(const std::string& prefix, const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent)
+{
+	rawData.assign(nRawData.begin(), nRawData.end());
+	rawDataIndex = nRawDataIndex;
+	parent = nParent;
+
+	name = GetDefaultName(prefix.c_str(), rawDataIndex);
+
+	ParseRawData();
+}
+
+void ZMtx::ParseRawData()
+{
+	ZResource::ParseRawData();
+
+    for (size_t i = 0; i < 4; ++i)
+    {
+        for (size_t j = 0; j < 4; ++j)
+        {
+            mtx[i][j] = BitConverter::ToInt32BE(rawData, rawDataIndex + (i*4 + j) * 4);
+        }
+    }
+}
+
+ZMtx* ZMtx::ExtractFromXML(tinyxml2::XMLElement* reader,
+            const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent)
+{
+	ZMtx* mtx = new ZMtx(reader, nRawData, nRawDataIndex, nParent);
+
+    mtx->DeclareVar("", "");
+
+	return mtx;
+}
+
+int ZMtx::GetRawDataSize()
+{
+    return 64;
+}
+
+void ZMtx::DeclareVar(const std::string& prefix, const std::string& bodyStr)
+{
+    std::string auxName = name;
+    if (name == "")
+    {
+        auxName = GetDefaultName(prefix, rawDataIndex);
+    }
+    parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align8, GetRawDataSize(),
+                            GetSourceTypeName(), auxName, bodyStr);
+}
+
+
+std::string ZMtx::GetBodySourceCode()
+{
+	std::string bodyStr = "\n";
+    for (const auto& row: mtx)
+    {
+        bodyStr += "    { ";
+        for (int32_t val: row)
+        {
+            bodyStr += StringHelper::Sprintf("%-11i, ", val);
+        }
+        bodyStr += "},\n";
+    }
+    return bodyStr;
+}
+
+std::string ZMtx::GetSourceOutputCode(const std::string& prefix)
+{
+    std::string bodyStr = GetBodySourceCode();
+
+	Declaration* decl = parent->GetDeclaration(rawDataIndex);
+	if (decl == nullptr)
+	{
+        DeclareVar(prefix, bodyStr);
+	}
+	else
+	{
+		decl->text = bodyStr;
+	}
+
+    return "";
+}
+
+std::string ZMtx::GetDefaultName(const std::string& prefix, uint32_t address)
+{
+    return StringHelper::Sprintf("%sMtx_%06X", prefix.c_str(), address);
+}
+
+std::string ZMtx::GetSourceTypeName()
+{
+    return "Mtx";
+}
+
+ZResourceType ZMtx::GetResourceType()
+{
+    return ZResourceType::Mtx;
+}
+

--- a/ZAPD/ZMtx.h
+++ b/ZAPD/ZMtx.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <cstdint>
 #include <array>
+#include <cstdint>
 #include "ZResource.h"
-
 
 class ZMtx : public ZResource
 {
@@ -13,12 +12,12 @@ protected:
 public:
 	ZMtx() = default;
 	ZMtx(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex,
-	          ZFile* nParent);
-	ZMtx(const std::string& prefix,
-	          const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent);
+	     ZFile* nParent);
+	ZMtx(const std::string& prefix, const std::vector<uint8_t>& nRawData, int nRawDataIndex,
+	     ZFile* nParent);
 	void ParseRawData() override;
-	static ZMtx* ExtractFromXML(tinyxml2::XMLElement* reader,
-				const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent);
+	static ZMtx* ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
+	                            int nRawDataIndex, ZFile* nParent);
 
 	int GetRawDataSize() override;
 

--- a/ZAPD/ZMtx.h
+++ b/ZAPD/ZMtx.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <array>
+#include "ZResource.h"
+
+
+class ZMtx : public ZResource
+{
+protected:
+	std::array<std::array<int32_t, 4>, 4> mtx;
+
+public:
+	ZMtx() = default;
+	ZMtx(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData, int nRawDataIndex,
+	          ZFile* nParent);
+	ZMtx(const std::string& prefix,
+	          const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent);
+	void ParseRawData() override;
+	static ZMtx* ExtractFromXML(tinyxml2::XMLElement* reader,
+				const std::vector<uint8_t>& nRawData, int nRawDataIndex, ZFile* nParent);
+
+	int GetRawDataSize() override;
+
+	void DeclareVar(const std::string& prefix, const std::string& bodyStr);
+
+	std::string GetBodySourceCode();
+	std::string GetSourceOutputCode(const std::string& prefix) override;
+	static std::string GetDefaultName(const std::string& prefix, uint32_t address);
+
+	std::string GetSourceTypeName() override;
+	ZResourceType GetResourceType() override;
+};

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -42,6 +42,7 @@ enum class ZResourceType
 	Vertex,
 	CollisionHeader,
 	Symbol,
+	Mtx,
 };
 
 class ZResource


### PR DESCRIPTION
Adds a new tag `<Mtx>` to extract RDP matrices.
The `<Mtx>` tag just needs a name and an offset.
Also adds the ability to display lists to extract Mtx which are in the same file.
