### PR TITLE
Add `rgba16` format and deprecate `rgb5a1`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 OPTIMIZATION_ON ?= 1
 ASAN ?= 0
-DEPRECATION_OFF ?= 0
+DEPRECATION_ON ?= 1
 CFLAGS ?= 
 
 CC := g++
@@ -15,8 +15,8 @@ endif
 ifneq ($(ASAN),0)
   CFLAGS += -fsanitize=address
 endif
-ifneq ($(DEPRECATION_OFF),0)
-  CFLAGS += -DDEPRECATION_OFF
+ifneq ($(DEPRECATION_ON),0)
+  CFLAGS += -DDEPRECATION_ON
 endif
 # CFLAGS += -DTEXTURE_DEBUG
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can configure a bit your ZAPD build with the following options:
 
 - `OPTIMIZATION_ON`: If set to `0`, then optimizations will be disabled (compile with `-O0`). Any other value compiles with `-O2`. Defaults to `1`.
 - `ASAN`: If it is set to a non-zero then ZAPD will be compiled with Address Sanitizer enabled (`-fsanitize=address`). Defaults to `0`.
-- `DEPRECATION_OFF`: If it is set to a non-zero then deprecation warnings will be disabled. Defaults to `0`.
+- `DEPRECATION_ON`: If it is set to a zero then deprecation warnings will be disabled. Defaults to `1`.
 
 As an example, if you want to build ZAPD with optimizations disabled and use the address sanitizer, you could use the following command:
 

--- a/ZAPD/HighLevel/HLModelIntermediette.cpp
+++ b/ZAPD/HighLevel/HLModelIntermediette.cpp
@@ -877,7 +877,7 @@ void HLTextureIntermediette::InitFromXML(tinyxml2::XMLElement* xmlElement)
 
 	fileName = xmlElement->Attribute("TextureName");
 	// std::string format = xmlElement->Attribute("Format");
-	std::string format = "rgb5a1";  // TEST
+	std::string format = "rgba16";  // TEST
 
 	// tex = HLTexture::FromPNG(fileName,
 	// (HLTextureType)ZTexture::GetTextureTypeFromString(format));

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -150,7 +150,7 @@ void ZRoom::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8
 			delete pathway;
 		}
 
