### PR TITLE
Hotfix: fix AnimatedMaterial and Minimap extraction

### DIFF
--- a/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.h
+++ b/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.h
@@ -56,6 +56,11 @@ public:
 
 	uint16_t cycleLength;
 	uint16_t numKeyFrames;
+
+	segptr_t primColorSegmentAddr;
+	segptr_t envColorSegmentAddr;
+	segptr_t keyFrameSegmentAddr;
+
 	uint32_t primColorSegmentOffset;
 	uint32_t envColorSegmentOffset;
 	uint32_t keyFrameSegmentOffset;
@@ -73,6 +78,9 @@ public:
 	size_t GetParamsSize() override;
 
 	uint16_t cycleLength;
+
+	segptr_t textureSegmentOffsetsSegmentAddress;
+	segptr_t textureIndicesSegmentAddress;
 	uint32_t textureSegmentOffsetsSegmentOffset;
 	uint32_t textureIndicesSegmentOffset;
 
@@ -87,6 +95,7 @@ public:
 
 	int8_t segment;
 	int16_t type;
+	segptr_t segmentAddress;
 	uint32_t segmentOffset;
 	std::vector<std::shared_ptr<AnitmatedTextureParams>> params;
 };

--- a/ZAPD/ZRoom/Commands/SetMinimapList.cpp
+++ b/ZAPD/ZRoom/Commands/SetMinimapList.cpp
@@ -13,8 +13,8 @@ SetMinimapList::SetMinimapList(ZFile* nParent) : ZRoomCommand(nParent)
 void SetMinimapList::ParseRawData()
 {
 	ZRoomCommand::ParseRawData();
-	listSegmentOffset =
-		GETSEGOFFSET(BitConverter::ToInt32BE(parent->GetRawData(), segmentOffset + 0));
+	listSegmentAddr = BitConverter::ToInt32BE(parent->GetRawData(), segmentOffset);
+	listSegmentOffset = GETSEGOFFSET(listSegmentAddr);
 	unk4 = BitConverter::ToInt32BE(parent->GetRawData(), segmentOffset + 4);
 
 	int32_t currentPtr = listSegmentOffset;
@@ -51,9 +51,8 @@ void SetMinimapList::DeclareReferences(const std::string& prefix)
 	}
 
 	{
-		std::string listName = parent->GetDeclarationPtrName(listSegmentOffset);
-
-		std::string declaration = StringHelper::Sprintf("(u32)%s, 0x%08X", listName.c_str(), unk4);
+		std::string listName = parent->GetDeclarationPtrName(listSegmentAddr);
+		std::string declaration = StringHelper::Sprintf("\n\t%s, 0x%08X\n", listName.c_str(), unk4);
 
 		parent->AddDeclaration(
 			segmentOffset, DeclarationAlignment::Align4, 8, "MinimapList",

--- a/ZAPD/ZRoom/Commands/SetMinimapList.h
+++ b/ZAPD/ZRoom/Commands/SetMinimapList.h
@@ -34,6 +34,7 @@ public:
 private:
 	std::vector<MinimapEntry> minimaps;
 
+	segptr_t listSegmentAddr;
 	uint32_t listSegmentOffset;
 	uint32_t unk4;
 };

--- a/copycheck.py
+++ b/copycheck.py
@@ -2,6 +2,6 @@ import os
 from shutil import copyfile
 
 if (os.environ.get('ZAPD_COPYDIR') != None):
-    print("Copying ZAPD.out to OoT repo...")
+    print("Copying ZAPD.out to repo...")
     #print(os.environ.get('ZAPD_COPYDIR'))
     copyfile("ZAPD.out", os.environ.get('ZAPD_COPYDIR') + "/ZAPD.out")


### PR DESCRIPTION
The extraction of this assets broke in some PR merge. This went unnoticed because the broken assets are MM-only.

This PR is needed for [MM's PR 129](https://github.com/zeldaret/mm/pull/129)