### PR TITLE
Optimize RAM usage and performance by removing redundant `rawData`

### DIFF
--- a/ZAPD/StringHelper.h
+++ b/ZAPD/StringHelper.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <algorithm>
 #include <cstring>
 #include <numeric>
 #include <stdarg.h>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 #ifndef __PRETTY_FUNCTION__
 #ifdef _MSC_VER
@@ -109,7 +109,7 @@ public:
 
 	static std::string BoolStr(bool b) { return b ? "true" : "false"; }
 
-	static bool HasOnlyDigits(const std::string &str)
+	static bool HasOnlyDigits(const std::string& str)
 	{
 		return std::all_of(str.begin(), str.end(), ::isdigit);
 	}

--- a/ZAPD/StringHelper.h
+++ b/ZAPD/StringHelper.h
@@ -7,6 +7,14 @@
 #include <vector>
 #include <algorithm>
 
+#ifndef __PRETTY_FUNCTION__
+#ifdef _MSC_VER
+#define __PRETTY_FUNCTION__ __FUNCSIG__
+#else
+#define __PRETTY_FUNCTION__ __func__
+#endif
+#endif
+
 class StringHelper
 {
 public:

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -18,10 +18,9 @@ ZAnimation::ZAnimation(ZFile* nParent) : ZResource(nParent)
 
 void ZAnimation::ParseRawData()
 {
-	const uint8_t* data = rawData.data();
+	ZResource::ParseRawData();
 
-	// Read the header
-	frameCount = BitConverter::ToInt16BE(data, rawDataIndex + 0);
+	frameCount = BitConverter::ToInt16BE(parent->GetRawData(), rawDataIndex + 0);
 }
 
 void ZAnimation::Save(const fs::path& outFolder)
@@ -119,7 +118,7 @@ void ZNormalAnimation::ParseRawData()
 {
 	ZAnimation::ParseRawData();
 
-	const uint8_t* data = rawData.data();
+	const uint8_t* data = parent->GetRawData().data();
 
 	rotationValuesSeg = BitConverter::ToInt32BE(data, rawDataIndex + 4) & 0x00FFFFFF;
 	rotationIndicesSeg = BitConverter::ToInt32BE(data, rawDataIndex + 8) & 0x00FFFFFF;
@@ -185,7 +184,7 @@ void ZLinkAnimation::ParseRawData()
 {
 	ZAnimation::ParseRawData();
 
-	const uint8_t* data = rawData.data();
+	const uint8_t* data = parent->GetRawData().data();
 	segmentAddress = (BitConverter::ToInt32BE(data, rawDataIndex + 4));
 }
 
@@ -249,6 +248,7 @@ void ZCurveAnimation::ParseRawData()
 {
 	ZAnimation::ParseRawData();
 
+	const auto& rawData = parent->GetRawData();
 	refIndex = BitConverter::ToUInt32BE(rawData, rawDataIndex + 0);
 	transformData = BitConverter::ToUInt32BE(rawData, rawDataIndex + 4);
 	copyValues = BitConverter::ToUInt32BE(rawData, rawDataIndex + 8);
@@ -292,10 +292,9 @@ void ZCurveAnimation::ParseRawData()
 	}
 }
 
-void ZCurveAnimation::ExtractFromXML(tinyxml2::XMLElement* reader,
-                                     const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex)
+void ZCurveAnimation::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
-	ZResource::ExtractFromXML(reader, nRawData, nRawDataIndex);
+	ZResource::ExtractFromXML(reader, nRawDataIndex);
 
 	parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align16, GetRawDataSize(),
 	                       GetSourceTypeName(), name, "");

--- a/ZAPD/ZAnimation.h
+++ b/ZAPD/ZAnimation.h
@@ -126,8 +126,7 @@ public:
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;
-	void ExtractFromXML(tinyxml2::XMLElement* reader,
-	                    uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
 
 	void DeclareReferences(const std::string& prefix) override;
 	size_t GetRawDataSize() const override;

--- a/ZAPD/ZAnimation.h
+++ b/ZAPD/ZAnimation.h
@@ -126,8 +126,8 @@ public:
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;
-	void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-	                    const uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader,
+	                    uint32_t nRawDataIndex) override;
 
 	void DeclareReferences(const std::string& prefix) override;
 	size_t GetRawDataSize() const override;

--- a/ZAPD/ZArray.cpp
+++ b/ZAPD/ZArray.cpp
@@ -46,7 +46,7 @@ void ZArray::ParseXML(tinyxml2::XMLElement* reader)
 		}
 		res->parent = parent;
 		res->SetInnerNode(true);
-		res->ExtractFromXML(child, rawData, childIndex);
+		res->ExtractFromXML(child, childIndex);
 
 		childIndex += res->GetRawDataSize();
 		resList.push_back(res);

--- a/ZAPD/ZBackground.cpp
+++ b/ZAPD/ZBackground.cpp
@@ -15,11 +15,10 @@ ZBackground::ZBackground(ZFile* nParent) : ZResource(nParent)
 {
 }
 