-#ifndef DEPRECATION_OFF
+#ifdef DEPRECATION_ON
 		fprintf(stderr,
 		        "ZRoom::ExtractFromXML: Deprecation warning in '%s'.\n"
 		        "\t The resource '%s' is currently deprecated, and will be removed in a future "

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -797,7 +797,7 @@ std::string ZTexture::GetExternalExtension() const
 	case TextureType::RGBA32bpp:
 		return "rgba32";
 	case TextureType::RGBA16bpp:
-		return "rgb5a1";
+		return "rgba16";
 	case TextureType::Grayscale4bpp:
 		return "i4";
 	case TextureType::Grayscale8bpp:
@@ -831,8 +831,19 @@ TextureType ZTexture::GetTextureTypeFromString(std::string str)
 
 	if (str == "rgba32")
 		texType = TextureType::RGBA32bpp;
-	else if (str == "rgb5a1")
+	else if (str == "rgba16")
 		texType = TextureType::RGBA16bpp;
+	else if (str == "rgb5a1")
+	{
+		texType = TextureType::RGBA16bpp;
+#ifndef DEPRECATION_OFF
+		fprintf(stderr,
+		        "ZTexture::GetTextureTypeFromString: Deprecation warning.\n"
+		        "\t The texture format 'rgb5a1' is currently deprecated, and will be removed in a future "
+		        "version.\n"
+		        "\t Use the format 'rgba16' instead.\n");
+#endif
+	}
 	else if (str == "i4")
 		texType = TextureType::Grayscale4bpp;
 	else if (str == "i8")

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -836,7 +836,7 @@ TextureType ZTexture::GetTextureTypeFromString(std::string str)
 	else if (str == "rgb5a1")
 	{
 		texType = TextureType::RGBA16bpp;
-#ifndef DEPRECATION_OFF
+#ifdef DEPRECATION_ON
 		fprintf(stderr,
 		        "ZTexture::GetTextureTypeFromString: Deprecation warning.\n"
 		        "\t The texture format 'rgb5a1' is currently deprecated, and will be removed in a future "

--- a/docs/zapd_extraction_xml_reference.md
+++ b/docs/zapd_extraction_xml_reference.md
@@ -42,9 +42,9 @@ An example of an object xml:
         <Skeleton Name="gJabuJabuSkel" Type="Flex" LimbType="Standard" Offset="0xB9A8"/>
             
         <!-- Jabu Jabu eye textures -->
-        <Texture Name="gJabuJabuEyeOpenTex" OutName="jabu_jabu_eye_open" Format="rgb5a1" Width="16" Height="32" Offset="0x7698"/>
-        <Texture Name="gJabuJabuEyeHalfTex" OutName="jabu_jabu_eye_half" Format="rgb5a1" Width="16" Height="32" Offset="0x7A98"/>
-        <Texture Name="gJabuJabuEyeClosedTex" OutName="jabu_jabu_eye_closed" Format="rgb5a1" Width="16" Height="32" Offset="0x7E98"/>
+        <Texture Name="gJabuJabuEyeOpenTex" OutName="jabu_jabu_eye_open" Format="rgba16" Width="16" Height="32" Offset="0x7698"/>
+        <Texture Name="gJabuJabuEyeHalfTex" OutName="jabu_jabu_eye_half" Format="rgba16" Width="16" Height="32" Offset="0x7A98"/>
+        <Texture Name="gJabuJabuEyeClosedTex" OutName="jabu_jabu_eye_closed" Format="rgba16" Width="16" Height="32" Offset="0x7E98"/>
 
 
         <Collision Name="gJabuJabu1Col" Offset="0x0A1C"/>
@@ -108,7 +108,7 @@ u64 gCraterSmokeConeTex[] = {
 
   - `Name`: Required. Suxffixed by `Tex`, unless it is a palette, in that case it is suffixed by `TLUT`.
   - `OutName`: Required. The filename of the extracted `.png` file.
-  - `Format`: Required. The format of the image. Valid values: `rgba32`, `rgb5a1`, `i4`, `i8`, `ia4`, `ia8`, `ia16`, `ci4` and `ci8`.
+  - `Format`: Required. The format of the image. Valid values: `rgba32`, `rgba16`, `i4`, `i8`, `ia4`, `ia8`, `ia16`, `ci4` and `ci8`.
   - `Width`: Required. Width in pixels of the image.
   - `Height`: Required. Height in pixels of the image.
   - `TlutOffset`: Optional. Specifies the tlut's offset used by this texture. This attribute is only valid if `Format` is either `ci4` or `ci8`, otherwise an exception would be thrown.
@@ -123,7 +123,7 @@ The following is a list of the texture formats the Nintendo 64 supports, with th
 | 8-bit I                                         | `G_IM_FMT_I, G_IM_SIZ_8b`        | `i8`            |
 | 8-bit IA (4/4)                                  | `G_IM_FMT_IA, G_IM_SIZ_8b`       | `ia8`           |
 | 8-bit CI                                        | `G_IM_FMT_CI, G_IM_SIZ_8b`       | `ci8`           |
-| 16-bit red, green, blue, alpha (RGBA) (5/5/5/1) | `G_IM_FMT_RGBA, G_IM_SIZ_16b`    | `rgb5a1`        |
+| 16-bit red, green, blue, alpha (RGBA) (5/5/5/1) | `G_IM_FMT_RGBA, G_IM_SIZ_16b`    | `rgba16`        |
 | 16-bit IA (8/8)                                 | `G_IM_FMT_IA, G_IM_SIZ_16b`      | `ia16`          |
 | 16-bit YUV (Luminance, Blue-Y, Red-Y)           | `G_IM_FMT_YUV, G_IM_SIZ_16b`     | (not used)      |
 | 32-bit RGBA (8/8/8/8)                           | `G_IM_FMT_RGBA, G_IM_SIZ_32b`    | `rgba8`         |


### PR DESCRIPTION
- Adds support for `rgba16` texture format.
- Extracted PNGs of this format will have the extension `.rgba16.png`
  - This change will need support on the OoT repo (see [814](https://github.com/zeldaret/oot/pull/814))
- The old `rgba5a1` format is still supported, but ZAPD will output a deprecation warning for every `rgb5a1` used.
