### PR TITLE
Fix `-export-dynamic` in mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OPTIMIZATION_ON ?= 1
 CC := g++
 INC := -I ZAPD -I lib/assimp/include -I lib/elfio -I lib/json/include -I lib/stb -I lib/tinygltf -I lib/libgfxd -I lib/tinyxml2
 
-CFLAGS := -g3 -fpic -Wl,-export-dynamic -std=c++17 -rdynamic -Wall
+CFLAGS := -g3 -fpic -std=c++17 -rdynamic -Wall
 ifeq ($(OPTIMIZATION_ON),1)
   CFLAGS += -O2
 else
@@ -16,6 +16,7 @@ UNAME := $(shell uname)
 FS_INC =
 ifneq ($(UNAME), Darwin)
     FS_INC += -lstdc++fs
+	CFLAGS += -Wl,-export-dynamic
 endif
 
 SRC_DIRS := ZAPD ZAPD/ZRoom ZAPD/ZRoom/Commands ZAPD/Overlays ZAPD/HighLevel ZAPD/OpenFBX


### PR DESCRIPTION
`-Wl,-export-dynamic` doesn't work well in Mac/clang.
This was needed to unmangle the traceback, since it isn't a critical feature, then it will be disabled for them.