-ZBackground::ZBackground(const std::string& prefix, const std::vector<uint8_t>& nRawData,
+ZBackground::ZBackground(const std::string& prefix,
                          uint32_t nRawDataIndex, ZFile* nParent)
 	: ZResource(nParent)
 {
-	
 	rawDataIndex = nRawDataIndex;
 	name = GetDefaultName(prefix.c_str(), rawDataIndex);
 	outName = name;

--- a/ZAPD/ZBackground.cpp
+++ b/ZAPD/ZBackground.cpp
@@ -15,8 +15,7 @@ ZBackground::ZBackground(ZFile* nParent) : ZResource(nParent)
 {
 }
 
-ZBackground::ZBackground(const std::string& prefix,
-                         uint32_t nRawDataIndex, ZFile* nParent)
+ZBackground::ZBackground(const std::string& prefix, uint32_t nRawDataIndex, ZFile* nParent)
 	: ZResource(nParent)
 {
 	rawDataIndex = nRawDataIndex;
@@ -61,8 +60,7 @@ void ZBackground::ParseBinaryFile(const std::string& inFolder, bool appendOutNam
 	CheckValidJpeg(filepath.generic_string());
 }
 
-void ZBackground::ExtractFromXML(tinyxml2::XMLElement* reader,
-                                 uint32_t nRawDataIndex)
+void ZBackground::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
 	ZResource::ExtractFromXML(reader, nRawDataIndex);
 	DeclareVar("", "");

--- a/ZAPD/ZBackground.cpp
+++ b/ZAPD/ZBackground.cpp
@@ -19,7 +19,7 @@ ZBackground::ZBackground(const std::string& prefix, const std::vector<uint8_t>& 
                          uint32_t nRawDataIndex, ZFile* nParent)
 	: ZResource(nParent)
 {
-	rawData.assign(nRawData.begin(), nRawData.end());
+	
 	rawDataIndex = nRawDataIndex;
 	name = GetDefaultName(prefix.c_str(), rawDataIndex);
 	outName = name;
@@ -31,6 +31,7 @@ void ZBackground::ParseRawData()
 {
 	ZResource::ParseRawData();
 
+	const auto& rawData = parent->GetRawData();
 	size_t i = 0;
 	while (true)
 	{
@@ -61,10 +62,10 @@ void ZBackground::ParseBinaryFile(const std::string& inFolder, bool appendOutNam
 	CheckValidJpeg(filepath.generic_string());
 }
 
-void ZBackground::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
+void ZBackground::ExtractFromXML(tinyxml2::XMLElement* reader,
                                  uint32_t nRawDataIndex)
 {
-	ZResource::ExtractFromXML(reader, nRawData, nRawDataIndex);
+	ZResource::ExtractFromXML(reader, nRawDataIndex);
 	DeclareVar("", "");
 }
 

--- a/ZAPD/ZBackground.h
+++ b/ZAPD/ZBackground.h
@@ -11,8 +11,9 @@ protected:
 
 public:
 	ZBackground(ZFile* nParent);
-	ZBackground(const std::string& prefix, const std::vector<uint8_t>& nRawData,
+	ZBackground(const std::string& prefix,
 	            uint32_t nRawDataIndex, ZFile* nParent);
+
 	void ParseRawData() override;
 	void ParseBinaryFile(const std::string& inFolder, bool appendOutName);
 	void ExtractFromXML(tinyxml2::XMLElement* reader,

--- a/ZAPD/ZBackground.h
+++ b/ZAPD/ZBackground.h
@@ -15,7 +15,7 @@ public:
 	            uint32_t nRawDataIndex, ZFile* nParent);
 	void ParseRawData() override;
 	void ParseBinaryFile(const std::string& inFolder, bool appendOutName);
-	void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
+	void ExtractFromXML(tinyxml2::XMLElement* reader,
 	                    uint32_t nRawDataIndex) override;
 
 	void CheckValidJpeg(const std::string& filepath);

--- a/ZAPD/ZBackground.h
+++ b/ZAPD/ZBackground.h
@@ -11,13 +11,11 @@ protected:
 
 public:
 	ZBackground(ZFile* nParent);
-	ZBackground(const std::string& prefix,
-	            uint32_t nRawDataIndex, ZFile* nParent);
+	ZBackground(const std::string& prefix, uint32_t nRawDataIndex, ZFile* nParent);
 
 	void ParseRawData() override;
 	void ParseBinaryFile(const std::string& inFolder, bool appendOutName);
-	void ExtractFromXML(tinyxml2::XMLElement* reader,
-	                    uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
 
 	void CheckValidJpeg(const std::string& filepath);
 

--- a/ZAPD/ZBlob.cpp
+++ b/ZAPD/ZBlob.cpp
@@ -45,7 +45,8 @@ void ZBlob::ParseXML(tinyxml2::XMLElement* reader)
 
 void ZBlob::ParseRawData()
 {
-	blobData.assign(parent->GetRawData().begin() + rawDataIndex, parent->GetRawData().begin() + rawDataIndex + blobSize);
+	blobData.assign(parent->GetRawData().begin() + rawDataIndex,
+	                parent->GetRawData().begin() + rawDataIndex + blobSize);
 }
 
 std::string ZBlob::GetSourceOutputCode(const std::string& prefix)

--- a/ZAPD/ZBlob.cpp
+++ b/ZAPD/ZBlob.cpp
@@ -45,7 +45,7 @@ void ZBlob::ParseXML(tinyxml2::XMLElement* reader)
 
 void ZBlob::ParseRawData()
 {
-	blobData.assign(rawData.data() + rawDataIndex, rawData.data() + rawDataIndex + blobSize);
+	blobData.assign(parent->GetRawData().begin() + rawDataIndex, parent->GetRawData().begin() + rawDataIndex + blobSize);
 }
 
 std::string ZBlob::GetSourceOutputCode(const std::string& prefix)

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -21,26 +21,26 @@ ZCollisionHeader::~ZCollisionHeader()
 
 void ZCollisionHeader::ParseRawData()
 {
-	const uint8_t* data = rawData.data();
+	const auto& rawData = parent->GetRawData();
 
-	absMinX = BitConverter::ToInt16BE(data, rawDataIndex + 0);
-	absMinY = BitConverter::ToInt16BE(data, rawDataIndex + 2);
-	absMinZ = BitConverter::ToInt16BE(data, rawDataIndex + 4);
+	absMinX = BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
+	absMinY = BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
+	absMinZ = BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
 
-	absMaxX = BitConverter::ToInt16BE(data, rawDataIndex + 6);
-	absMaxY = BitConverter::ToInt16BE(data, rawDataIndex + 8);
-	absMaxZ = BitConverter::ToInt16BE(data, rawDataIndex + 10);
+	absMaxX = BitConverter::ToInt16BE(rawData, rawDataIndex + 6);
+	absMaxY = BitConverter::ToInt16BE(rawData, rawDataIndex + 8);
+	absMaxZ = BitConverter::ToInt16BE(rawData, rawDataIndex + 10);
 
-	numVerts = BitConverter::ToUInt16BE(data, rawDataIndex + 12);
-	vtxAddress = BitConverter::ToInt32BE(data, rawDataIndex + 16);
+	numVerts = BitConverter::ToUInt16BE(rawData, rawDataIndex + 12);
+	vtxAddress = BitConverter::ToInt32BE(rawData, rawDataIndex + 16);
 
-	numPolygons = BitConverter::ToUInt16BE(data, rawDataIndex + 20);
-	polyAddress = BitConverter::ToInt32BE(data, rawDataIndex + 24);
-	polyTypeDefAddress = BitConverter::ToInt32BE(data, rawDataIndex + 28);
-	camDataAddress = BitConverter::ToInt32BE(data, rawDataIndex + 32);
+	numPolygons = BitConverter::ToUInt16BE(rawData, rawDataIndex + 20);
+	polyAddress = BitConverter::ToInt32BE(rawData, rawDataIndex + 24);
+	polyTypeDefAddress = BitConverter::ToInt32BE(rawData, rawDataIndex + 28);
+	camDataAddress = BitConverter::ToInt32BE(rawData, rawDataIndex + 32);
 
-	numWaterBoxes = BitConverter::ToUInt16BE(data, rawDataIndex + 36);
-	waterBoxAddress = BitConverter::ToInt32BE(data, rawDataIndex + 40);
+	numWaterBoxes = BitConverter::ToUInt16BE(rawData, rawDataIndex + 36);
+	waterBoxAddress = BitConverter::ToInt32BE(rawData, rawDataIndex + 40);
 
 	vtxSegmentOffset = Seg2Filespace(vtxAddress, parent->baseAddress);
 	polySegmentOffset = Seg2Filespace(polyAddress, parent->baseAddress);
@@ -66,7 +66,7 @@ void ZCollisionHeader::ParseRawData()
 	}
 
 	for (uint16_t i = 0; i < highestPolyType + 1; i++)
-		polygonTypes.push_back(BitConverter::ToUInt64BE(data, polyTypeDefSegmentOffset + (i * 8)));
+		polygonTypes.push_back(BitConverter::ToUInt64BE(rawData, polyTypeDefSegmentOffset + (i * 8)));
 
 	if (camDataAddress != 0)
 		camData = new CameraDataList(parent, name, rawData, camDataSegmentOffset,

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -66,7 +66,8 @@ void ZCollisionHeader::ParseRawData()
 	}
 
 	for (uint16_t i = 0; i < highestPolyType + 1; i++)
-		polygonTypes.push_back(BitConverter::ToUInt64BE(rawData, polyTypeDefSegmentOffset + (i * 8)));
+		polygonTypes.push_back(
+			BitConverter::ToUInt64BE(rawData, polyTypeDefSegmentOffset + (i * 8)));
 
 	if (camDataAddress != 0)
 		camData = new CameraDataList(parent, name, rawData, camDataSegmentOffset,

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -151,8 +151,7 @@ size_t ZCutscene::GetRawDataSize() const
 	return size;
 }
 
-void ZCutscene::ExtractFromXML(tinyxml2::XMLElement* reader,
-                               uint32_t nRawDataIndex)
+void ZCutscene::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
 	ZResource::ExtractFromXML(reader, nRawDataIndex);
 	DeclareVar(parent->GetName(), "");

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -151,15 +151,19 @@ size_t ZCutscene::GetRawDataSize() const
 	return size;
 }
 
-void ZCutscene::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-                               const uint32_t nRawDataIndex)
+void ZCutscene::ExtractFromXML(tinyxml2::XMLElement* reader,
+                               uint32_t nRawDataIndex)
 {
-	ZResource::ExtractFromXML(reader, nRawData, nRawDataIndex);
+	ZResource::ExtractFromXML(reader, nRawDataIndex);
 	DeclareVar(parent->GetName(), "");
 }
 
 void ZCutscene::ParseRawData()
 {
+	ZResource::ParseRawData();
+
+	const auto& rawData = parent->GetRawData();
+
 	numCommands = BitConverter::ToInt32BE(rawData, rawDataIndex + 0);
 	commands = std::vector<CutsceneCommand*>();
 

--- a/ZAPD/ZCutscene.h
+++ b/ZAPD/ZCutscene.h
@@ -434,8 +434,7 @@ public:
 
 	ZResourceType GetResourceType() const override;
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader,
-	                    uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
 
 protected:
 	int32_t numCommands;

--- a/ZAPD/ZCutscene.h
+++ b/ZAPD/ZCutscene.h
@@ -434,8 +434,8 @@ public:
 
 	ZResourceType GetResourceType() const override;
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-	                    const uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader,
+	                    uint32_t nRawDataIndex) override;
 
 protected:
 	int32_t numCommands;

--- a/ZAPD/ZCutsceneMM.cpp
+++ b/ZAPD/ZCutsceneMM.cpp
@@ -58,8 +58,7 @@ size_t ZCutsceneMM::GetRawDataSize() const
 	return 8 + data.size() * 4;
 }
 
-void ZCutsceneMM::ExtractFromXML(tinyxml2::XMLElement* reader,
-                                 uint32_t nRawDataIndex)
+void ZCutsceneMM::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
 	ZResource::ExtractFromXML(reader, nRawDataIndex);
 	DeclareVar(parent->GetName(), "");

--- a/ZAPD/ZCutsceneMM.cpp
+++ b/ZAPD/ZCutsceneMM.cpp
@@ -58,16 +58,17 @@ size_t ZCutsceneMM::GetRawDataSize() const
 	return 8 + data.size() * 4;
 }
 
-void ZCutsceneMM::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-                                 const uint32_t nRawDataIndex)
+void ZCutsceneMM::ExtractFromXML(tinyxml2::XMLElement* reader,
+                                 uint32_t nRawDataIndex)
 {
-	ZResource::ExtractFromXML(reader, nRawData, nRawDataIndex);
+	ZResource::ExtractFromXML(reader, nRawDataIndex);
 	DeclareVar(parent->GetName(), "");
 }
 
 void ZCutsceneMM::ParseRawData()
 {
 	segmentOffset = rawDataIndex;
+	const auto& rawData = parent->GetRawData();
 
 	numCommands = BitConverter::ToInt32BE(rawData, rawDataIndex + 0);
 	commands = std::vector<CutsceneCommand*>();

--- a/ZAPD/ZCutsceneMM.h
+++ b/ZAPD/ZCutsceneMM.h
@@ -24,8 +24,8 @@ public:
 	void ParseRawData() override;
 	ZResourceType GetResourceType() const override;
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-	                    const uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader,
+	                    uint32_t nRawDataIndex) override;
 
 protected:
 	int32_t numCommands;

--- a/ZAPD/ZCutsceneMM.h
+++ b/ZAPD/ZCutsceneMM.h
@@ -24,8 +24,7 @@ public:
 	void ParseRawData() override;
 	ZResourceType GetResourceType() const override;
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader,
-	                    uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
 
 protected:
 	int32_t numCommands;

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -410,8 +410,6 @@ void ZDisplayList::ParseF3DEX(F3DEXOpcode opcode, uint64_t data, std::string pre
 int32_t ZDisplayList::GetDListLength(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex,
                                      DListType dListType)
 {
-	int32_t i = 0;
-
 	uint8_t endDLOpcode;
 
 	if (dListType == DListType::F3DZEX)

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -43,8 +43,7 @@ ZDisplayList::~ZDisplayList()
 }
 
 // EXTRACT MODE
-void ZDisplayList::ExtractFromXML(tinyxml2::XMLElement* reader,
-                                  uint32_t nRawDataIndex)
+void ZDisplayList::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
 	rawDataIndex = nRawDataIndex;
 	ParseXML(reader);
@@ -58,8 +57,7 @@ void ZDisplayList::ExtractFromXML(tinyxml2::XMLElement* reader,
 	DeclareVar("", "");
 }
 
-ZDisplayList::ZDisplayList(uint32_t nRawDataIndex,
-                           int32_t rawDataSize, ZFile* nParent)
+ZDisplayList::ZDisplayList(uint32_t nRawDataIndex, int32_t rawDataSize, ZFile* nParent)
 	: ZDisplayList(nParent)
 {
 	rawDataIndex = nRawDataIndex;
@@ -260,9 +258,9 @@ void ZDisplayList::ParseF3DZEX(F3DZEXOpcode opcode, uint64_t data, int32_t i, st
 			sprintf(line, "gsSPBranchLessZraw(%sDlist0x%06X, 0x%02X, 0x%02X),", prefix.c_str(),
 			        h & 0x00FFFFFF, (a / 5) | (b / 2), z);
 
-			ZDisplayList* nList =
-				new ZDisplayList(h & 0x00FFFFFF,
-			                     GetDListLength(parent->GetRawData(), h & 0x00FFFFFF, dListType), parent);
+			ZDisplayList* nList = new ZDisplayList(
+				h & 0x00FFFFFF, GetDListLength(parent->GetRawData(), h & 0x00FFFFFF, dListType),
+				parent);
 			nList->scene = scene;
 			otherDLists.push_back(nList);
 
@@ -427,10 +425,11 @@ int32_t ZDisplayList::GetDListLength(const std::vector<uint8_t>& rawData, uint32
 	{
 		if (ptr > rawDataSize)
 		{
-			throw std::runtime_error(StringHelper::Sprintf(
-				"%s: Fatal error.\n"
-				"\t End of file found when trying to find the end of the DisplayList at offset: '0x%X'.\n", 
-				__PRETTY_FUNCTION__, rawDataIndex));
+			throw std::runtime_error(
+				StringHelper::Sprintf("%s: Fatal error.\n"
+			                          "\t End of file found when trying to find the end of the "
+			                          "DisplayList at offset: '0x%X'.\n",
+			                          __PRETTY_FUNCTION__, rawDataIndex));
 			throw std::runtime_error("");
 		}
 
@@ -707,9 +706,9 @@ void ZDisplayList::Opcode_G_DL(uint64_t data, std::string prefix, char* line)
 	}
 	else
 	{
-		ZDisplayList* nList =
-			new ZDisplayList(GETSEGOFFSET(data),
-		                     GetDListLength(parent->GetRawData(), GETSEGOFFSET(data), dListType), parent);
+		ZDisplayList* nList = new ZDisplayList(
+			GETSEGOFFSET(data), GetDListLength(parent->GetRawData(), GETSEGOFFSET(data), dListType),
+			parent);
 
 		// if (scene != nullptr)
 		{
@@ -1741,7 +1740,8 @@ static int32_t GfxdCallback_DisplayList(uint32_t seg)
 	{
 		ZDisplayList* newDList = new ZDisplayList(
 			dListOffset,
-			self->GetDListLength(self->parent->GetRawData(), dListOffset, self->dListType), self->parent);
+			self->GetDListLength(self->parent->GetRawData(), dListOffset, self->dListType),
+			self->parent);
 		newDList->scene = self->scene;
 		newDList->parent = self->parent;
 		self->otherDLists.push_back(newDList);
@@ -1771,8 +1771,7 @@ static int32_t GfxdCallback_Matrix(uint32_t seg)
 			self->parent->GetDeclaration(Seg2Filespace(seg, self->parent->baseAddress));
 		if (decl == nullptr)
 		{
-			ZMtx mtx(self->GetName(), Seg2Filespace(seg, self->parent->baseAddress),
-			         self->parent);
+			ZMtx mtx(self->GetName(), Seg2Filespace(seg, self->parent->baseAddress), self->parent);
 
 			mtx.GetSourceOutputCode(self->GetName());
 			self->mtxList.push_back(mtx);
@@ -2039,8 +2038,8 @@ std::string ZDisplayList::ProcessGfxDis(const std::string& prefix)
 
 void ZDisplayList::TextureGenCheck(std::string prefix)
 {
-	if (TextureGenCheck(scene, parent, prefix, lastTexWidth, lastTexHeight, lastTexAddr,
-	                    lastTexSeg, lastTexFmt, lastTexSiz, lastTexLoaded, lastTexIsPalette, this))
+	if (TextureGenCheck(scene, parent, prefix, lastTexWidth, lastTexHeight, lastTexAddr, lastTexSeg,
+	                    lastTexFmt, lastTexSiz, lastTexLoaded, lastTexIsPalette, this))
 	{
 		lastTexAddr = 0;
 		lastTexLoaded = false;
@@ -2048,11 +2047,10 @@ void ZDisplayList::TextureGenCheck(std::string prefix)
 	}
 }
 
-bool ZDisplayList::TextureGenCheck(ZRoom* scene, ZFile* parent,
-                                   std::string prefix, int32_t texWidth, int32_t texHeight,
-                                   uint32_t texAddr, uint32_t texSeg, F3DZEXTexFormats texFmt,
-                                   F3DZEXTexSizes texSiz, bool texLoaded, bool texIsPalette,
-                                   ZDisplayList* self)
+bool ZDisplayList::TextureGenCheck(ZRoom* scene, ZFile* parent, std::string prefix,
+                                   int32_t texWidth, int32_t texHeight, uint32_t texAddr,
+                                   uint32_t texSeg, F3DZEXTexFormats texFmt, F3DZEXTexSizes texSiz,
+                                   bool texLoaded, bool texIsPalette, ZDisplayList* self)
 {
 	int32_t segmentNumber = GETSEGNUM(texSeg);
 

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -42,19 +42,18 @@ ZDisplayList::~ZDisplayList()
 
 // EXTRACT MODE
 void ZDisplayList::ExtractFromXML(tinyxml2::XMLElement* reader,
-                                  const std::vector<uint8_t>& nRawData,
-                                  const uint32_t nRawDataIndex)
+                                  uint32_t nRawDataIndex)
 {
-	rawData.assign(nRawData.begin(), nRawData.end());
+	
 	rawDataIndex = nRawDataIndex;
 	ParseXML(reader);
 
-	fileData = nRawData;
+	fileData = parent->GetRawData();
 	int32_t rawDataSize = ZDisplayList::GetDListLength(
-		nRawData, rawDataIndex,
+		parent->GetRawData(), rawDataIndex,
 		Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX);
-	dlistRawData.assign(nRawData.data() + rawDataIndex,
-	                    nRawData.data() + rawDataIndex + rawDataSize);
+	dlistRawData.assign(parent->GetRawData().data() + rawDataIndex,
+	                    parent->GetRawData().data() + rawDataIndex + rawDataSize);
 	ParseRawData();
 
 	DeclareVar("", "");
@@ -64,7 +63,7 @@ ZDisplayList::ZDisplayList(std::vector<uint8_t> nRawData, uint32_t nRawDataIndex
                            int32_t rawDataSize, ZFile* nParent)
 	: ZDisplayList(nParent)
 {
-	rawData.assign(nRawData.begin(), nRawData.end());
+	
 	fileData = nRawData;
 	rawDataIndex = nRawDataIndex;
 	name = StringHelper::Sprintf("DL_%06X", rawDataIndex);
@@ -411,7 +410,7 @@ void ZDisplayList::ParseF3DEX(F3DEXOpcode opcode, uint64_t data, std::string pre
 	}
 }
 
-int32_t ZDisplayList::GetDListLength(std::vector<uint8_t> rawData, uint32_t rawDataIndex,
+int32_t ZDisplayList::GetDListLength(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex,
                                      DListType dListType)
 {
 	int32_t i = 0;
@@ -863,7 +862,6 @@ void ZDisplayList::Opcode_G_VTX(uint64_t data, char* line)
 			for (int32_t i = 0; i < nn; i++)
 			{
 				ZVtx vtx(parent);
-				vtx.SetRawData(fileData);
 				vtx.SetRawDataIndex(currentPtr);
 				vtx.ParseRawData();
 				vtxList.push_back(vtx);
@@ -1633,7 +1631,6 @@ static int32_t GfxdCallback_Vtx(uint32_t seg, int32_t count)
 			for (int32_t i = 0; i < count; i++)
 			{
 				ZVtx vtx(self->parent);
-				vtx.SetRawData(self->fileData);
 				vtx.SetRawDataIndex(currentPtr);
 				vtx.ParseRawData();
 
@@ -2094,7 +2091,7 @@ bool ZDisplayList::TextureGenCheck(std::vector<uint8_t> fileData, ZRoom* scene, 
 				else
 				{
 					tex = new ZTexture(scene->parent);
-					tex->FromBinary(scene->GetRawData(), texAddr, texWidth, texHeight,
+					tex->FromBinary(scene->parent->GetRawData(), texAddr, texWidth, texHeight,
 					                TexFormatToTexType(texFmt, texSiz), texIsPalette);
 
 					scene->parent->AddTextureResource(texAddr, tex);

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -349,23 +349,20 @@ public:
 	std::vector<ZMtx> mtxList;
 
 	ZDisplayList(ZFile* nParent);
-	ZDisplayList(uint32_t rawDataIndex, int32_t rawDataSize,
-	             ZFile* nParent);
+	ZDisplayList(uint32_t rawDataIndex, int32_t rawDataSize, ZFile* nParent);
 	~ZDisplayList();
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader,
-	                    uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
 
 	void ParseRawData() override;
 
 	Declaration* DeclareVar(const std::string& prefix, const std::string& bodyStr);
 
 	void TextureGenCheck(std::string prefix);
-	static bool TextureGenCheck(ZRoom* scene, ZFile* parent,
-	                            std::string prefix, int32_t texWidth, int32_t texHeight,
-	                            uint32_t texAddr, uint32_t texSeg, F3DZEXTexFormats texFmt,
-	                            F3DZEXTexSizes texSiz, bool texLoaded, bool texIsPalette,
-	                            ZDisplayList* self);
+	static bool TextureGenCheck(ZRoom* scene, ZFile* parent, std::string prefix, int32_t texWidth,
+	                            int32_t texHeight, uint32_t texAddr, uint32_t texSeg,
+	                            F3DZEXTexFormats texFmt, F3DZEXTexSizes texSiz, bool texLoaded,
+	                            bool texIsPalette, ZDisplayList* self);
 	static int32_t GetDListLength(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex,
 	                              DListType dListType);
 

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -346,11 +346,10 @@ public:
 	std::vector<uint32_t> references;
 
 	std::string defines;  // Hack for special cases where vertex arrays intersect...
-	std::vector<uint8_t> fileData;
 	std::vector<ZMtx> mtxList;
 
 	ZDisplayList(ZFile* nParent);
-	ZDisplayList(std::vector<uint8_t> nRawData, uint32_t rawDataIndex, int32_t rawDataSize,
+	ZDisplayList(uint32_t rawDataIndex, int32_t rawDataSize,
 	             ZFile* nParent);
 	~ZDisplayList();
 
@@ -362,7 +361,7 @@ public:
 	Declaration* DeclareVar(const std::string& prefix, const std::string& bodyStr);
 
 	void TextureGenCheck(std::string prefix);
-	static bool TextureGenCheck(std::vector<uint8_t> fileData, ZRoom* scene, ZFile* parent,
+	static bool TextureGenCheck(ZRoom* scene, ZFile* parent,
 	                            std::string prefix, int32_t texWidth, int32_t texHeight,
 	                            uint32_t texAddr, uint32_t texSeg, F3DZEXTexFormats texFmt,
 	                            F3DZEXTexSizes texSiz, bool texLoaded, bool texIsPalette,
@@ -384,5 +383,5 @@ public:
 	ZResourceType GetResourceType() const override;
 
 protected:
-	std::vector<uint8_t> dlistRawData;
+	size_t numInstructions;
 };

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -354,8 +354,8 @@ public:
 	             ZFile* nParent);
 	~ZDisplayList();
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-	                    const uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader,
+	                    uint32_t nRawDataIndex) override;
 
 	void ParseRawData() override;
 
@@ -367,7 +367,7 @@ public:
 	                            uint32_t texAddr, uint32_t texSeg, F3DZEXTexFormats texFmt,
 	                            F3DZEXTexSizes texSiz, bool texLoaded, bool texIsPalette,
 	                            ZDisplayList* self);
-	static int32_t GetDListLength(std::vector<uint8_t> rawData, uint32_t rawDataIndex,
+	static int32_t GetDListLength(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex,
 	                              DListType dListType);
 
 	size_t GetRawDataSize() const override;

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -194,7 +194,7 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, b
 			ZResource* nRes = nodeMap[nodeName](this);
 
 			if (mode == ZFileMode::Extract)
-				nRes->ExtractFromXML(child, rawData, rawDataIndex);
+				nRes->ExtractFromXML(child, rawDataIndex);
 
 			auto resType = nRes->GetResourceType();
 			if (resType == ZResourceType::Texture)

--- a/ZAPD/ZLimb.cpp
+++ b/ZAPD/ZLimb.cpp
@@ -217,7 +217,7 @@ std::string Struct_800A598C::GetSourceTypeName()
 
 Struct_800A5E28::Struct_800A5E28(ZFile* parent, const std::vector<uint8_t>& nRawData,
                                  uint32_t fileOffset)
-	: parent(parent), rawData(nRawData)
+	: parent(parent)
 {
 	unk_0 = BitConverter::ToUInt16BE(nRawData, fileOffset + 0x00);
 	unk_2 = BitConverter::ToUInt16BE(nRawData, fileOffset + 0x02);
@@ -282,9 +282,9 @@ void Struct_800A5E28::PreGenSourceFiles(const std::string& prefix)
 		uint32_t unk_8_Offset = Seg2Filespace(unk_8, parent->baseAddress);
 
 		int32_t dlistLength = ZDisplayList::GetDListLength(
-			rawData, unk_8_Offset,
+			parent->GetRawData(), unk_8_Offset,
 			Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX);
-		unk_8_dlist = new ZDisplayList(rawData, unk_8_Offset, dlistLength, parent);
+		unk_8_dlist = new ZDisplayList(parent->GetRawData(), unk_8_Offset, dlistLength, parent);
 
 		std::string dListStr =
 			StringHelper::Sprintf("%sSkinLimbDL_%06X", prefix.c_str(), unk_8_Offset);
@@ -358,7 +358,7 @@ ZLimb::ZLimb(ZLimbType limbType, const std::string& prefix, const std::vector<ui
              uint32_t nRawDataIndex, ZFile* nParent)
 	: ZLimb(nParent)
 {
-	rawData.assign(nRawData.begin(), nRawData.end());
+	
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
 	type = limbType;
@@ -368,10 +368,10 @@ ZLimb::ZLimb(ZLimbType limbType, const std::string& prefix, const std::vector<ui
 	ParseRawData();
 }
 
-void ZLimb::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-                           const uint32_t nRawDataIndex)
+void ZLimb::ExtractFromXML(tinyxml2::XMLElement* reader,
+                           uint32_t nRawDataIndex)
 {
-	ZResource::ExtractFromXML(reader, nRawData, nRawDataIndex);
+	ZResource::ExtractFromXML(reader, nRawDataIndex);
 
 	parent->AddDeclaration(GetFileAddress(), DeclarationAlignment::None, GetRawDataSize(),
 	                       GetSourceTypeName(), name, "");
@@ -429,6 +429,7 @@ void ZLimb::ParseRawData()
 {
 	ZResource::ParseRawData();
 
+	const auto& rawData = parent->GetRawData();
 	if (type == ZLimbType::Curve)
 	{
 		childIndex = rawData.at(rawDataIndex + 0);
@@ -607,9 +608,9 @@ std::string ZLimb::GetLimbDListSourceOutputCode(const std::string& prefix,
 		StringHelper::Sprintf("%s%sLimbDL_%06X", prefix.c_str(), limbPrefix.c_str(), dListOffset);
 
 	int32_t dlistLength = ZDisplayList::GetDListLength(
-		rawData, dListOffset,
+		parent->GetRawData(), dListOffset,
 		Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX);
-	auto dList = new ZDisplayList(rawData, dListOffset, dlistLength, parent);
+	auto dList = new ZDisplayList(parent->GetRawData(), dListOffset, dlistLength, parent);
 	dList->SetName(dListStr);
 	dList->GetSourceOutputCode(prefix);
 	return dListStr;

--- a/ZAPD/ZLimb.cpp
+++ b/ZAPD/ZLimb.cpp
@@ -354,8 +354,7 @@ ZLimb::ZLimb(ZFile* nParent) : ZResource(nParent)
 	RegisterOptionalAttribute("Type");
 }
 
-ZLimb::ZLimb(ZLimbType limbType, const std::string& prefix,
-             uint32_t nRawDataIndex, ZFile* nParent)
+ZLimb::ZLimb(ZLimbType limbType, const std::string& prefix, uint32_t nRawDataIndex, ZFile* nParent)
 	: ZLimb(nParent)
 {
 	rawDataIndex = nRawDataIndex;
@@ -367,8 +366,7 @@ ZLimb::ZLimb(ZLimbType limbType, const std::string& prefix,
 	ParseRawData();
 }
 
-void ZLimb::ExtractFromXML(tinyxml2::XMLElement* reader,
-                           uint32_t nRawDataIndex)
+void ZLimb::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
 	ZResource::ExtractFromXML(reader, nRawDataIndex);
 

--- a/ZAPD/ZLimb.cpp
+++ b/ZAPD/ZLimb.cpp
@@ -284,7 +284,7 @@ void Struct_800A5E28::PreGenSourceFiles(const std::string& prefix)
 		int32_t dlistLength = ZDisplayList::GetDListLength(
 			parent->GetRawData(), unk_8_Offset,
 			Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX);
-		unk_8_dlist = new ZDisplayList(parent->GetRawData(), unk_8_Offset, dlistLength, parent);
+		unk_8_dlist = new ZDisplayList(unk_8_Offset, dlistLength, parent);
 
 		std::string dListStr =
 			StringHelper::Sprintf("%sSkinLimbDL_%06X", prefix.c_str(), unk_8_Offset);
@@ -354,11 +354,10 @@ ZLimb::ZLimb(ZFile* nParent) : ZResource(nParent)
 	RegisterOptionalAttribute("Type");
 }
 
-ZLimb::ZLimb(ZLimbType limbType, const std::string& prefix, const std::vector<uint8_t>& nRawData,
+ZLimb::ZLimb(ZLimbType limbType, const std::string& prefix,
              uint32_t nRawDataIndex, ZFile* nParent)
 	: ZLimb(nParent)
 {
-	
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
 	type = limbType;
@@ -610,7 +609,7 @@ std::string ZLimb::GetLimbDListSourceOutputCode(const std::string& prefix,
 	int32_t dlistLength = ZDisplayList::GetDListLength(
 		parent->GetRawData(), dListOffset,
 		Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX);
-	auto dList = new ZDisplayList(parent->GetRawData(), dListOffset, dlistLength, parent);
+	auto dList = new ZDisplayList(dListOffset, dlistLength, parent);
 	dList->SetName(dListStr);
 	dList->GetSourceOutputCode(prefix);
 	return dListStr;

--- a/ZAPD/ZLimb.h
+++ b/ZAPD/ZLimb.h
@@ -139,7 +139,7 @@ public:
 	uint8_t childIndex, siblingIndex;
 
 	ZLimb(ZFile* nParent);
-	ZLimb(ZLimbType limbType, const std::string& prefix, const std::vector<uint8_t>& nRawData,
+	ZLimb(ZLimbType limbType, const std::string& prefix,
 	      uint32_t nRawDataIndex, ZFile* nParent);
 
 	void ExtractFromXML(tinyxml2::XMLElement* reader,

--- a/ZAPD/ZLimb.h
+++ b/ZAPD/ZLimb.h
@@ -139,11 +139,9 @@ public:
 	uint8_t childIndex, siblingIndex;
 
 	ZLimb(ZFile* nParent);
-	ZLimb(ZLimbType limbType, const std::string& prefix,
-	      uint32_t nRawDataIndex, ZFile* nParent);
+	ZLimb(ZLimbType limbType, const std::string& prefix, uint32_t nRawDataIndex, ZFile* nParent);
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader,
-	                    uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;

--- a/ZAPD/ZLimb.h
+++ b/ZAPD/ZLimb.h
@@ -93,7 +93,6 @@ class Struct_800A5E28
 {
 protected:
 	ZFile* parent;
-	std::vector<uint8_t> rawData;
 
 	uint16_t unk_0;  // Vtx count
 	uint16_t unk_2;  // Length of unk_4
@@ -143,8 +142,8 @@ public:
 	ZLimb(ZLimbType limbType, const std::string& prefix, const std::vector<uint8_t>& nRawData,
 	      uint32_t nRawDataIndex, ZFile* nParent);
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-	                    const uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader,
+	                    uint32_t nRawDataIndex) override;
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;

--- a/ZAPD/ZMtx.cpp
+++ b/ZAPD/ZMtx.cpp
@@ -9,9 +9,7 @@ ZMtx::ZMtx(ZFile* nParent) : ZResource(nParent)
 {
 }
 
-ZMtx::ZMtx(const std::string& prefix, uint32_t nRawDataIndex,
-           ZFile* nParent)
-	: ZResource(nParent)
+ZMtx::ZMtx(const std::string& prefix, uint32_t nRawDataIndex, ZFile* nParent) : ZResource(nParent)
 {
 	name = GetDefaultName(prefix.c_str(), rawDataIndex);
 	ExtractFromFile(nRawDataIndex);
@@ -28,8 +26,7 @@ void ZMtx::ParseRawData()
 			mtx[i][j] = BitConverter::ToInt32BE(rawData, rawDataIndex + (i * 4 + j) * 4);
 }
 
-void ZMtx::ExtractFromXML(tinyxml2::XMLElement* reader,
-                          uint32_t nRawDataIndex)
+void ZMtx::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
 	ZResource::ExtractFromXML(reader, nRawDataIndex);
 	DeclareVar("", "");

--- a/ZAPD/ZMtx.cpp
+++ b/ZAPD/ZMtx.cpp
@@ -14,7 +14,7 @@ ZMtx::ZMtx(const std::string& prefix, const std::vector<uint8_t>& nRawData, uint
 	: ZResource(nParent)
 {
 	name = GetDefaultName(prefix.c_str(), rawDataIndex);
-	ExtractFromFile(nRawData, nRawDataIndex);
+	ExtractFromFile(nRawDataIndex);
 	DeclareVar("", "");
 }
 
@@ -22,15 +22,16 @@ void ZMtx::ParseRawData()
 {
 	ZResource::ParseRawData();
 
+	const auto& rawData = parent->GetRawData();
 	for (size_t i = 0; i < 4; ++i)
 		for (size_t j = 0; j < 4; ++j)
 			mtx[i][j] = BitConverter::ToInt32BE(rawData, rawDataIndex + (i * 4 + j) * 4);
 }
 
-void ZMtx::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
+void ZMtx::ExtractFromXML(tinyxml2::XMLElement* reader,
                           uint32_t nRawDataIndex)
 {
-	ZResource::ExtractFromXML(reader, nRawData, nRawDataIndex);
+	ZResource::ExtractFromXML(reader, nRawDataIndex);
 	DeclareVar("", "");
 }
 

--- a/ZAPD/ZMtx.cpp
+++ b/ZAPD/ZMtx.cpp
@@ -9,7 +9,7 @@ ZMtx::ZMtx(ZFile* nParent) : ZResource(nParent)
 {
 }
 
-ZMtx::ZMtx(const std::string& prefix, const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex,
+ZMtx::ZMtx(const std::string& prefix, uint32_t nRawDataIndex,
            ZFile* nParent)
 	: ZResource(nParent)
 {

--- a/ZAPD/ZMtx.h
+++ b/ZAPD/ZMtx.h
@@ -8,7 +8,7 @@ class ZMtx : public ZResource
 {
 public:
 	ZMtx(ZFile* nParent);
-	ZMtx(const std::string& prefix, const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex,
+	ZMtx(const std::string& prefix, uint32_t nRawDataIndex,
 	     ZFile* nParent);
 
 	void ParseRawData() override;

--- a/ZAPD/ZMtx.h
+++ b/ZAPD/ZMtx.h
@@ -12,7 +12,7 @@ public:
 	     ZFile* nParent);
 
 	void ParseRawData() override;
-	void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
+	void ExtractFromXML(tinyxml2::XMLElement* reader,
 	                    uint32_t nRawDataIndex) override;
 
 	size_t GetRawDataSize() const override;

--- a/ZAPD/ZMtx.h
+++ b/ZAPD/ZMtx.h
@@ -8,12 +8,10 @@ class ZMtx : public ZResource
 {
 public:
 	ZMtx(ZFile* nParent);
-	ZMtx(const std::string& prefix, uint32_t nRawDataIndex,
-	     ZFile* nParent);
+	ZMtx(const std::string& prefix, uint32_t nRawDataIndex, ZFile* nParent);
 
 	void ParseRawData() override;
-	void ExtractFromXML(tinyxml2::XMLElement* reader,
-	                    uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
 
 	size_t GetRawDataSize() const override;
 

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -13,10 +13,10 @@ ZPath::ZPath(ZFile* nParent) : ZResource(nParent)
 	RegisterOptionalAttribute("NumPaths", "1");
 }
 
-void ZPath::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-                           const uint32_t nRawDataIndex)
+void ZPath::ExtractFromXML(tinyxml2::XMLElement* reader,
+                           uint32_t nRawDataIndex)
 {
-	ZResource::ExtractFromXML(reader, nRawData, nRawDataIndex);
+	ZResource::ExtractFromXML(reader, nRawDataIndex);
 
 	parent->AddDeclarationArray(rawDataIndex, DeclarationAlignment::Align4, pathways.size() * 8,
 	                            GetSourceTypeName(), name, pathways.size(), "");
@@ -135,7 +135,6 @@ void PathwayEntry::ParseRawData()
 	for (int32_t i = 0; i < numPoints; i++)
 	{
 		ZVector vec(parent);
-		vec.SetRawData(parentRawData);
 		vec.SetRawDataIndex(currentPtr);
 		vec.SetScalarType(ZScalarType::ZSCALAR_S16);
 		vec.SetDimensions(3);

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -13,8 +13,7 @@ ZPath::ZPath(ZFile* nParent) : ZResource(nParent)
 	RegisterOptionalAttribute("NumPaths", "1");
 }
 
-void ZPath::ExtractFromXML(tinyxml2::XMLElement* reader,
-                           uint32_t nRawDataIndex)
+void ZPath::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
 	ZResource::ExtractFromXML(reader, nRawDataIndex);
 

--- a/ZAPD/ZPath.h
+++ b/ZAPD/ZPath.h
@@ -32,8 +32,7 @@ class ZPath : public ZResource
 public:
 	ZPath(ZFile* nParent);
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader,
-	                    uint32_t nRawDataIndex);
+	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex);
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;

--- a/ZAPD/ZPath.h
+++ b/ZAPD/ZPath.h
@@ -32,8 +32,8 @@ class ZPath : public ZResource
 public:
 	ZPath(ZFile* nParent);
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-	                    const uint32_t nRawDataIndex);
+	void ExtractFromXML(tinyxml2::XMLElement* reader,
+	                    uint32_t nRawDataIndex);
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;

--- a/ZAPD/ZResource.cpp
+++ b/ZAPD/ZResource.cpp
@@ -21,10 +21,8 @@ ZResource::ZResource(ZFile* nParent)
 	RegisterOptionalAttribute("Custom");
 }
 
-void ZResource::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-                               const uint32_t nRawDataIndex)
+void ZResource::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
-	rawData = nRawData;
 	rawDataIndex = nRawDataIndex;
 
 	if (reader != nullptr)
@@ -34,9 +32,8 @@ void ZResource::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<u
 	CalcHash();
 }
 
-void ZResource::ExtractFromFile(const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex)
+void ZResource::ExtractFromFile(uint32_t nRawDataIndex)
 {
-	rawData = nRawData;
 	rawDataIndex = nRawDataIndex;
 
 	ParseRawData();
@@ -158,16 +155,6 @@ bool ZResource::DoesSupportArray() const
 std::string ZResource::GetExternalExtension() const
 {
 	return "";
-}
-
-const std::vector<uint8_t>& ZResource::GetRawData() const
-{
-	return rawData;
-}
-
-void ZResource::SetRawData(const std::vector<uint8_t>& nData)
-{
-	rawData = nData;
 }
 
 bool ZResource::WasDeclaredInXml() const

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -69,9 +69,8 @@ public:
 	virtual ~ZResource() = default;
 
 	// Parsing from File
-	virtual void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-	                            uint32_t nRawDataIndex);
-	virtual void ExtractFromFile(const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex);
+	virtual void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex);
+	virtual void ExtractFromFile(uint32_t nRawDataIndex);
 
 	// Misc
 	virtual void ParseXML(tinyxml2::XMLElement* reader);
@@ -101,15 +100,12 @@ public:
 	virtual uint32_t GetRawDataIndex() const;
 	virtual void SetRawDataIndex(uint32_t value);
 	virtual size_t GetRawDataSize() const = 0;
-	virtual const std::vector<uint8_t>& GetRawData() const;
-	virtual void SetRawData(const std::vector<uint8_t>& nData);
 	void SetInnerNode(bool inner);
 	bool WasDeclaredInXml() const;
 
 protected:
 	std::string name;
 	std::string outName;
-	std::vector<uint8_t> rawData;
 	uint32_t rawDataIndex;
 	std::string sourceOutput;
 	bool isInner = false;  // Is this resource an inner node of another resource? inside of <Array>

--- a/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.cpp
+++ b/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.cpp
@@ -255,12 +255,12 @@ std::string FlashingTexture::GenerateSourceCode(ZRoom* zRoom, uint32_t baseAddre
 			index++;
 		}
 
-		zRoom->parent->AddDeclarationArray(
-			primColorSegmentOffset, DeclarationAlignment::Align4, primColors.size() * 5,
-			"F3DPrimColor",
-			StringHelper::Sprintf("%sAnimatedMaterialPrimColor_%06X", zRoom->GetName().c_str(),
-		                          primColorSegmentOffset),
-			primColors.size(), declaration);
+		zRoom->parent->AddDeclarationArray(primColorSegmentOffset, DeclarationAlignment::Align4,
+		                                   primColors.size() * 5, "F3DPrimColor",
+		                                   StringHelper::Sprintf("%sAnimatedMaterialPrimColor_%06X",
+		                                                         zRoom->GetName().c_str(),
+		                                                         primColorSegmentOffset),
+		                                   primColors.size(), declaration);
 	}
 
 	if (envColorSegmentOffset != 0)
@@ -400,7 +400,8 @@ std::string AnimatedMatTexCycleParams::GenerateSourceCode(ZRoom* zRoom, uint32_t
 			textureIndices.size(), declaration);
 	}
 
-	std::string segmName = zRoom->parent->GetDeclarationPtrName(textureSegmentOffsetsSegmentAddress);
+	std::string segmName =
+		zRoom->parent->GetDeclarationPtrName(textureSegmentOffsetsSegmentAddress);
 	std::string indexesName = zRoom->parent->GetDeclarationPtrName(textureIndicesSegmentAddress);
 
 	return StringHelper::Sprintf("%i, %s, %s", cycleLength, segmName.c_str(), indexesName.c_str());

--- a/ZAPD/ZRoom/Commands/SetCollisionHeader.cpp
+++ b/ZAPD/ZRoom/Commands/SetCollisionHeader.cpp
@@ -13,7 +13,6 @@ void SetCollisionHeader::ParseRawData()
 {
 	ZRoomCommand::ParseRawData();
 	collisionHeader = new ZCollisionHeader(parent);
-	collisionHeader->SetRawData(parent->GetRawData());
 	collisionHeader->SetRawDataIndex(segmentOffset);
 	collisionHeader->SetName(
 		StringHelper::Sprintf("%sCollisionHeader_%06X", parent->GetName().c_str(), segmentOffset));

--- a/ZAPD/ZRoom/Commands/SetCsCamera.cpp
+++ b/ZAPD/ZRoom/Commands/SetCsCamera.cpp
@@ -33,7 +33,6 @@ void SetCsCamera::ParseRawData()
 		for (int32_t i = 0; i < numPoints; i++)
 		{
 			ZVector vec(parent);
-			vec.SetRawData(parent->GetRawData());
 			vec.SetRawDataIndex(currentPtr);
 			vec.SetScalarType(ZScalarType::ZSCALAR_S16);
 			vec.SetDimensions(3);

--- a/ZAPD/ZRoom/Commands/SetCutscenes.cpp
+++ b/ZAPD/ZRoom/Commands/SetCutscenes.cpp
@@ -19,7 +19,7 @@ void SetCutscenes::ParseRawData()
 	if (Globals::Instance->game == ZGame::OOT_RETAIL || Globals::Instance->game == ZGame::OOT_SW97)
 	{
 		ZCutscene* cutscene = new ZCutscene(parent);
-		cutscene->ExtractFromFile(parent->GetRawData(), segmentOffset);
+		cutscene->ExtractFromFile(segmentOffset);
 
 		auto decl = parent->GetDeclaration(segmentOffset);
 		if (decl == nullptr)
@@ -48,7 +48,7 @@ void SetCutscenes::ParseRawData()
 				declaration += "\n";
 
 			ZCutsceneMM* cutscene = new ZCutsceneMM(parent);
-			cutscene->ExtractFromFile(parent->GetRawData(), entry.segmentOffset);
+			cutscene->ExtractFromFile(entry.segmentOffset);
 			cutscenes.push_back(cutscene);
 		}
 

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -164,7 +164,7 @@ ZDisplayList* PolygonDlist::MakeDlist(segptr_t ptr, const std::string& prefix)
 	int32_t dlistLength = ZDisplayList::GetDListLength(
 		parent->GetRawData(), dlistAddress,
 		Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX);
-	ZDisplayList* dlist = new ZDisplayList(parent->GetRawData(), dlistAddress, dlistLength, parent);
+	ZDisplayList* dlist = new ZDisplayList(dlistAddress, dlistLength, parent);
 	GenDListDeclarations(zRoom, parent, dlist);
 
 	return dlist;
@@ -314,7 +314,7 @@ ZBackground* BgImage::MakeBackground(segptr_t ptr, const std::string& prefix)
 
 	uint32_t backAddress = Seg2Filespace(ptr, parent->baseAddress);
 
-	ZBackground* background = new ZBackground(prefix, parent->GetRawData(), backAddress, parent);
+	ZBackground* background = new ZBackground(prefix, backAddress, parent);
 	background->DeclareVar(prefix, "");
 	parent->resources.push_back(background);
 

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -116,7 +116,7 @@ RoomCommand SetMesh::GetRoomCommand() const
 PolygonDlist::PolygonDlist(const std::string& prefix, const std::vector<uint8_t>& nRawData,
                            uint32_t nRawDataIndex, ZFile* nParent, ZRoom* nRoom)
 {
-	rawData.assign(nRawData.begin(), nRawData.end());
+	
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
 	zRoom = nRoom;
@@ -126,6 +126,7 @@ PolygonDlist::PolygonDlist(const std::string& prefix, const std::vector<uint8_t>
 
 void PolygonDlist::ParseRawData()
 {
+	const auto& rawData = parent->GetRawData();
 	switch (polyType)
 	{
 	case 2:
@@ -161,9 +162,9 @@ ZDisplayList* PolygonDlist::MakeDlist(segptr_t ptr, const std::string& prefix)
 	uint32_t dlistAddress = Seg2Filespace(ptr, parent->baseAddress);
 
 	int32_t dlistLength = ZDisplayList::GetDListLength(
-		rawData, dlistAddress,
+		parent->GetRawData(), dlistAddress,
 		Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX);
-	ZDisplayList* dlist = new ZDisplayList(rawData, dlistAddress, dlistLength, parent);
+	ZDisplayList* dlist = new ZDisplayList(parent->GetRawData(), dlistAddress, dlistLength, parent);
 	GenDListDeclarations(zRoom, parent, dlist);
 
 	return dlist;
@@ -271,7 +272,7 @@ std::string PolygonDlist::GetName()
 BgImage::BgImage(bool nIsSubStruct, const std::string& prefix, const std::vector<uint8_t>& nRawData,
                  uint32_t nRawDataIndex, ZFile* nParent)
 {
-	rawData.assign(nRawData.begin(), nRawData.end());
+	
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
 	isSubStruct = nIsSubStruct;
@@ -285,6 +286,7 @@ BgImage::BgImage(bool nIsSubStruct, const std::string& prefix, const std::vector
 void BgImage::ParseRawData()
 {
 	size_t pad = 0x00;
+	const auto& rawData = parent->GetRawData();
 	if (!isSubStruct)
 	{
 		pad = 0x04;
@@ -312,7 +314,7 @@ ZBackground* BgImage::MakeBackground(segptr_t ptr, const std::string& prefix)
 
 	uint32_t backAddress = Seg2Filespace(ptr, parent->baseAddress);
 
-	ZBackground* background = new ZBackground(prefix, rawData, backAddress, parent);
+	ZBackground* background = new ZBackground(prefix, parent->GetRawData(), backAddress, parent);
 	background->DeclareVar(prefix, "");
 	parent->resources.push_back(background);
 
@@ -408,9 +410,9 @@ std::string BgImage::GetName()
 
 PolygonTypeBase::PolygonTypeBase(ZFile* nParent, const std::vector<uint8_t>& nRawData,
                                  uint32_t nRawDataIndex, ZRoom* nRoom)
-	: rawData{nRawData}, rawDataIndex{nRawDataIndex}, parent{nParent}, zRoom{nRoom}
+	: rawDataIndex{nRawDataIndex}, parent{nParent}, zRoom{nRoom}
 {
-	type = BitConverter::ToUInt8BE(rawData, rawDataIndex);
+	type = BitConverter::ToUInt8BE(parent->GetRawData(), rawDataIndex);
 }
 
 void PolygonTypeBase::DeclareVar(const std::string& prefix, const std::string& bodyStr)
@@ -477,6 +479,8 @@ PolygonType1::PolygonType1(ZFile* nParent, const std::vector<uint8_t>& nRawData,
 
 void PolygonType1::ParseRawData()
 {
+	const auto& rawData = parent->GetRawData();
+
 	format = BitConverter::ToUInt8BE(rawData, rawDataIndex + 0x01);
 	dlist = BitConverter::ToUInt32BE(rawData, rawDataIndex + 0x04);
 
@@ -506,7 +510,7 @@ void PolygonType1::DeclareReferences(const std::string& prefix)
 	switch (format)
 	{
 	case 1:
-		single = BgImage(true, prefix, rawData, rawDataIndex + 0x08, parent);
+		single = BgImage(true, prefix, parent->GetRawData(), rawDataIndex + 0x08, parent);
 		break;
 
 	case 2:
@@ -515,7 +519,7 @@ void PolygonType1::DeclareReferences(const std::string& prefix)
 			listAddress = Seg2Filespace(list, parent->baseAddress);
 			for (size_t i = 0; i < count; ++i)
 			{
-				BgImage bg(false, prefix, rawData, listAddress + i * BgImage::GetRawDataSize(),
+				BgImage bg(false, prefix, parent->GetRawData(), listAddress + i * BgImage::GetRawDataSize(),
 				           parent);
 				multiList.push_back(bg);
 				bgImageArrayBody += bg.GetBodySourceCode(true);
@@ -609,6 +613,8 @@ PolygonType2::PolygonType2(ZFile* nParent, const std::vector<uint8_t>& nRawData,
 
 void PolygonType2::ParseRawData()
 {
+	const auto& rawData = parent->GetRawData();
+
 	num = BitConverter::ToUInt8BE(rawData, rawDataIndex + 0x01);
 
 	start = BitConverter::ToUInt32BE(rawData, rawDataIndex + 0x04);

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -116,7 +116,6 @@ RoomCommand SetMesh::GetRoomCommand() const
 PolygonDlist::PolygonDlist(const std::string& prefix, const std::vector<uint8_t>& nRawData,
                            uint32_t nRawDataIndex, ZFile* nParent, ZRoom* nRoom)
 {
-	
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
 	zRoom = nRoom;
@@ -272,7 +271,6 @@ std::string PolygonDlist::GetName()
 BgImage::BgImage(bool nIsSubStruct, const std::string& prefix, const std::vector<uint8_t>& nRawData,
                  uint32_t nRawDataIndex, ZFile* nParent)
 {
-	
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
 	isSubStruct = nIsSubStruct;
@@ -519,8 +517,8 @@ void PolygonType1::DeclareReferences(const std::string& prefix)
 			listAddress = Seg2Filespace(list, parent->baseAddress);
 			for (size_t i = 0; i < count; ++i)
 			{
-				BgImage bg(false, prefix, parent->GetRawData(), listAddress + i * BgImage::GetRawDataSize(),
-				           parent);
+				BgImage bg(false, prefix, parent->GetRawData(),
+				           listAddress + i * BgImage::GetRawDataSize(), parent);
 				multiList.push_back(bg);
 				bgImageArrayBody += bg.GetBodySourceCode(true);
 				if (i + 1 < count)

--- a/ZAPD/ZRoom/Commands/SetMesh.h
+++ b/ZAPD/ZRoom/Commands/SetMesh.h
@@ -114,7 +114,6 @@ protected:
 
 	std::vector<PolygonDlist> polyDLists;
 
-	std::vector<uint8_t> rawData;
 	uint32_t rawDataIndex;
 	ZFile* parent;
 	ZRoom* zRoom;

--- a/ZAPD/ZRoom/Commands/SetMesh.h
+++ b/ZAPD/ZRoom/Commands/SetMesh.h
@@ -39,7 +39,6 @@ protected:
 	ZDisplayList* opaDList = nullptr;  // Gfx*
 	ZDisplayList* xluDList = nullptr;  // Gfx*
 
-	std::vector<uint8_t> rawData;
 	uint32_t rawDataIndex;
 	ZFile* parent;
 	ZRoom* zRoom;
@@ -65,7 +64,6 @@ protected:
 
 	ZBackground* sourceBackground;
 
-	std::vector<uint8_t> rawData;
 	uint32_t rawDataIndex;
 	ZFile* parent;
 	std::string name;

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -60,10 +60,10 @@ ZRoom::~ZRoom()
 		delete cmd;
 }
 
-void ZRoom::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-                           const uint32_t nRawDataIndex)
+void ZRoom::ExtractFromXML(tinyxml2::XMLElement* reader,
+                           uint32_t nRawDataIndex)
 {
-	ZResource::ExtractFromXML(reader, nRawData, nRawDataIndex);
+	ZResource::ExtractFromXML(reader, nRawDataIndex);
 
 	scene = Globals::Instance->lastScene;
 
@@ -97,8 +97,8 @@ void ZRoom::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8
 			int32_t address = strtol(StringHelper::Split(addressStr, "0x")[1].c_str(), NULL, 16);
 
 			ZDisplayList* dList = new ZDisplayList(
-				rawData, address,
-				ZDisplayList::GetDListLength(rawData, address,
+				parent->GetRawData(), address,
+				ZDisplayList::GetDListLength(parent->GetRawData(), address,
 			                                 Globals::Instance->game == ZGame::OOT_SW97 ?
                                                  DListType::F3DEX :
                                                  DListType::F3DZEX),
@@ -115,7 +115,7 @@ void ZRoom::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8
 
 			ZCutscene* cutscene = new ZCutscene(parent);
 			cutscene->SetInnerNode(true);
-			cutscene->ExtractFromXML(child, rawData, address);
+			cutscene->ExtractFromXML(child, address);
 
 			cutscene->GetSourceOutputCode(name);
 
@@ -174,6 +174,7 @@ void ZRoom::ParseCommands(std::vector<ZRoomCommand*>& commandList, CommandSet co
 
 	uint32_t commandsLeft = commandSet.commandCount;
 
+	const auto& rawData = parent->GetRawData();
 	while (shouldContinue)
 	{
 		if (commandsLeft <= 0)
@@ -392,7 +393,7 @@ size_t ZRoom::GetDeclarationSizeFromNeighbor(uint32_t declarationAddress)
 	auto nextDecl = currentDecl;
 	std::advance(nextDecl, 1);
 	if (nextDecl == parent->declarations.end())
-		return rawData.size() - currentDecl->first;
+		return parent->GetRawData().size() - currentDecl->first;
 
 	return nextDecl->first - currentDecl->first;
 }
@@ -415,7 +416,7 @@ size_t ZRoom::GetCommandSizeFromNeighbor(ZRoomCommand* cmd)
 		if (cmdIndex + 1 < (int32_t)commands.size())
 			return commands[cmdIndex + 1]->cmdAddress - commands[cmdIndex]->cmdAddress;
 		else
-			return rawData.size() - commands[cmdIndex]->cmdAddress;
+			return parent->GetRawData().size() - commands[cmdIndex]->cmdAddress;
 	}
 
 	return 0;

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -97,7 +97,7 @@ void ZRoom::ExtractFromXML(tinyxml2::XMLElement* reader,
 			int32_t address = strtol(StringHelper::Split(addressStr, "0x")[1].c_str(), NULL, 16);
 
 			ZDisplayList* dList = new ZDisplayList(
-				parent->GetRawData(), address,
+				address,
 				ZDisplayList::GetDListLength(parent->GetRawData(), address,
 			                                 Globals::Instance->game == ZGame::OOT_SW97 ?
                                                  DListType::F3DEX :

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -60,8 +60,7 @@ ZRoom::~ZRoom()
 		delete cmd;
 }
 
-void ZRoom::ExtractFromXML(tinyxml2::XMLElement* reader,
-                           uint32_t nRawDataIndex)
+void ZRoom::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
 	ZResource::ExtractFromXML(reader, nRawDataIndex);
 

--- a/ZAPD/ZRoom/ZRoom.h
+++ b/ZAPD/ZRoom/ZRoom.h
@@ -36,7 +36,7 @@ public:
 	ZRoom(ZFile* nParent);
 	virtual ~ZRoom();
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
+	void ExtractFromXML(tinyxml2::XMLElement* reader,
 	                    uint32_t nRawDataIndex) override;
 
 	void ParseCommands(std::vector<ZRoomCommand*>& commandList, CommandSet commandSet);

--- a/ZAPD/ZRoom/ZRoom.h
+++ b/ZAPD/ZRoom/ZRoom.h
@@ -36,8 +36,7 @@ public:
 	ZRoom(ZFile* nParent);
 	virtual ~ZRoom();
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader,
-	                    uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
 
 	void ParseCommands(std::vector<ZRoomCommand*>& commandList, CommandSet commandSet);
 	size_t GetDeclarationSizeFromNeighbor(uint32_t declarationAddress);

--- a/ZAPD/ZScalar.cpp
+++ b/ZAPD/ZScalar.cpp
@@ -137,6 +137,7 @@ size_t ZScalar::GetRawDataSize() const
 
 void ZScalar::ParseRawData()
 {
+	const auto& rawData = parent->GetRawData();
 	switch (scalarType)
 	{
 	case ZScalarType::ZSCALAR_S8:

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -19,7 +19,7 @@ ZSkeleton::ZSkeleton(ZSkeletonType nType, ZLimbType nLimbType, const std::string
                      const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex, ZFile* nParent)
 	: ZSkeleton(nParent)
 {
-	rawData.assign(nRawData.begin(), nRawData.end());
+	
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
 
@@ -35,9 +35,9 @@ ZSkeleton::ZSkeleton(ZSkeletonType nType, ZLimbType nLimbType, const std::string
 
 	for (size_t i = 0; i < limbCount; i++)
 	{
-		uint32_t ptr2 = Seg2Filespace(BitConverter::ToUInt32BE(rawData, ptr), parent->baseAddress);
+		uint32_t ptr2 = Seg2Filespace(BitConverter::ToUInt32BE(parent->GetRawData(), ptr), parent->baseAddress);
 
-		ZLimb* limb = new ZLimb(limbType, prefix, rawData, ptr2, parent);
+		ZLimb* limb = new ZLimb(limbType, prefix, parent->GetRawData(), ptr2, parent);
 		limbs.push_back(limb);
 
 		ptr += 4;
@@ -95,15 +95,16 @@ void ZSkeleton::ParseRawData()
 {
 	ZResource::ParseRawData();
 
+	const auto& rawData = parent->GetRawData();
 	limbsArrayAddress = BitConverter::ToUInt32BE(rawData, rawDataIndex);
 	limbCount = BitConverter::ToUInt8BE(rawData, rawDataIndex + 4);
 	dListCount = BitConverter::ToUInt8BE(rawData, rawDataIndex + 8);
 }
 
-void ZSkeleton::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-                               const uint32_t nRawDataIndex)
+void ZSkeleton::ExtractFromXML(tinyxml2::XMLElement* reader,
+                               uint32_t nRawDataIndex)
 {
-	ZResource::ExtractFromXML(reader, nRawData, nRawDataIndex);
+	ZResource::ExtractFromXML(reader, nRawDataIndex);
 
 	parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align16, GetRawDataSize(),
 	                       GetSourceTypeName(), name, "");
@@ -112,6 +113,7 @@ void ZSkeleton::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<u
 	defaultPrefix.replace(0, 1, "s");  // replace g prefix with s for local variables
 	uint32_t ptr = Seg2Filespace(limbsArrayAddress, parent->baseAddress);
 
+	const auto& rawData = parent->GetRawData();
 	for (size_t i = 0; i < limbCount; i++)
 	{
 		uint32_t ptr2 = Seg2Filespace(BitConverter::ToUInt32BE(rawData, ptr), parent->baseAddress);
@@ -124,7 +126,7 @@ void ZSkeleton::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<u
 		ZLimb* limb = new ZLimb(parent);
 		limb->SetLimbType(limbType);
 		limb->SetName(limbName);
-		limb->ExtractFromXML(nullptr, rawData, ptr2);
+		limb->ExtractFromXML(nullptr, ptr2);
 		limbs.push_back(limb);
 
 		ptr += 4;

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -19,7 +19,6 @@ ZSkeleton::ZSkeleton(ZSkeletonType nType, ZLimbType nLimbType, const std::string
                      uint32_t nRawDataIndex, ZFile* nParent)
 	: ZSkeleton(nParent)
 {
-	
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
 
@@ -35,7 +34,8 @@ ZSkeleton::ZSkeleton(ZSkeletonType nType, ZLimbType nLimbType, const std::string
 
 	for (size_t i = 0; i < limbCount; i++)
 	{
-		uint32_t ptr2 = Seg2Filespace(BitConverter::ToUInt32BE(parent->GetRawData(), ptr), parent->baseAddress);
+		uint32_t ptr2 =
+			Seg2Filespace(BitConverter::ToUInt32BE(parent->GetRawData(), ptr), parent->baseAddress);
 
 		ZLimb* limb = new ZLimb(limbType, prefix, ptr2, parent);
 		limbs.push_back(limb);
@@ -101,8 +101,7 @@ void ZSkeleton::ParseRawData()
 	dListCount = BitConverter::ToUInt8BE(rawData, rawDataIndex + 8);
 }
 
-void ZSkeleton::ExtractFromXML(tinyxml2::XMLElement* reader,
-                               uint32_t nRawDataIndex)
+void ZSkeleton::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
 	ZResource::ExtractFromXML(reader, nRawDataIndex);
 

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -16,7 +16,7 @@ ZSkeleton::ZSkeleton(ZFile* nParent) : ZResource(nParent)
 }
 
 ZSkeleton::ZSkeleton(ZSkeletonType nType, ZLimbType nLimbType, const std::string& prefix,
-                     const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex, ZFile* nParent)
+                     uint32_t nRawDataIndex, ZFile* nParent)
 	: ZSkeleton(nParent)
 {
 	
@@ -37,7 +37,7 @@ ZSkeleton::ZSkeleton(ZSkeletonType nType, ZLimbType nLimbType, const std::string
 	{
 		uint32_t ptr2 = Seg2Filespace(BitConverter::ToUInt32BE(parent->GetRawData(), ptr), parent->baseAddress);
 
-		ZLimb* limb = new ZLimb(limbType, prefix, parent->GetRawData(), ptr2, parent);
+		ZLimb* limb = new ZLimb(limbType, prefix, ptr2, parent);
 		limbs.push_back(limb);
 
 		ptr += 4;

--- a/ZAPD/ZSkeleton.h
+++ b/ZAPD/ZSkeleton.h
@@ -29,8 +29,8 @@ public:
 	          const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex, ZFile* nParent);
 	~ZSkeleton();
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-	                    const uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader,
+	                    uint32_t nRawDataIndex) override;
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;

--- a/ZAPD/ZSkeleton.h
+++ b/ZAPD/ZSkeleton.h
@@ -26,7 +26,7 @@ public:
 
 	ZSkeleton(ZFile* nParent);
 	ZSkeleton(ZSkeletonType nType, ZLimbType nLimbType, const std::string& prefix,
-	          const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex, ZFile* nParent);
+	          uint32_t nRawDataIndex, ZFile* nParent);
 	~ZSkeleton();
 
 	void ExtractFromXML(tinyxml2::XMLElement* reader,

--- a/ZAPD/ZSkeleton.h
+++ b/ZAPD/ZSkeleton.h
@@ -29,8 +29,7 @@ public:
 	          uint32_t nRawDataIndex, ZFile* nParent);
 	~ZSkeleton();
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader,
-	                    uint32_t nRawDataIndex) override;
+	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;

--- a/ZAPD/ZString.cpp
+++ b/ZAPD/ZString.cpp
@@ -13,7 +13,8 @@ ZString::ZString(ZFile* nParent) : ZResource(nParent)
 void ZString::ParseRawData()
 {
 	size_t size = 0;
-	uint8_t* rawDataArr = rawData.data();
+	const auto& rawData = parent->GetRawData();
+	const auto& rawDataArr = rawData.data();
 	size_t rawDataSize = rawData.size();
 	for (size_t i = rawDataIndex; i < rawDataSize; ++i)
 	{
@@ -43,7 +44,7 @@ std::string ZString::GetSourceOutputCode(const std::string& prefix)
 
 std::string ZString::GetSourceOutputHeader(const std::string& prefix)
 {
-	return StringHelper::Sprintf("#define %s_macro \"%s\"", name.c_str(), rawData.data());
+	return StringHelper::Sprintf("#define %s_macro \"%s\"", name.c_str(), strData.data());
 }
 
 std::string ZString::GetSourceTypeName() const

--- a/ZAPD/ZSymbol.cpp
+++ b/ZAPD/ZSymbol.cpp
@@ -11,12 +11,6 @@ ZSymbol::ZSymbol(ZFile* nParent) : ZResource(nParent)
 	RegisterOptionalAttribute("Count");
 }
 
-void ZSymbol::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-                             const uint32_t nRawDataIndex)
-{
-	ZResource::ExtractFromXML(reader, nRawData, nRawDataIndex);
-}
-
 void ZSymbol::ParseXML(tinyxml2::XMLElement* reader)
 {
 	ZResource::ParseXML(reader);

--- a/ZAPD/ZSymbol.h
+++ b/ZAPD/ZSymbol.h
@@ -14,9 +14,6 @@ protected:
 public:
 	ZSymbol(ZFile* nParent);
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
-	                    const uint32_t nRawDataIndex) override;
-
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 
 	size_t GetRawDataSize() const override;

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -21,10 +21,10 @@ ZTexture::ZTexture(ZFile* nParent) : ZResource(nParent)
 	RegisterOptionalAttribute("TlutOffset");
 }
 
-void ZTexture::ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
+void ZTexture::ExtractFromXML(tinyxml2::XMLElement* reader,
                               uint32_t nRawDataIndex)
 {
-	ZResource::ExtractFromXML(reader, nRawData, nRawDataIndex);
+	ZResource::ExtractFromXML(reader, nRawDataIndex);
 
 	auto filepath = Globals::Instance->outputPath / fs::path(name).stem();
 
@@ -46,7 +46,7 @@ void ZTexture::FromBinary(const std::vector<uint8_t>& nRawData, uint32_t nRawDat
 	name = GetDefaultName(parent->GetName());
 	outName = name;
 
-	rawData.assign(nRawData.begin(), nRawData.end());
+	
 
 	ParseRawData();
 	CalcHash();
@@ -348,7 +348,7 @@ void ZTexture::DeclareReferences(const std::string& prefix)
 			                                           GetExternalExtension().c_str());
 
 			tlut = new ZTexture(parent);
-			tlut->FromBinary(rawData, tlutOffset, tlutDim, tlutDim, TextureType::RGBA16bpp, true);
+			tlut->FromBinary(parent->GetRawData(), tlutOffset, tlutDim, tlutDim, TextureType::RGBA16bpp, true);
 			parent->AddTextureResource(tlutOffset, tlut);
 			parent->AddDeclarationIncludeArray(tlutOffset, incStr, tlut->GetRawDataSize(),
 			                                   tlut->GetSourceTypeName(), tlut->GetName(), 0);

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -35,7 +35,7 @@ void ZTexture::ExtractFromXML(tinyxml2::XMLElement* reader,
 	                                   name, 0);
 }
 
-void ZTexture::FromBinary(const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex,
+void ZTexture::FromBinary(uint32_t nRawDataIndex,
                           int32_t nWidth, int32_t nHeight, TextureType nType, bool nIsPalette)
 {
 	width = nWidth;
@@ -348,7 +348,7 @@ void ZTexture::DeclareReferences(const std::string& prefix)
 			                                           GetExternalExtension().c_str());
 
 			tlut = new ZTexture(parent);
-			tlut->FromBinary(parent->GetRawData(), tlutOffset, tlutDim, tlutDim, TextureType::RGBA16bpp, true);
+			tlut->FromBinary(tlutOffset, tlutDim, tlutDim, TextureType::RGBA16bpp, true);
 			parent->AddTextureResource(tlutOffset, tlut);
 			parent->AddDeclarationIncludeArray(tlutOffset, incStr, tlut->GetRawDataSize(),
 			                                   tlut->GetSourceTypeName(), tlut->GetName(), 0);

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -21,8 +21,7 @@ ZTexture::ZTexture(ZFile* nParent) : ZResource(nParent)
 	RegisterOptionalAttribute("TlutOffset");
 }
 
-void ZTexture::ExtractFromXML(tinyxml2::XMLElement* reader,
-                              uint32_t nRawDataIndex)
+void ZTexture::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
 	ZResource::ExtractFromXML(reader, nRawDataIndex);
 
@@ -35,8 +34,8 @@ void ZTexture::ExtractFromXML(tinyxml2::XMLElement* reader,
 	                                   name, 0);
 }
 
-void ZTexture::FromBinary(uint32_t nRawDataIndex,
-                          int32_t nWidth, int32_t nHeight, TextureType nType, bool nIsPalette)
+void ZTexture::FromBinary(uint32_t nRawDataIndex, int32_t nWidth, int32_t nHeight,
+                          TextureType nType, bool nIsPalette)
 {
 	width = nWidth;
 	height = nHeight;
@@ -45,8 +44,6 @@ void ZTexture::FromBinary(uint32_t nRawDataIndex,
 	isPalette = nIsPalette;
 	name = GetDefaultName(parent->GetName());
 	outName = name;
-
-	
 
 	ParseRawData();
 	CalcHash();
@@ -75,17 +72,17 @@ void ZTexture::ParseXML(tinyxml2::XMLElement* reader)
 
 	if (!StringHelper::HasOnlyDigits(widthXml))
 	{
-		throw std::runtime_error(StringHelper::Sprintf(
-			"ZTexture::ParseXML: Error in %s\n"
-			"\t Value of 'Width' attribute has non-decimal digits: '%s'.\n",
-			name.c_str(), widthXml.c_str()));
+		throw std::runtime_error(
+			StringHelper::Sprintf("ZTexture::ParseXML: Error in %s\n"
+		                          "\t Value of 'Width' attribute has non-decimal digits: '%s'.\n",
+		                          name.c_str(), widthXml.c_str()));
 	}
 	if (!StringHelper::HasOnlyDigits(heightXml))
 	{
-		throw std::runtime_error(StringHelper::Sprintf(
-			"ZTexture::ParseXML: Error in %s\n"
-			"\t Value of 'Height' attribute has non-decimal digits: '%s'.\n",
-			name.c_str(), heightXml.c_str()));
+		throw std::runtime_error(
+			StringHelper::Sprintf("ZTexture::ParseXML: Error in %s\n"
+		                          "\t Value of 'Height' attribute has non-decimal digits: '%s'.\n",
+		                          name.c_str(), heightXml.c_str()));
 	}
 
 	width = StringHelper::StrToL(widthXml);

--- a/ZAPD/ZTexture.h
+++ b/ZAPD/ZTexture.h
@@ -58,7 +58,7 @@ public:
 
 	bool isPalette = false;
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader, const std::vector<uint8_t>& nRawData,
+	void ExtractFromXML(tinyxml2::XMLElement* reader,
 	                    uint32_t nRawDataIndex) override;
 	void FromBinary(const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex, int32_t nWidth,
 	                int32_t nHeight, TextureType nType, bool nIsPalette);

--- a/ZAPD/ZTexture.h
+++ b/ZAPD/ZTexture.h
@@ -58,10 +58,9 @@ public:
 
 	bool isPalette = false;
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader,
-	                    uint32_t nRawDataIndex) override;
-	void FromBinary(uint32_t nRawDataIndex, int32_t nWidth,
-	                int32_t nHeight, TextureType nType, bool nIsPalette);
+	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
+	void FromBinary(uint32_t nRawDataIndex, int32_t nWidth, int32_t nHeight, TextureType nType,
+	                bool nIsPalette);
 	void FromPNG(const fs::path& pngFilePath, TextureType texType);
 	void FromHLTexture(HLTexture* hlTex);
 

--- a/ZAPD/ZTexture.h
+++ b/ZAPD/ZTexture.h
@@ -60,7 +60,7 @@ public:
 
 	void ExtractFromXML(tinyxml2::XMLElement* reader,
 	                    uint32_t nRawDataIndex) override;
-	void FromBinary(const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex, int32_t nWidth,
+	void FromBinary(uint32_t nRawDataIndex, int32_t nWidth,
 	                int32_t nHeight, TextureType nType, bool nIsPalette);
 	void FromPNG(const fs::path& pngFilePath, TextureType texType);
 	void FromHLTexture(HLTexture* hlTex);

--- a/ZAPD/ZVector.cpp
+++ b/ZAPD/ZVector.cpp
@@ -35,7 +35,6 @@ void ZVector::ParseRawData()
 	{
 		ZScalar scalar(scalarType, parent);
 		scalar.rawDataIndex = currentRawDataIndex;
-		scalar.rawData = rawData;
 		scalar.ParseRawData();
 		currentRawDataIndex += scalar.GetRawDataSize();
 

--- a/ZAPD/ZVtx.cpp
+++ b/ZAPD/ZVtx.cpp
@@ -21,6 +21,9 @@ ZVtx::ZVtx(ZFile* nParent) : ZResource(nParent)
 
 void ZVtx::ParseRawData()
 {
+	ZResource::ParseRawData();
+
+	const auto& rawData = parent->GetRawData();
 	x = BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
 	y = BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
 	z = BitConverter::ToInt16BE(rawData, rawDataIndex + 4);


### PR DESCRIPTION
Currently each `ZResource` has the vector member `rawData`, which contains a copy of the binary data of the whole file being extracted (ie an object, scene, etc). This means that it makes a copy of the whole data vector once for every resource, using an unnecessary amount of memory and CPU time from all these redundant copies.
This solution removes said member, and instead makes every resource ask for a reference of the data to their `parent` (`ZFile`).

To put this change in perspective, here are some numbers¹:

| Measuring tool | Current master | This PR | % |
|--------------------|------------------------|--------------------|--------------------|
| Run time (`time ./extract_assets.py`)                | `0m23.732s` | `0m5.079s` | `−78.62%` |
| CPU cycles (`perf record ./extract_assets.py`)   | `179.61 GCycles` (or `179,606,898,977 cycles`) | `25.98 GCycles` (or `25,981,576,639 cycles`) | `-85.53%` |
| RAM usage² (`valgrind --tool=massif`)            |  `1421.04 MiB` (or `1,421,040,336 bytes`) | `12.82 MiB` (or `13,447,320 bytes`) | `−99.05%` |


--------------------------------------
¹ Only tested with OoT repo.
² I tested this method only with `gameplay_keep`, because I couldn't find an easy and quick way to automate this for every asset we have.