### PR TITLE
Add a `format` rule to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,12 @@ ifneq ($(UNAME), Darwin)
 	CFLAGS += -Wl,-export-dynamic
 endif
 
-SRC_DIRS := ZAPD ZAPD/ZRoom ZAPD/ZRoom/Commands ZAPD/Overlays ZAPD/HighLevel ZAPD/OpenFBX
+SRC_DIRS := ZAPD ZAPD/ZRoom ZAPD/ZRoom/Commands ZAPD/Overlays ZAPD/HighLevel
 
-CPP_FILES := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.cpp))
-CPP_FILES += lib/tinyxml2/tinyxml2.cpp
+ZAPD_CPP_FILES := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.cpp))
+ZAPD_H_FILES   := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.h))
+
+CPP_FILES += $(ZAPD_CPP_FILES) lib/tinyxml2/tinyxml2.cpp
 O_FILES   := $(CPP_FILES:.cpp=.o)
 
 all: ZAPD.out copycheck
@@ -38,6 +40,11 @@ clean:
 	$(MAKE) -C lib/libgfxd clean
 
 rebuild: clean all
+
+format:
+	clang-format-11 -i $(ZAPD_CPP_FILES) $(ZAPD_H_FILES)
+
+.PHONY: all genbuildinfo copycheck clean rebuild format
 
 %.o: %.cpp
 	$(CC) $(CFLAGS) $(INC) -c $< -o $@ $(LDFLAGS)

--- a/ZAPD/HighLevel/HLModelIntermediette.cpp
+++ b/ZAPD/HighLevel/HLModelIntermediette.cpp
@@ -875,7 +875,8 @@ void HLTextureIntermediette::InitFromXML(tinyxml2::XMLElement* xmlElement)
 
 	// tex = HLTexture::FromPNG(fileName,
 	// (HLTextureType)ZTexture::GetTextureTypeFromString(format));
-	tex = ZTexture::FromPNG(Path::GetDirectoryName(Globals::Instance->inputPath.string()) + "/" + fileName,
+	tex = ZTexture::FromPNG(Path::GetDirectoryName(Globals::Instance->inputPath.string()) + "/" +
+	                            fileName,
 	                        ZTexture::GetTextureTypeFromString(format));
 }
 

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -182,8 +182,9 @@ int main(int argc, char* argv[])
 			Globals::Instance->texType = ZTexture::GetTextureTypeFromString(argv[i + 1]);
 			i++;
 		}
-		else if (arg == "-cfg")  // Set cfg path (for overlays) 
-								 // TODO: Change the name of this to something else so it doesn't get confused with XML config files.
+		else if (arg == "-cfg")  // Set cfg path (for overlays)
+		                         // TODO: Change the name of this to something else so it doesn't
+		                         // get confused with XML config files.
 		{
 			Globals::Instance->cfgPath = argv[i + 1];
 			i++;
@@ -256,7 +257,8 @@ int main(int argc, char* argv[])
 			                        Path::GetDirectoryName(Globals::Instance->cfgPath.string()));
 
 			if (overlay)
-				File::WriteAllText(Globals::Instance->outputPath.string(), overlay->GetSourceOutputCode(""));
+				File::WriteAllText(Globals::Instance->outputPath.string(),
+				                   overlay->GetSourceOutputCode(""));
 		}
 	}
 	catch (std::runtime_error& e)

