### PR TITLE
Texture Pool Fully Implemented

### DIFF
--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -152,14 +152,10 @@ void Globals::ReadTexturePool(const std::string& texturePoolXmlPath)
 			string crcStr = string(child->Attribute("CRC"));
 			string texPath = string(child->Attribute("Path"));
 			string texName = "";
-			
-			if (child->Attribute("Name") != nullptr)
-				texName = string(child->Attribute("Name"));
 
 			uint32_t crc = strtoul(crcStr.c_str(), NULL, 16);
 
 			cfg.texturePool[crc].path = texPath;
-			cfg.texturePool[crc].name = texName;
 		}
 	}
 }

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -151,8 +151,15 @@ void Globals::ReadTexturePool(const std::string& texturePoolXmlPath)
 		{
 			string crcStr = string(child->Attribute("CRC"));
 			string texPath = string(child->Attribute("Path"));
+			string texName = "";
+			
+			if (child->Attribute("Name") != nullptr)
+				texName = string(child->Attribute("Name"));
 
-			cfg.texturePool[strtol(crcStr.c_str(), NULL, 16)] = texPath;
+			uint32_t crc = strtoul(crcStr.c_str(), NULL, 16);
+
+			cfg.texturePool[crc].path = texPath;
+			cfg.texturePool[crc].name = texName;
 		}
 	}
 }

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -17,7 +17,6 @@ enum VerbosityLevel
 struct TexturePoolEntry
 {
 	std::string path = ""; // Path to Shared Texture
-	std::string name = ""; // Symbol Name of Texture
 };
 
 class GameConfig

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -14,6 +14,12 @@ enum VerbosityLevel
 	VERBOSITY_DEBUG
 };
 
+struct TexturePoolEntry
+{
+	std::string path = ""; // Path to Shared Texture
+	std::string name = ""; // Symbol Name of Texture
+};
+
 class GameConfig
 {
 public:
@@ -22,7 +28,7 @@ public:
 	std::map<uint32_t, std::string> symbolMap;
 	std::vector<std::string> actorList;
 	std::vector<std::string> objectList;
-	std::map<uint32_t, std::string> texturePool;  // Key = CRC, Value = Path to Shared Texture
+	std::map<uint32_t, TexturePoolEntry> texturePool;  // Key = CRC
 
 	GameConfig() = default;
 };

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -2331,11 +2331,6 @@ ZResourceType ZDisplayList::GetResourceType()
 	return ZResourceType::DisplayList;
 }
 
