### PR TITLE
Strip extra padding at the end of each file

### DIFF
--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -920,7 +920,13 @@ std::string ZFile::ProcessDeclarations()
 					std::string unaccountedPrefix = "unaccounted";
 
 					if (diff < 16 && !nonZeroUnaccounted)
+					{
 						unaccountedPrefix = "possiblePadding";
+
+						// Strip unnecessary padding at the end of the file.
+						if (unaccountedAddress + diff >= rawData.size())
+							break;
+					}
 
 					Declaration* decl = AddDeclarationArray(
 						unaccountedAddress, DeclarationAlignment::None, diff, "static u8",


### PR DESCRIPTION
The extra unaccounted/padding at the end of every extracted file is not necessary, since it would be re-added automatically in the compilation process, so there's no point in keeping it explicitly.