--- a/ZAPD/ZBackground.cpp
+++ b/ZAPD/ZBackground.cpp
@@ -53,7 +53,7 @@ void ZBackground::ParseBinaryFile(const std::string& inFolder, bool appendOutNam
 
 	if (appendOutName)
 		filepath = filepath / (outName + "." + GetExternalExtension());
-	
+
 	data = File::ReadAllBytes(filepath.string());
 
 	// Add padding.
@@ -142,7 +142,8 @@ void ZBackground::DeclareVar(const std::string& prefix, const std::string& bodyS
 		auxName = GetDefaultName(prefix, rawDataIndex);
 
 	parent->AddDeclarationArray(rawDataIndex, DeclarationAlignment::Align8, GetRawDataSize(),
-	                            GetSourceTypeName(), auxName, "SCREEN_WIDTH * SCREEN_HEIGHT / 4", bodyStr);
+	                            GetSourceTypeName(), auxName, "SCREEN_WIDTH * SCREEN_HEIGHT / 4",
+	                            bodyStr);
 }
 
 bool ZBackground::IsExternalResource()

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -350,8 +350,8 @@ Declaration* ZFile::AddDeclarationArray(uint32_t address, DeclarationAlignment a
 }
 
 Declaration* ZFile::AddDeclarationArray(uint32_t address, DeclarationAlignment alignment,
-	size_t size, std::string varType, std::string varName,
-	std::string arrayItemCntStr, std::string body)
+                                        size_t size, std::string varType, std::string varName,
+                                        std::string arrayItemCntStr, std::string body)
 {
 	AddDeclarationDebugChecks(address);
 
@@ -530,7 +530,8 @@ void ZFile::GenerateSourceFiles(fs::path outputDir)
 		{
 			string path = Path::GetFileNameWithoutExtension(res->GetName()).c_str();
 
-			string assetOutDir = (outputDir / Path::GetFileNameWithoutExtension(res->GetOutName())).string();
+			string assetOutDir =
+				(outputDir / Path::GetFileNameWithoutExtension(res->GetOutName())).string();
 			string declType = res->GetSourceTypeName();
 
 			std::string incStr = StringHelper::Sprintf("%s.%s.inc", assetOutDir.c_str(),
@@ -574,7 +575,8 @@ void ZFile::GenerateSourceFiles(fs::path outputDir)
 	sourceOutput += ProcessDeclarations();
 
 	string outPath =
-		(Globals::Instance->sourceOutputPath / (Path::GetFileNameWithoutExtension(name) + ".c")).string();
+		(Globals::Instance->sourceOutputPath / (Path::GetFileNameWithoutExtension(name) + ".c"))
+			.string();
 
 	OutputFormatter formatter;
 	formatter.Write(sourceOutput);
@@ -901,19 +903,19 @@ string ZFile::ProcessDeclarations()
 				if (item.second->arrayItemCntStr != "")
 				{
 					output += StringHelper::Sprintf("%s %s[%s];\n", item.second->varType.c_str(),
-						item.second->varName.c_str(),
-						item.second->arrayItemCntStr.c_str());
+					                                item.second->varName.c_str(),
+					                                item.second->arrayItemCntStr.c_str());
 				}
 				else if (item.second->arrayItemCnt == 0)
 				{
 					output += StringHelper::Sprintf("%s %s[];\n", item.second->varType.c_str(),
-						item.second->varName.c_str());
+					                                item.second->varName.c_str());
 				}
 				else
 				{
 					output += StringHelper::Sprintf("%s %s[%i];\n", item.second->varType.c_str(),
-						item.second->varName.c_str(),
-						item.second->arrayItemCnt);
+					                                item.second->varName.c_str(),
+					                                item.second->arrayItemCnt);
 				}
 			}
 			else
@@ -1001,7 +1003,8 @@ string ZFile::ProcessDeclarations()
 				if (item.second->arrayItemCntStr != "")
 					output += StringHelper::Sprintf(
 						"%s %s[%s] = {\n    #include \"%s\"\n};\n\n", item.second->varType.c_str(),
-						item.second->varName.c_str(), item.second->arrayItemCntStr.c_str(), item.second->includePath.c_str());
+						item.second->varName.c_str(), item.second->arrayItemCntStr.c_str(),
+						item.second->includePath.c_str());
 				else
 					output += StringHelper::Sprintf(
 						"%s %s[] = {\n    #include \"%s\"\n};\n\n", item.second->varType.c_str(),
@@ -1018,16 +1021,16 @@ string ZFile::ProcessDeclarations()
 				{
 					if (item.second->arrayItemCntStr != "")
 					{
-						output += StringHelper::Sprintf("%s %s[%s];\n", item.second->varType.c_str(),
-							item.second->varName.c_str(),
-							item.second->arrayItemCntStr.c_str());
+						output += StringHelper::Sprintf(
+							"%s %s[%s];\n", item.second->varType.c_str(),
+							item.second->varName.c_str(), item.second->arrayItemCntStr.c_str());
 					}
 					else
 					{
 						if (item.second->arrayItemCnt == 0)
 							output +=
-							StringHelper::Sprintf("%s %s[] = {\n", item.second->varType.c_str(),
-								item.second->varName.c_str());
+								StringHelper::Sprintf("%s %s[] = {\n", item.second->varType.c_str(),
+							                          item.second->varName.c_str());
 						else
 							output += StringHelper::Sprintf(
 								"%s %s[%i] = {\n", item.second->varType.c_str(),

--- a/ZAPD/ZFile.h
+++ b/ZAPD/ZFile.h
@@ -59,9 +59,9 @@ public:
 	Declaration* AddDeclarationArray(uint32_t address, DeclarationAlignment alignment, size_t size,
 	                                 std::string varType, std::string varName, size_t arrayItemCnt,
 	                                 std::string body, bool isExternal);
-	Declaration* AddDeclarationArray(uint32_t address, DeclarationAlignment alignment,
-									 size_t size, std::string varType, std::string varName,
-									 std::string arrayItemCntStr, std::string body);
+	Declaration* AddDeclarationArray(uint32_t address, DeclarationAlignment alignment, size_t size,
+	                                 std::string varType, std::string varName,
+	                                 std::string arrayItemCntStr, std::string body);
 	Declaration* AddDeclarationArray(uint32_t address, DeclarationAlignment alignment,
 	                                 DeclarationPadding padding, size_t size, std::string varType,
 	                                 std::string varName, size_t arrayItemCnt, std::string body);

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -149,7 +149,8 @@ public:
 	Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nVarType,
 	            std::string nVarName, bool nIsArray, size_t nArrayItemCnt, std::string nText);
 	Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nVarType,
-		std::string nVarName, bool nIsArray, std::string nArrayItemCntStr, std::string nText);
+	            std::string nVarName, bool nIsArray, std::string nArrayItemCntStr,
+	            std::string nText);
 	Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nVarType,
 	            std::string nVarName, bool nIsArray, size_t nArrayItemCnt, std::string nText,
 	            bool nIsExternal);