-vector<uint8_t> ZDisplayList::GetRawData()
-{
-	return rawData;
-}
-
 int ZDisplayList::GetRawDataSize()
 {
 	return (int)instructions.size() * 8;

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -1678,24 +1678,7 @@ static int GfxdCallback_Texture(segptr_t seg, int32_t fmt, int32_t siz, int32_t 
 	instance->lastTexLoaded = true;
 	instance->lastTexIsPalette = false;
 
-	if (texOffset == 0x37960)
-	{
-		int bp = 0;
-	}
-
 	instance->TextureGenCheck(instance->curPrefix);
-	
-	// TEXTURE POOL CHECK
-	if (instance->textures.find(texOffset) != instance->textures.end())
-	{
-		if (texOffset == 0x37B60)
-		{
-			int bp = 0;
-		}
-
-		ZTexture* texTest = instance->textures[texOffset];
-		//texName = instance->textures[texOffset]->GetPoolOutName(texName);
-	}
 	
 	gfxd_puts(texName.c_str());
 
@@ -1984,13 +1967,8 @@ string ZDisplayList::GetSourceOutputCode(const std::string& prefix)
 			{
 				if (parent->GetDeclaration(item.first) == nullptr)
 				{
-					if (item.first == 0xD890)
-					{
-						int bp = 0;
-					}
-
+					// TEXTURE POOL CHECK
 					std::string texOutPath = item.second->GetPoolOutPath(Globals::Instance->outputPath);
-					//std::string texOutName = item.second->GetPoolOutName(item.second->GetName());
 					std::string texOutName = item.second->GetName();
 
 					auto start = chrono::steady_clock::now();
@@ -2006,17 +1984,7 @@ string ZDisplayList::GetSourceOutputCode(const std::string& prefix)
 						"%s/%s.%s.inc.c", texOutPath.c_str(),
 						Path::GetFileNameWithoutExtension(texOutName).c_str(),
 						item.second->GetExternalExtension().c_str());
-					//std::string texName = item.second->GetPoolOutName(StringHelper::Sprintf("%sTex_%06X", prefix.c_str(), item.first));
 					std::string texName = StringHelper::Sprintf("%sTex_%06X", prefix.c_str(), item.first);
-
-
-					// TEXTURE POOL CHECK
-					//if (Globals::Instance->cfg.texturePool.find(item.second->hash) !=
-					//    Globals::Instance->cfg.texturePool.end())
-					//{
-					//	incStr = Globals::Instance->cfg.texturePool[item.second->hash];
-					//	texName = Path::GetFileNameWithoutExtension(incStr);
-					//}
 
 					parent->AddDeclarationIncludeArray(
 						item.first, incStr, item.second->GetRawDataSize(), "u64", texName, 0);

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -2302,7 +2302,7 @@ ZResourceType ZDisplayList::GetResourceType()
 	return ZResourceType::DisplayList;
 }
 
-int ZDisplayList::GetRawDataSize()
+size_t ZDisplayList::GetRawDataSize()
 {
 	return instructions.size() * 8;
 }

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -382,7 +382,6 @@ public:
 	                            bool texIsPalette);
 	static int GetDListLength(std::vector<uint8_t> rawData, int rawDataIndex, DListType dListType);
 
-	std::vector<uint8_t> GetRawData() override;
 	int GetRawDataSize() override;
 	std::string GetSourceOutputHeader(const std::string& prefix) override;
 	std::string GetSourceOutputCode(const std::string& prefix) override;

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -383,7 +383,7 @@ public:
 	                            bool texIsPalette);
 	static int32_t GetDListLength(std::vector<uint8_t> rawData, uint32_t rawDataIndex, DListType dListType);
 
