### PR TITLE
Use `CXX` instead of `CC` for the C++ compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,24 @@
 OPTIMIZATION_ON ?= 1
 ASAN ?= 0
 DEPRECATION_OFF ?= 0
-CFLAGS ?= 
+CXXFLAGS ?= 
 
 CXX := g++
 INC := -I ZAPD -I lib/assimp/include -I lib/elfio -I lib/json/include -I lib/stb -I lib/tinygltf -I lib/libgfxd -I lib/tinyxml2
-CFLAGS += -g3 -ggdb -fpic -std=c++17 -rdynamic -Wall -fno-omit-frame-pointer
+CXXFLAGS += -g3 -ggdb -fpic -std=c++17 -rdynamic -Wall -fno-omit-frame-pointer
 
 ifeq ($(OPTIMIZATION_ON),0)
-  CFLAGS += -O0
+  CXXFLAGS += -O0
 else
-  CFLAGS += -O2
+  CXXFLAGS += -O2
 endif
 ifneq ($(ASAN),0)
-  CFLAGS += -fsanitize=address
+  CXXFLAGS += -fsanitize=address
 endif
 ifneq ($(DEPRECATION_OFF),0)
-  CFLAGS += -DDEPRECATION_OFF
+  CXXFLAGS += -DDEPRECATION_OFF
 endif
-# CFLAGS += -DTEXTURE_DEBUG
+# CXXFLAGS += -DTEXTURE_DEBUG
 
 LDFLAGS := -ldl -lpng
 UNAME := $(shell uname)
@@ -26,7 +26,7 @@ UNAME := $(shell uname)
 FS_INC ?=
 ifneq ($(UNAME), Darwin)
     FS_INC += -lstdc++fs
-	CFLAGS += -Wl,-export-dynamic
+	CXXFLAGS += -Wl,-export-dynamic
 endif
 
 SRC_DIRS := ZAPD ZAPD/ZRoom ZAPD/ZRoom/Commands ZAPD/Overlays ZAPD/HighLevel
@@ -57,13 +57,13 @@ format:
 .PHONY: all genbuildinfo copycheck clean rebuild format
 
 %.o: %.cpp
-	$(CXX) $(CFLAGS) $(INC) -c $< -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) $(INC) -c $< -o $@ $(LDFLAGS)
 
 ZAPD/Main.o: genbuildinfo ZAPD/Main.cpp
-	$(CXX) $(CFLAGS) $(INC) -c ZAPD/Main.cpp -o $@ $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) $(INC) -c ZAPD/Main.cpp -o $@ $(LDFLAGS)
 
 lib/libgfxd/libgfxd.a:
 	$(MAKE) -C lib/libgfxd
 
 ZAPD.out: $(O_FILES) lib/libgfxd/libgfxd.a
-	$(CXX) $(CFLAGS) $(INC) $(O_FILES) lib/libgfxd/libgfxd.a -o $@ $(FS_INC) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) $(INC) $(O_FILES) lib/libgfxd/libgfxd.a -o $@ $(FS_INC) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ ASAN ?= 0
 DEPRECATION_OFF ?= 0
 CFLAGS ?= 
 
-CC := g++
 INC := -I ZAPD -I lib/assimp/include -I lib/elfio -I lib/json/include -I lib/stb -I lib/tinygltf -I lib/libgfxd -I lib/tinyxml2
 CFLAGS += -g3 -ggdb -fpic -std=c++17 -rdynamic -Wall -fno-omit-frame-pointer
 
@@ -57,13 +56,13 @@ format:
 .PHONY: all genbuildinfo copycheck clean rebuild format
 
 %.o: %.cpp
-	$(CC) $(CFLAGS) $(INC) -c $< -o $@ $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(INC) -c $< -o $@ $(LDFLAGS)
 
 ZAPD/Main.o: genbuildinfo ZAPD/Main.cpp
-	$(CC) $(CFLAGS) $(INC) -c ZAPD/Main.cpp -o $@ $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(INC) -c ZAPD/Main.cpp -o $@ $(LDFLAGS)
 
 lib/libgfxd/libgfxd.a:
 	$(MAKE) -C lib/libgfxd
 
 ZAPD.out: $(O_FILES) lib/libgfxd/libgfxd.a
-	$(CC) $(CFLAGS) $(INC) $(O_FILES) lib/libgfxd/libgfxd.a -o $@ $(FS_INC) $(LDFLAGS)
+	$(CXX) $(CFLAGS) $(INC) $(O_FILES) lib/libgfxd/libgfxd.a -o $@ $(FS_INC) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ ASAN ?= 0
 DEPRECATION_OFF ?= 0
 CFLAGS ?= 
 
+CXX := g++
 INC := -I ZAPD -I lib/assimp/include -I lib/elfio -I lib/json/include -I lib/stb -I lib/tinygltf -I lib/libgfxd -I lib/tinyxml2
 CFLAGS += -g3 -ggdb -fpic -std=c++17 -rdynamic -Wall -fno-omit-frame-pointer
 


### PR DESCRIPTION
~~Apparently is bad to explicitly define `CC := g++`. Also, `CC` is for the C compiler, while `CXX` seems to be for the C++ compiler.~~
The convention says "`CC` = C compiler", "`CXX` = C++ compiler", so we should use `CXX` instead.

Also change `CFLAGS` to `CXXFLAGS`