--- a/ZAPD/ZRoom/Commands/EndMarker.h
+++ b/ZAPD/ZRoom/Commands/EndMarker.h
@@ -7,7 +7,8 @@ class EndMarker : public ZRoomCommand
 public:
 	EndMarker(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/SetActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetActorList.cpp
@@ -25,7 +25,6 @@ SetActorList::~SetActorList()
 {
 	for (ActorSpawnEntry* entry : actors)
 		delete entry;
-
 }
 
 string SetActorList::GetSourceOutputCode(std::string prefix)

--- a/ZAPD/ZRoom/Commands/SetActorList.h
+++ b/ZAPD/ZRoom/Commands/SetActorList.h
@@ -24,8 +24,10 @@ public:
 	~SetActorList();
 
 	std::string GetSourceOutputCode(std::string prefix);
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
-	virtual std::string GenerateSourceCodePass2(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass2(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual RoomCommand GetRoomCommand() override;
 	virtual size_t GetRawDataSize() override;
 	virtual std::string GetCommandCName() override;

--- a/ZAPD/ZRoom/Commands/SetAlternateHeaders.h
+++ b/ZAPD/ZRoom/Commands/SetAlternateHeaders.h
@@ -8,7 +8,8 @@ class SetAlternateHeaders : public ZRoomCommand
 public:
 	SetAlternateHeaders(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual size_t GetRawDataSize() override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;

--- a/ZAPD/ZRoom/Commands/SetAnimatedTextureList.cpp
+++ b/ZAPD/ZRoom/Commands/SetAnimatedTextureList.cpp
@@ -197,13 +197,15 @@ size_t ScrollingTexture::GetParamsSize()
 	return 4;
 }
 
-FlashingTexturePrimColor::FlashingTexturePrimColor(std::vector<uint8_t> rawData, uint32_t rawDataIndex)
+FlashingTexturePrimColor::FlashingTexturePrimColor(std::vector<uint8_t> rawData,
+                                                   uint32_t rawDataIndex)
 	: r(rawData[rawDataIndex + 0]), g(rawData[rawDataIndex + 1]), b(rawData[rawDataIndex + 2]),
 	  a(rawData[rawDataIndex + 3]), lodFrac(rawData[rawDataIndex + 4])
 {
 }
 
-FlashingTextureEnvColor::FlashingTextureEnvColor(std::vector<uint8_t> rawData, uint32_t rawDataIndex)
+FlashingTextureEnvColor::FlashingTextureEnvColor(std::vector<uint8_t> rawData,
+                                                 uint32_t rawDataIndex)
 	: r(rawData[rawDataIndex + 0]), g(rawData[rawDataIndex + 1]), b(rawData[rawDataIndex + 2]),
 	  a(rawData[rawDataIndex + 3])
 {

--- a/ZAPD/ZRoom/Commands/SetAnimatedTextureList.h
+++ b/ZAPD/ZRoom/Commands/SetAnimatedTextureList.h
@@ -99,7 +99,8 @@ public:
 	~SetAnimatedTextureList();
 
 	std::string GetSourceOutputCode(std::string prefix);
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual RoomCommand GetRoomCommand() override;
 	virtual size_t GetRawDataSize() override;
 	virtual std::string GetCommandCName() override;

--- a/ZAPD/ZRoom/Commands/SetCameraSettings.cpp
+++ b/ZAPD/ZRoom/Commands/SetCameraSettings.cpp
@@ -4,7 +4,8 @@
 
 using namespace std;
 
-SetCameraSettings::SetCameraSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex)
+SetCameraSettings::SetCameraSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData,
+                                     uint32_t rawDataIndex)
 	: ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
 	cameraMovement = rawData[rawDataIndex + 0x01];

--- a/ZAPD/ZRoom/Commands/SetCameraSettings.h
+++ b/ZAPD/ZRoom/Commands/SetCameraSettings.h
@@ -7,7 +7,8 @@ class SetCameraSettings : public ZRoomCommand
 public:
 	SetCameraSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/SetCollisionHeader.h
+++ b/ZAPD/ZRoom/Commands/SetCollisionHeader.h
@@ -8,8 +8,10 @@ class SetCollisionHeader : public ZRoomCommand
 public:
 	SetCollisionHeader(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
-	virtual std::string GenerateSourceCodePass2(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass2(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual std::string GenerateExterns() override;
 	virtual RoomCommand GetRoomCommand() override;

--- a/ZAPD/ZRoom/Commands/SetCsCamera.h
+++ b/ZAPD/ZRoom/Commands/SetCsCamera.h
@@ -21,8 +21,10 @@ public:
 	~SetCsCamera();
 
 	std::string GetSourceOutputCode(std::string prefix);
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
-	virtual std::string GenerateSourceCodePass2(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass2(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual RoomCommand GetRoomCommand() override;
 	virtual size_t GetRawDataSize() override;
 	virtual std::string GetCommandCName() override;

--- a/ZAPD/ZRoom/Commands/SetCutscenes.h
+++ b/ZAPD/ZRoom/Commands/SetCutscenes.h
@@ -22,7 +22,8 @@ public:
 	~SetCutscenes();
 
 	std::string GetSourceOutputCode(std::string prefix);
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual RoomCommand GetRoomCommand() override;
 	virtual size_t GetRawDataSize() override;
 	virtual std::string GetCommandCName() override;

--- a/ZAPD/ZRoom/Commands/SetEchoSettings.h
+++ b/ZAPD/ZRoom/Commands/SetEchoSettings.h
@@ -7,7 +7,8 @@ class SetEchoSettings : public ZRoomCommand
 public:
 	SetEchoSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/SetEntranceList.h
+++ b/ZAPD/ZRoom/Commands/SetEntranceList.h
@@ -17,7 +17,8 @@ public:
 	SetEntranceList(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 	~SetEntranceList();
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GenerateExterns() override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;

--- a/ZAPD/ZRoom/Commands/SetExitList.h
+++ b/ZAPD/ZRoom/Commands/SetExitList.h
@@ -7,7 +7,8 @@ class SetExitList : public ZRoomCommand
 public:
 	SetExitList(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GenerateExterns() override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;

--- a/ZAPD/ZRoom/Commands/SetLightList.h
+++ b/ZAPD/ZRoom/Commands/SetLightList.h
@@ -11,7 +11,8 @@ class SetLightList : public ZRoomCommand
 public:
 	SetLightList(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 	virtual std::string GenerateExterns() override;

--- a/ZAPD/ZRoom/Commands/SetLightingSettings.h
+++ b/ZAPD/ZRoom/Commands/SetLightingSettings.h
@@ -23,8 +23,10 @@ public:
 	SetLightingSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 	~SetLightingSettings();
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
-	virtual std::string GenerateSourceCodePass2(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass2(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual std::string GenerateExterns() override;
 	virtual RoomCommand GetRoomCommand() override;

--- a/ZAPD/ZRoom/Commands/SetMesh.h
+++ b/ZAPD/ZRoom/Commands/SetMesh.h
@@ -48,8 +48,8 @@ protected:
 
 public:
 	PolygonDlist() = default;
-	PolygonDlist(const std::string& prefix, const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex,
-	             ZFile* nParent, ZRoom* nRoom);
+	PolygonDlist(const std::string& prefix, const std::vector<uint8_t>& nRawData,
+	             uint32_t nRawDataIndex, ZFile* nParent, ZRoom* nRoom);
 
 	size_t GetRawDataSize();
 
@@ -97,7 +97,7 @@ public:
 	BgImage(bool nIsSubStruct, const std::string& prefix, const std::vector<uint8_t>& nRawData,
 	        uint32_t nRawDataIndex, ZFile* nParent);
 
-	static size_t GetRawDataSize() ;
+	static size_t GetRawDataSize();
 
 	std::string GetBodySourceCode(bool arrayElement);
 
@@ -129,10 +129,10 @@ protected:
 	void ParseRawData();
 
 public:
-	PolygonType1(const std::string& prefix, const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex,
-	             ZFile* nParent, ZRoom* nRoom);
+	PolygonType1(const std::string& prefix, const std::vector<uint8_t>& nRawData,
+	             uint32_t nRawDataIndex, ZFile* nParent, ZRoom* nRoom);
 
-	size_t GetRawDataSize() ;
+	size_t GetRawDataSize();
 
 	void DeclareVar(const std::string& prefix, const std::string& bodyStr);
 
@@ -149,10 +149,12 @@ public:
 class SetMesh : public ZRoomCommand
 {
 public:
-	SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex, int32_t segAddressOffset);
+	SetMesh(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex,
+	        int32_t segAddressOffset);
 	~SetMesh();
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GenerateExterns() override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;

--- a/ZAPD/ZRoom/Commands/SetMinimapChests.cpp
+++ b/ZAPD/ZRoom/Commands/SetMinimapChests.cpp
@@ -7,7 +7,8 @@
 
 using namespace std;
 
-SetMinimapChests::SetMinimapChests(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex)
+SetMinimapChests::SetMinimapChests(ZRoom* nZRoom, std::vector<uint8_t> rawData,
+                                   uint32_t rawDataIndex)
 	: ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
 	int32_t numChests = rawData[rawDataIndex + 1];

--- a/ZAPD/ZRoom/Commands/SetObjectList.h
+++ b/ZAPD/ZRoom/Commands/SetObjectList.h
@@ -7,7 +7,8 @@ class SetObjectList : public ZRoomCommand
 public:
 	SetObjectList(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 	virtual size_t GetRawDataSize() override;

--- a/ZAPD/ZRoom/Commands/SetPathways.cpp
+++ b/ZAPD/ZRoom/Commands/SetPathways.cpp
@@ -13,8 +13,8 @@ ZSetPathways::ZSetPathways(ZFile* nParent) : ZResource(nParent)
 {
 }
 
-ZSetPathways::ZSetPathways(ZRoom* nZRoom, const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex,
-                           bool nIsFromHeader)
+ZSetPathways::ZSetPathways(ZRoom* nZRoom, const std::vector<uint8_t>& nRawData,
+                           uint32_t nRawDataIndex, bool nIsFromHeader)
 	: ZResource(nZRoom->parent), ZRoomCommand(nZRoom, nRawData, nRawDataIndex)
 {
 	rawData = nRawData;
@@ -55,8 +55,8 @@ void ZSetPathways::ParseRawData()
 		parent->AddDeclarationPlaceholder(segmentOffset);
 
 	int32_t numPaths = (Globals::Instance->game != ZGame::MM_RETAIL) ?
-                       1 :
-                       zRoom->GetDeclarationSizeFromNeighbor(segmentOffset) / 8;
+                           1 :
+                           zRoom->GetDeclarationSizeFromNeighbor(segmentOffset) / 8;
 
 	pathwayList = new PathwayList(parent, rawData, segmentOffset, numPaths);
 }
@@ -138,7 +138,8 @@ PathwayEntry::PathwayEntry(std::vector<uint8_t> rawData, uint32_t rawDataIndex)
 	}
 }
 
-PathwayList::PathwayList(ZFile* nParent, std::vector<uint8_t> rawData, uint32_t rawDataIndex, int32_t length)
+PathwayList::PathwayList(ZFile* nParent, std::vector<uint8_t> rawData, uint32_t rawDataIndex,
+                         int32_t length)
 {
 	parent = nParent;
 	_rawDataIndex = rawDataIndex;

--- a/ZAPD/ZRoom/Commands/SetPathways.h
+++ b/ZAPD/ZRoom/Commands/SetPathways.h
@@ -21,10 +21,11 @@ public:
 struct PathwayList
 {
 public:
-	PathwayList(ZFile* nParent, std::vector<uint8_t> rawData, uint32_t rawDataIndex, int32_t length);
+	PathwayList(ZFile* nParent, std::vector<uint8_t> rawData, uint32_t rawDataIndex,
+	            int32_t length);
 	~PathwayList();
 
-	void GetSourceOutputCode(const std::string& prefix) ;
+	void GetSourceOutputCode(const std::string& prefix);
 	size_t GetRawDataSize();
 	std::string GenerateExterns(const std::string& prefix);
 

--- a/ZAPD/ZRoom/Commands/SetRoomBehavior.h
+++ b/ZAPD/ZRoom/Commands/SetRoomBehavior.h
@@ -7,7 +7,8 @@ class SetRoomBehavior : public ZRoomCommand
 public:
 	SetRoomBehavior(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/SetRoomList.h
+++ b/ZAPD/ZRoom/Commands/SetRoomList.h
@@ -18,8 +18,10 @@ public:
 	SetRoomList(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 	~SetRoomList();
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
-	virtual std::string GenerateSourceCodePass2(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass2(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual std::string GenerateExterns() override;
 	virtual RoomCommand GetRoomCommand() override;

--- a/ZAPD/ZRoom/Commands/SetSkyboxModifier.cpp
+++ b/ZAPD/ZRoom/Commands/SetSkyboxModifier.cpp
@@ -3,7 +3,8 @@
 
 using namespace std;
 
-SetSkyboxModifier::SetSkyboxModifier(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex)
+SetSkyboxModifier::SetSkyboxModifier(ZRoom* nZRoom, std::vector<uint8_t> rawData,
+                                     uint32_t rawDataIndex)
 	: ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
 	disableSky = rawData[rawDataIndex + 0x04];

--- a/ZAPD/ZRoom/Commands/SetSkyboxModifier.h
+++ b/ZAPD/ZRoom/Commands/SetSkyboxModifier.h
@@ -7,7 +7,8 @@ class SetSkyboxModifier : public ZRoomCommand
 public:
 	SetSkyboxModifier(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/SetSkyboxSettings.cpp
+++ b/ZAPD/ZRoom/Commands/SetSkyboxSettings.cpp
@@ -4,7 +4,8 @@
 
 using namespace std;
 
-SetSkyboxSettings::SetSkyboxSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex)
+SetSkyboxSettings::SetSkyboxSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData,
+                                     uint32_t rawDataIndex)
 	: ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
 	unk1 = rawData[rawDataIndex + 0x01];

--- a/ZAPD/ZRoom/Commands/SetSkyboxSettings.h
+++ b/ZAPD/ZRoom/Commands/SetSkyboxSettings.h
@@ -7,7 +7,8 @@ class SetSkyboxSettings : public ZRoomCommand
 public:
 	SetSkyboxSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/SetSoundSettings.cpp
+++ b/ZAPD/ZRoom/Commands/SetSoundSettings.cpp
@@ -3,7 +3,8 @@
 
 using namespace std;
 
-SetSoundSettings::SetSoundSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex)
+SetSoundSettings::SetSoundSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData,
+                                   uint32_t rawDataIndex)
 	: ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
 	reverb = rawData[rawDataIndex + 0x01];

--- a/ZAPD/ZRoom/Commands/SetSoundSettings.h
+++ b/ZAPD/ZRoom/Commands/SetSoundSettings.h
@@ -7,7 +7,8 @@ class SetSoundSettings : public ZRoomCommand
 public:
 	SetSoundSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/SetSpecialObjects.cpp
+++ b/ZAPD/ZRoom/Commands/SetSpecialObjects.cpp
@@ -4,7 +4,8 @@
 
 using namespace std;
 
-SetSpecialObjects::SetSpecialObjects(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex)
+SetSpecialObjects::SetSpecialObjects(ZRoom* nZRoom, std::vector<uint8_t> rawData,
+                                     uint32_t rawDataIndex)
 	: ZRoomCommand(nZRoom, rawData, rawDataIndex)
 {
 	elfMessage = rawData[rawDataIndex + 0x01];

--- a/ZAPD/ZRoom/Commands/SetSpecialObjects.h
+++ b/ZAPD/ZRoom/Commands/SetSpecialObjects.h
@@ -7,7 +7,8 @@ class SetSpecialObjects : public ZRoomCommand
 public:
 	SetSpecialObjects(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/SetStartPositionList.h
+++ b/ZAPD/ZRoom/Commands/SetStartPositionList.h
@@ -11,8 +11,10 @@ public:
 	SetStartPositionList(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 	~SetStartPositionList();
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
-	virtual std::string GenerateSourceCodePass2(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass2(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual std::string GenerateExterns() override;
 	virtual RoomCommand GetRoomCommand() override;

--- a/ZAPD/ZRoom/Commands/SetTimeSettings.h
+++ b/ZAPD/ZRoom/Commands/SetTimeSettings.h
@@ -7,7 +7,8 @@ class SetTimeSettings : public ZRoomCommand
 public:
 	SetTimeSettings(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/SetTransitionActorList.h
+++ b/ZAPD/ZRoom/Commands/SetTransitionActorList.h
@@ -24,8 +24,10 @@ public:
 	~SetTransitionActorList();
 
 	std::string GetSourceOutputCode(std::string prefix);
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
-	virtual std::string GenerateSourceCodePass2(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass2(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual RoomCommand GetRoomCommand() override;
 	virtual size_t GetRawDataSize() override;
 	virtual std::string GetCommandCName() override;

--- a/ZAPD/ZRoom/Commands/SetWind.h
+++ b/ZAPD/ZRoom/Commands/SetWind.h
@@ -7,7 +7,8 @@ class SetWind : public ZRoomCommand
 public:
 	SetWind(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/SetWorldMapVisited.h
+++ b/ZAPD/ZRoom/Commands/SetWorldMapVisited.h
@@ -7,7 +7,8 @@ class SetWorldMapVisited : public ZRoomCommand
 public:
 	SetWorldMapVisited(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/Unused09.h
+++ b/ZAPD/ZRoom/Commands/Unused09.h
@@ -7,7 +7,8 @@ class Unused09 : public ZRoomCommand
 public:
 	Unused09(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/Unused1D.h
+++ b/ZAPD/ZRoom/Commands/Unused1D.h
@@ -7,7 +7,8 @@ class Unused1D : public ZRoomCommand
 public:
 	Unused1D(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GetCommandCName() override;
 	virtual RoomCommand GetRoomCommand() override;
 

--- a/ZAPD/ZRoom/Commands/ZRoomCommandUnk.h
+++ b/ZAPD/ZRoom/Commands/ZRoomCommandUnk.h
@@ -14,8 +14,10 @@ public:
 
 	ZRoomCommandUnk(ZRoom* nZRoom, std::vector<uint8_t> rawData, uint32_t rawDataIndex);
 
-	virtual std::string GenerateSourceCodePass1(std::string roomName, uint32_t baseAddress) override;
-	virtual std::string GenerateSourceCodePass2(std::string roomName, uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass1(std::string roomName,
+	                                            uint32_t baseAddress) override;
+	virtual std::string GenerateSourceCodePass2(std::string roomName,
+	                                            uint32_t baseAddress) override;
 	virtual std::string GenerateSourceCodePass3(std::string roomName) override;
 	virtual RoomCommand GetRoomCommand() override;
 	virtual size_t GetRawDataSize() override;

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -64,7 +64,7 @@ ZRoom::~ZRoom()
 	for (ZRoomCommand* cmd : commands)
 		delete cmd;
 
-	for(auto t : textures)
+	for (auto t : textures)
 		delete t.second;
 }
 
@@ -503,8 +503,8 @@ string ZRoom::GetSourceOutputCode(const std::string& prefix)
 
 				if ((texturesSorted[i].first + texSize) > texturesSorted[i + 1].first)
 				{
-					// int32_t intersectAmt = (texturesSorted[i].first + texSize) - texturesSorted[i +
-					// 1].first;
+					// int32_t intersectAmt = (texturesSorted[i].first + texSize) - texturesSorted[i
+					// + 1].first;
 
 					defines += StringHelper::Sprintf(
 						"#define %sTex_%06X ((u32)%sTex_%06X + 0x%06X)\n", prefix.c_str(),
@@ -536,10 +536,12 @@ string ZRoom::GetSourceOutputCode(const std::string& prefix)
 
 		item.second->Save(outPath);
 
-		auto filepath = Globals::Instance->outputPath / Path::GetFileNameWithoutExtension(item.second->GetName());
+		auto filepath = Globals::Instance->outputPath /
+						Path::GetFileNameWithoutExtension(item.second->GetName());
 		parent->AddDeclarationIncludeArray(
 			item.first,
-			StringHelper::Sprintf("%s.%s.inc.c", filepath.c_str(), item.second->GetExternalExtension().c_str()),
+			StringHelper::Sprintf("%s.%s.inc.c", filepath.c_str(),
+		                          item.second->GetExternalExtension().c_str()),
 			item.second->GetRawDataSize(), "u64",
 			StringHelper::Sprintf("%sTex_%06X", prefix.c_str(), item.first), 0);
 	}
@@ -574,8 +576,8 @@ void ZRoom::PreGenSourceFiles()
 		cmd->PreGenSourceFiles();
 }
 
-Declaration::Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding,
-                         size_t nSize, string nText)
+Declaration::Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding, size_t nSize,
+                         string nText)
 {
 	alignment = nAlignment;
 	padding = nPadding;
@@ -605,9 +607,8 @@ Declaration::Declaration(DeclarationAlignment nAlignment, size_t nSize, string n
 	isArray = nIsArray;
 }
 
-Declaration::Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding,
-                         size_t nSize, string nVarType, string nVarName, bool nIsArray,
-                         string nText)
+Declaration::Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding, size_t nSize,
+                         string nVarType, string nVarName, bool nIsArray, string nText)
 	: Declaration(nAlignment, nPadding, nSize, nText)
 {
 	varType = nVarType;
@@ -626,7 +627,7 @@ Declaration::Declaration(DeclarationAlignment nAlignment, size_t nSize, string n
 }
 
 Declaration::Declaration(DeclarationAlignment nAlignment, size_t nSize, string nVarType,
-	string nVarName, bool nIsArray, std::string nArrayItemCntStr, string nText)
+                         string nVarName, bool nIsArray, std::string nArrayItemCntStr, string nText)
 	: Declaration(nAlignment, DeclarationPadding::None, nSize, nText)
 {
 	varType = nVarType;
@@ -636,16 +637,16 @@ Declaration::Declaration(DeclarationAlignment nAlignment, size_t nSize, string n
 }
 
 Declaration::Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nVarType,
-                         std::string nVarName, bool nIsArray, size_t nArrayItemCnt, std::string nText,
-                         bool nIsExternal)
+                         std::string nVarName, bool nIsArray, size_t nArrayItemCnt,
+                         std::string nText, bool nIsExternal)
 	: Declaration(nAlignment, nSize, nVarType, nVarName, nIsArray, nArrayItemCnt, nText)
 {
 	isExternal = nIsExternal;
 }
 
-Declaration::Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding,
-                         size_t nSize, string nVarType, string nVarName, bool nIsArray,
-                         size_t nArrayItemCnt, string nText)
+Declaration::Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding, size_t nSize,
+                         string nVarType, string nVarName, bool nIsArray, size_t nArrayItemCnt,
+                         string nText)
 	: Declaration(nAlignment, nPadding, nSize, nText)
 {
 	varType = nVarType;

--- a/ZAPD/ZString.cpp
+++ b/ZAPD/ZString.cpp
@@ -1,8 +1,8 @@
 #include "ZString.h"
 
 #include "File.h"
-#include "ZFile.h"
 #include "StringHelper.h"
+#include "ZFile.h"
 
 REGISTER_ZFILENODE(String, ZString);
 
@@ -15,12 +15,14 @@ void ZString::ParseRawData()
 	size_t size = 0;
 	uint8_t* rawDataArr = rawData.data();
 	size_t rawDataSize = rawData.size();
-    for (size_t i = rawDataIndex; i < rawDataSize; ++i) {
-        ++size;
-        if (rawDataArr[i] == '\0') {
-            break;
-        }
-    }
+	for (size_t i = rawDataIndex; i < rawDataSize; ++i)
+	{
+		++size;
+		if (rawDataArr[i] == '\0')
+		{
+			break;
+		}
+	}
 
 	auto dataStart = rawData.begin() + rawDataIndex;
 	strData.assign(dataStart, dataStart + size);


### PR DESCRIPTION
Adds a simple way to automatically format ZAPD's source code.
Uses `clang-format-11` (earlier versions have problems with our `.clangformat` file). 
To install `clang-format-11` in a Debian/Ubuntu environment:
```bash
sudo apt update
sudo apt install clang-format-11
```