-	int GetRawDataSize() override;
+	size_t GetRawDataSize() override;
 	std::string GetSourceOutputHeader(const std::string& prefix) override;
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 	std::string ProcessLegacy(const std::string& prefix);

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -589,15 +589,7 @@ void ZFile::GenerateSourceFiles(string outputDir)
 				if (Globals::Instance->cfg.texturePool.find(tex->hash) !=
 				    Globals::Instance->cfg.texturePool.end())
 				{
-					if (res->GetRawDataIndex() == 0xF0A0)
-					{
-						int bp = 0;
-					}
-
-					//incStr = Globals::Instance->cfg.texturePool[tex->hash].path + ".inc";
 					incStr = Globals::Instance->cfg.texturePool[tex->hash].path + "." + res->GetExternalExtension() + ".inc";
-					//res->SetName(Path::GetFileNameWithoutExtension(incStr));
-					//res->SetName(tex->GetPoolOutName(res->GetName()));
 				}
 
 				incStr += ".c";

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -578,12 +578,26 @@ void ZFile::GenerateSourceFiles(string outputDir)
 			{
 				ZTexture* tex = (ZTexture*)res;
 
-				// POOL CHECK
+				tex->CalcHash();
+
+				if (res->GetRawDataIndex() == 0xF0A0)
+				{
+					int bp = 0;
+				}
+
+				// TEXTURE POOL CHECK
 				if (Globals::Instance->cfg.texturePool.find(tex->hash) !=
 				    Globals::Instance->cfg.texturePool.end())
 				{
-					incStr = Globals::Instance->cfg.texturePool[tex->hash];
-					res->SetName(Path::GetFileNameWithoutExtension(incStr));
+					if (res->GetRawDataIndex() == 0xF0A0)
+					{
+						int bp = 0;
+					}
+
+					//incStr = Globals::Instance->cfg.texturePool[tex->hash].path + ".inc";
+					incStr = Globals::Instance->cfg.texturePool[tex->hash].path + "." + res->GetExternalExtension() + ".inc";
+					//res->SetName(Path::GetFileNameWithoutExtension(incStr));
+					//res->SetName(tex->GetPoolOutName(res->GetName()));
 				}
 
 				incStr += ".c";
@@ -880,11 +894,10 @@ string ZFile::ProcessDeclarations()
 				if (diff > 0)
 				{
 					std::string unaccountedPrefix = "unaccounted";
-					if (diff < 16 && !nonZeroUnaccounted)
-					{
-						unaccountedPrefix = "possiblePadding";
-					}
 
+					if (diff < 16 && !nonZeroUnaccounted)
+						unaccountedPrefix = "possiblePadding";
+					
 					Declaration* decl = AddDeclarationArray(
 						unaccountedAddress, DeclarationAlignment::None, diff, "static u8",
 						StringHelper::Sprintf("%s_%06X", unaccountedPrefix.c_str(),

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -526,14 +526,16 @@ string ZRoom::GetSourceOutputCode(const std::string& prefix)
 
 		declaration += item.second->GetSourceOutputCode(prefix);
 
-		if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
-			printf("SAVING IMAGE TO %s\n", Globals::Instance->outputPath.c_str());
+		std::string outPath = item.second->GetPoolOutPath(Globals::Instance->outputPath);
 
-		item.second->Save(Globals::Instance->outputPath);
+		if (Globals::Instance->verbosity >= VERBOSITY_DEBUG)
+			printf("SAVING IMAGE TO %s\n", outPath.c_str());
+
+		item.second->Save(outPath);
 
 		parent->AddDeclarationIncludeArray(
 			item.first,
-			StringHelper::Sprintf("%s/%s.%s.inc.c", Globals::Instance->outputPath.c_str(),
+			StringHelper::Sprintf("%s/%s.%s.inc.c", outPath.c_str(),
 		                          Path::GetFileNameWithoutExtension(item.second->GetName()).c_str(),
 		                          item.second->GetExternalExtension().c_str()),
 			item.second->GetRawDataSize(), "u64",

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -547,11 +547,6 @@ string ZRoom::GetSourceOutputCode(const std::string& prefix)
 	return sourceOutput;
 }
 
-vector<uint8_t> ZRoom::GetRawData()
-{
-	return rawData;
-}
-
 int ZRoom::GetRawDataSize()
 {
 	int32_t size = 0;

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -548,7 +548,7 @@ string ZRoom::GetSourceOutputCode(const std::string& prefix)
 	return sourceOutput;
 }
 
-int ZRoom::GetRawDataSize()
+size_t ZRoom::GetRawDataSize()
 {
 	size_t size = 0;
 

--- a/ZAPD/ZRoom/ZRoom.h
+++ b/ZAPD/ZRoom/ZRoom.h
@@ -36,7 +36,6 @@ public:
 	size_t GetDeclarationSizeFromNeighbor(int declarationAddress);
 	size_t GetCommandSizeFromNeighbor(ZRoomCommand* cmd);
 	ZRoomCommand* FindCommandOfType(RoomCommand cmdType);
-	std::vector<uint8_t> GetRawData();
 	int GetRawDataSize();
 	virtual ZResourceType GetResourceType();
 	virtual void Save(const std::string& outFolder);

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -792,7 +792,7 @@ void ZTexture::Save(const std::string& outFolder)
 {
 	//CalcHash();
 
-	// Optionally generate text file containing CRC information
+	// Optionally generate text file containing CRC information. This is going to be a one time process for generating the Texture Pool XML.
 	if (Globals::Instance->testMode)
 	{
 		if (hash != 0)
@@ -803,13 +803,7 @@ void ZTexture::Save(const std::string& outFolder)
 		}
 	}
 
-	if (rawDataIndex == 0xC160)
-	{
-		int bp = 0;
-	}
-
 	std::string outPath = GetPoolOutPath(outFolder);
-	//outName = GetPoolOutName(outName);
 
 	if (!Directory::Exists(outPath))
 		Directory::CreateDirectory(outPath);
@@ -894,24 +888,11 @@ void ZTexture::CalcHash()
 {
 	// Make sure raw data is fixed before we calc the hash...
 	bool fixFlag = !isRawDataFixed;
-
-	if (rawDataIndex == 0x37B60)
-	{
-		//uint32_t hashA = CRC32B(rawData.data(), GetRawDataSize());
-		//FixRawData();
-		//uint32_t hashB = CRC32B(rawData.data(), GetRawDataSize());
-		int bp = 0;
-	}
 	
 	if (fixFlag)
 		FixRawData();
 
 	hash = CRC32B(rawData.data(), GetRawDataSize());
-
-	if (hash == 0x16CCF21D)
-	{
-		int bp = 0;
-	}
 
 	if (fixFlag)
 		FixRawData();
@@ -948,21 +929,6 @@ std::string ZTexture::GetPoolOutPath(std::string defaultValue)
 {
 	if (Globals::Instance->cfg.texturePool.find(hash) != Globals::Instance->cfg.texturePool.end())
 		return Path::GetDirectoryName(Globals::Instance->cfg.texturePool[hash].path);
-
-	return defaultValue;
-}
-
-std::string ZTexture::GetPoolOutName(std::string defaultValue)
-{
-	if (Globals::Instance->cfg.texturePool.find(hash) != Globals::Instance->cfg.texturePool.end())
-	{
-		TexturePoolEntry entry = Globals::Instance->cfg.texturePool[hash];
-		
-		if (entry.name == "")
-			return Path::GetFileNameWithoutExtension(entry.path);
-		else
-			return entry.name;
-	}
 
 	return defaultValue;
 }

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -710,11 +710,6 @@ float ZTexture::GetPixelMultiplyer()
 	}
 }
 
-vector<uint8_t> ZTexture::GetRawData()
-{
-	return rawData;
-}
-
 int ZTexture::GetRawDataSize()
 {
 	return (int)(width * height * GetPixelMultiplyer());

--- a/ZAPD/ZTexture.h
+++ b/ZAPD/ZTexture.h
@@ -89,7 +89,6 @@ public:
 	void Save(const std::string& outFolder) override;
 	std::string GetExternalExtension() override;
 	std::string GetPoolOutPath(std::string defaultValue);
-	std::string GetPoolOutName(std::string defaultValue);
 	void CalcHash() override;
 
 	bool IsExternalResource() override;

--- a/ZAPD/ZTexture.h
+++ b/ZAPD/ZTexture.h
@@ -28,6 +28,7 @@ protected:
 
 	uint8_t* bmpRgb;
 	uint8_t* bmpRgba;
+	bool isRawDataFixed;
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void FixRawData();
@@ -56,7 +57,6 @@ protected:
 	void PrepareRawDataPalette4(std::string palPath);
 	void PrepareRawDataPalette8(std::string palPath);
 	float GetPixelMultiplyer();
-	void CalcHash() override;
 
 public:
 	ZTexture(ZFile* nParent);
@@ -88,6 +88,9 @@ public:
 	TextureType GetTextureType();
 	void Save(const std::string& outFolder) override;
 	std::string GetExternalExtension() override;
+	std::string GetPoolOutPath(std::string defaultValue);
+	std::string GetPoolOutName(std::string defaultValue);
+	void CalcHash() override;
 
 	bool IsExternalResource() override;
 	std::string GetSourceTypeName() override;

--- a/ZAPD/ZTexture.h
+++ b/ZAPD/ZTexture.h
@@ -77,7 +77,6 @@ public:
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 	std::string GetSourceOutputHeader(const std::string& prefix) override;
 
-	std::vector<uint8_t> GetRawData() override;
 	int GetRawDataSize() override;
 	std::string GetIMFmtFromType();
 	std::string GetIMSizFromType();


### PR DESCRIPTION
Ocarina of Time (and mostly likely Majora too) have a large number of duplicated textures across files. This update keeps track of those duplicates through an XML file containing a list of CRCs and the path of the "shared texture". The XML file looks something like this:

```xml
    <Texture CRC="025B6C9A" Path="assets/textures/shared/cucco_icon"/>
    <Texture CRC="1D5C3BC6" Path="assets/textures/shared/pocket_egg"/>
    <Texture CRC="FAA79704" Path="assets/textures/shared/bomb_item_name_fra"/>
    <Texture CRC="E8908EDA" Path="assets/textures/shared/haunted_wasteland_minimap"/>
    <Texture CRC="FFBFEAD1" Path="assets/textures/shared/fire_temple_room_13_floor_3_minimap"/>
    <Texture CRC="E17C45AB" Path="assets/textures/shared/fire_temple_room_5_floor_3_minimap"/>
```

When ZAPD sees finds a CRC match for a texture, it `#include`'s the `.inc.c` from this XML while still maintaining the original symbol name.
    