### PR TITLE
Remove debugging symbols in standard builds and add debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,18 @@
 OPTIMIZATION_ON ?= 1
 ASAN ?= 0
 DEPRECATION_OFF ?= 0
+DEBUG ?= 0
 CFLAGS ?= 
 
 CC := g++
 INC := -I ZAPD -I lib/assimp/include -I lib/elfio -I lib/json/include -I lib/stb -I lib/tinygltf -I lib/libgfxd -I lib/tinyxml2
-CFLAGS += -g3 -ggdb -fpic -std=c++17 -rdynamic -Wall -fno-omit-frame-pointer
+CFLAGS += -fpic -std=c++17 -rdynamic -Wall -fno-omit-frame-pointer
+
+ifneq ($(DEBUG),0)
+  OPTIMIZATION_ON = 0
+  DEPRECATION_OFF = 1
+  CFLAGS += -g3
+endif
 
 ifeq ($(OPTIMIZATION_ON),0)
   CFLAGS += -O0

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ ASAN ?= 0
 DEPRECATION_OFF ?= 0
 DEBUG ?= 0
 CFLAGS ?= 
+COPYCHECK_ARGS ?= 
 
 CC := g++
 INC := -I ZAPD -I lib/assimp/include -I lib/elfio -I lib/json/include -I lib/stb -I lib/tinygltf -I lib/libgfxd -I lib/tinyxml2
@@ -11,7 +12,8 @@ CFLAGS += -fpic -std=c++17 -rdynamic -Wall -fno-omit-frame-pointer
 ifneq ($(DEBUG),0)
   OPTIMIZATION_ON = 0
   DEPRECATION_OFF = 1
-  CFLAGS += -g3
+  CFLAGS += -g3 -DDEVELOPMENT
+  COPYCHECK_ARGS += --devel
 endif
 
 ifeq ($(OPTIMIZATION_ON),0)
@@ -47,7 +49,7 @@ O_FILES   := $(CPP_FILES:.cpp=.o)
 all: ZAPD.out copycheck
 
 genbuildinfo:
-	python3 ZAPD/genbuildinfo.py
+	python3 ZAPD/genbuildinfo.py $(COPYCHECK_ARGS)
 
 copycheck: ZAPD.out
 	python3 copycheck.py

--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ ZAPD uses the clasic `Makefile` approach. To build just run `make` (or even bett
 
 You can configure a bit your ZAPD build with the following options:
 
-- `OPTIMIZATION_ON`: If set to `0`, then optimizations will be disabled (compile with `-O0`). Any other value compiles with `-O2`. Defaults to `1`.
+- `OPTIMIZATION_ON`: If set to `0` optimizations will be disabled (compile with `-O0`). Any other value compiles with `-O2`. Defaults to `1`.
 - `ASAN`: If it is set to a non-zero then ZAPD will be compiled with Address Sanitizer enabled (`-fsanitize=address`). Defaults to `0`.
 - `DEPRECATION_OFF`: If it is set to a non-zero then deprecation warnings will be disabled. Defaults to `0`.
+- `DEBUG`: If non-zero, ZAPD will be compiled in _development mode_. This implies the following:
+  - Debugging symbols enabled (`-g3`). They are disabled by default.
+  - `OPTIMIZATION_ON=0`: Disables optimizations (`-O0`).
+  - `DEPRECATION_OFF=1`: Disables deprecation warnings.
 
 As an example, if you want to build ZAPD with optimizations disabled and use the address sanitizer, you could use the following command:
 
@@ -101,3 +105,5 @@ ZAPD also accepts the following list of extra parameters:
 - `-wu` / `--warn-unaccounted`: Enable warnings for each unaccounted block of data found.
   - Can be used only in `e` or `bsf` modes.
 - `-tm MODE`: Test Mode (enables certain experimental features). To enable it, set `MODE` to `1`.
+
+Additionally, you can pass the flag `--version` to see the current ZAPD version. If that flag is passed, ZAPD will ignore any other parameter passed.

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -47,6 +47,7 @@ void ErrorHandler(int sig)
 
 	fprintf(stderr, "\nZAPD crashed. (Signal: %i)\n", sig);
 
+	// Feel free to add more crash messages.
 	const char* crashEasterEgg[] = {
 		"\tYou've met with a terrible fate, haven't you?",
 		"\tSEA BEARS FOAM. SLEEP BEARS DREAMS. \n\tBOTH END IN THE SAME WAY: CRASSSH!",
@@ -92,12 +93,28 @@ void ErrorHandler(int sig)
 
 int main(int argc, char* argv[])
 {
-	// Syntax: ZAPD.exe [mode (btex/bovl/e)] (Arbritrary Number of Arguments)
+	// Syntax: ZAPD.out [mode (btex/bovl/e)] (Arbritrary Number of Arguments)
 
 	if (argc < 2)
 	{
-		printf("ZAPD.exe (%s) [mode (btex/bovl/bsf/bblb/bmdlintr/bamnintr/e)] ...\n", gBuildHash);
+		printf("ZAPD.out (%s) [mode (btex/bovl/bsf/bblb/bmdlintr/bamnintr/e)] ...\n", gBuildHash);
 		return 1;
+	}
+
+	for (int i = 1; i < argc; i++)
+	{
+		if (!strcmp(argv[i], "--version"))
+		{
+			printf("ZAPD.out %s\n", gBuildHash);
+			return 0;
+		}
+		else if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-h"))
+		{
+			printf("Congratulations!\n");
+			printf("You just found the (unimplemented and undocumented) ZAPD's help message.\n");
+			printf("Feel free to implement it if you want :D\n");
+			return 0;
+		}
 	}
 
 	Globals* g = new Globals();

--- a/ZAPD/genbuildinfo.py
+++ b/ZAPD/genbuildinfo.py
@@ -1,12 +1,18 @@
 #!/usr/bin/python3
 
+import argparse
 from datetime import datetime
 import getpass
 import subprocess
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--devel", action="store_true")
+args = parser.parse_args()
+
 with open("ZAPD/BuildInfo.h", "w+") as buildFile:
     label = subprocess.check_output(["git", "describe", "--always"]).strip().decode("utf-8")
     now = datetime.now()
+    if args.devel:
+        label += " ~ Development version"
     buildFile.write("const char gBuildHash[] = \"" + label + "\";\n")
     #buildFile.write("const char gBuildDate[] = \"" + now.strftime("%Y-%m-%d %H:%M:%S") + "\";\n")
-    


### PR DESCRIPTION
- Remove the debugging symbols from normal builds (ie running `make` without extra arguments).
- Adds a new parameter to pass when running `make`: `DEBUG`. It can be used like `make DEBUG=1`
  - Disables optimizations.
  - Add debugging symbols.
  - Disables deprecation warnings.
  - Enables development mode.
- Add `--version` flag to ZAPD.
  - When used, ZAPD will print the current version (git hash label) and exit.
- The new stuff was added to the README too.

This change is needed because the big amount of debugging symbols can crash some systems during compilation (it already happened to @louist103 ).