### PR TITLE
OutputFormatter fixes

### DIFF
--- a/ZAPD/OutputFormatter.cpp
+++ b/ZAPD/OutputFormatter.cpp
@@ -1,60 +1,80 @@
 #include "OutputFormatter.h"
 
+void OutputFormatter::Flush()
+{
+	if (col > lineLimit)
+	{
+		str.append(1, '\n');
+		str.append(currentIndent, ' ');
+
+		int newCol = currentIndent + (wordP - word);
+
+		for (int i = 0; i < wordNests; i++)
+			nestIndent[nest - i] -= col - newCol;
+
+		col = newCol;
+	}
+	else
+	{
+		str.append(space, spaceP - space);
+	}
+	spaceP = space;
+
+	str.append(word, wordP - word);
+	wordP = word;
+	wordNests = 0;
+}
+
 int OutputFormatter::Write(const char* buf, int count)
 {
 	for (int i = 0; i < count; i++)
 	{
 		char c = buf[i];
 
-		if (c == '\n')
+		if (c == ' ' || c == '\t' || c == '\n')
 		{
-			col = 0;
+			if (wordP - word != 0)
+			{
+				Flush();
+			}
+
+			if (c == '\n')
+			{
+				col = 0;
+				*spaceP++ = c;
+			}
+			else if (c == '\t')
+			{
+				int n = tabSize - (col % tabSize);
+				col += n;
+				for (int j = 0; j < n; j++)
+					*spaceP++ = ' ';
+			}
+			else
+			{
+				col++;
+				*spaceP++ = c;
+			}
+
 			currentIndent = nestIndent[nest];
-		}
-		else if (c == '\t')
-		{
-			int n = tabSize - (col % tabSize);
-			for (int j = 0; j < n - 1; j++)
-				*spaceP++ = ' ';
-			c = ' ';
-			col += n;
 		}
 		else
 		{
 			col++;
-		}
 
-		if (c == '(')
-		{
-			nest++;
-			nestIndent[nest] = col;
-			currentIndent = col;
-		}
-		else if (c == ')')
-		{
-			nest--;
-		}
-
-		if (c == ' ' || c == '\t' || c == '\n')
-		{
-			str.append(word, wordP - word);
-			wordP = word;
-
-			*spaceP++ = c;
-		}
-		else
-		{
-			if (col > lineLimit)
+			if (c == '(')
 			{
-				str.append(1, '\n');
-				str.append(currentIndent, ' ');
-				col = currentIndent + 1 + (wordP - word);
+				nest++;
+				nestIndent[nest] = col;
+				wordNests++;
 			}
-			else
+			else if (c == ')')
 			{
-				str.append(space, spaceP - space);
+				if (nest > 0)
+					nest--;
+				if (wordNests > 0)
+					wordNests--;
 			}
-			spaceP = space;
 
 			*wordP++ = c;
 		}
@@ -78,17 +98,13 @@ int (*OutputFormatter::StaticWriter())(const char* buf, int count)
 
 OutputFormatter::OutputFormatter(int tabSize, int defaultIndent, int lineLimit)
 	: tabSize{tabSize}, defaultIndent{defaultIndent}, lineLimit{lineLimit}, col{0}, nest{0},
-	  nestIndent{defaultIndent}, currentIndent{defaultIndent}, wordP{word}, spaceP{space}
+	  nestIndent{defaultIndent}, currentIndent{defaultIndent}, wordNests(0), wordP{word}, spaceP{space}
 {
 }
 
 std::string OutputFormatter::GetOutput()
 {
-	str.append(space, spaceP - space);
-	spaceP = space;
-
-	str.append(word, wordP - word);
-	wordP = word;
+	Flush();
 
 	return std::move(str);
 }

--- a/ZAPD/OutputFormatter.h
+++ b/ZAPD/OutputFormatter.h
@@ -15,6 +15,7 @@ private:
 	int nest;
 	int nestIndent[8];
 	int currentIndent;
+	int wordNests;
 
 	char word[128];
 	char space[128];
@@ -23,7 +24,7 @@ private:
 
 	std::string str;
 
-	int Write(const char* buf, int count);
+	void Flush();
 
 	static OutputFormatter* Instance;
 	static int WriteStatic(const char* buf, int count);
@@ -32,6 +33,8 @@ public:
 	OutputFormatter(int tabSize = 4, int defaultIndent = 4, int lineLimit = 120);
 
 	int (*StaticWriter())(const char* buf, int count);
+
+	int Write(const char* buf, int count);
 
 	std::string GetOutput();
 };


### PR DESCRIPTION
Fixes some weird formatting issues that were observed in `assets/overlays/ovl_Boss_Sst/ovl_Boss_Sst.c` of the oot repo.

Excerpt of output before changes:
```
Gfx sHandTrailDList[] = {
    gsDPPipeSync(),
    gsDPSetCombineLERP(0, 0, 0, PRIMITIVE, 0, 0, 0, PRIMITIVE, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
    gsDPSetRenderMode(AA_EN | Z_CMP | Z_UPD | IM_RD | CLR_ON_CVG | CVG_DST_WRAP | ZMODE_XLU | FORCE_BL | G_RM_PASS, 
                      AA_EN | Z_CMP | Z_UPD | IM_RD | CLR_ON_CVG | CVG_DST_WRAP | ZMODE_XLU | FORCE_BL | 
                                                                                                                
                                                                                                                
                                                                                                                
                                                                                                                GBL_c2(G_BL_CLR_IN,
                                                                                                                
                                                                                                                
                                                                                                                G_BL_A_IN,
                                                                                                                
                                                                                                                
                                                                                                                
                                                                                                                
                                                                                                                
                                                                                                                G_BL_CLR_MEM,
                                                                                                                
                                                                                                                
                                                                                                                
                                                                                                                G_BL_1MA)),
    gsSPEndDisplayList(),
};
```

After changes:
```
Gfx sHandTrailDList[] = {
    gsDPPipeSync(),
    gsDPSetCombineLERP(0, 0, 0, PRIMITIVE, 0, 0, 0, PRIMITIVE, COMBINED, 0, SHADE, 0, 0, 0, 0, COMBINED),
    gsDPSetRenderMode(AA_EN | Z_CMP | Z_UPD | IM_RD | CLR_ON_CVG | CVG_DST_WRAP | ZMODE_XLU | FORCE_BL | G_RM_PASS,
                      AA_EN | Z_CMP | Z_UPD | IM_RD | CLR_ON_CVG | CVG_DST_WRAP | ZMODE_XLU | FORCE_BL |
                      GBL_c2(G_BL_CLR_IN, G_BL_A_IN, G_BL_CLR_MEM, G_BL_1MA)),
    gsSPEndDisplayList(),
}; 
```
