### PR TITLE
Update libgfxd

### DIFF
--- a/lib/libgfxd/.gitrepo
+++ b/lib/libgfxd/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/glankk/libgfxd.git
 	branch = master
-	commit = 2f00ff7dff14ae44c12ed421be54b9fec815541b
-	parent = a43a526c4296d7dc48852f6017fe069724465494
+	commit = 01db16329ef5cac23566b6d143b57d0525e22876
+	parent = c6b352aac040527d2962f3e764e460eb9e813fe5
 	method = merge
 	cmdver = 0.4.3

--- a/lib/libgfxd/gbi.h
+++ b/lib/libgfxd/gbi.h
@@ -1,5 +1,5 @@
 /**
- * gbi.h version 0.3.4
+ * gbi.h version 0.3.5
  * n64 graphics microcode interface library
  * compatible with fast3d, f3dex, f3dex2, s2dex, and s2dex2
  *
@@ -2748,6 +2748,14 @@
 
 #if defined(F3DEX_GBI)
 
+# define gsSP1Triangle(v0, v1, v2, flag) \
+	gO_( \
+		G_TRI1, \
+		0, \
+		gF_(gV3_(v0, v1, v2, flag) * 2, 8, 16) | \
+		gF_(gV3_(v1, v2, v0, flag) * 2, 8, 8) | \
+		gF_(gV3_(v2, v0, v1, flag) * 2, 8, 0))
+
 # define gsSP1Quadrangle(v0, v1, v2, v3, flag) \
 	gO_( \
 		G_TRI2, \
@@ -2771,14 +2779,6 @@
 /* instruction macros for f3dex and f3dex2 */
 
 #if defined(F3DEX_GBI) || defined(F3DEX_GBI_2)
-
-# define gsSP1Triangle(v0, v1, v2, flag) \
-	gO_( \
-		G_TRI1, \
-		gF_(gV3_(v0, v1, v2, flag) * 2, 8, 16) | \
-		gF_(gV3_(v1, v2, v0, flag) * 2, 8, 8) | \
-		gF_(gV3_(v2, v0, v1, flag) * 2, 8, 0), \
-		0)
 
 # define gsSP2Triangles(v00, v01, v02, flag0, v10, v11, v12, flag1) \
 	gO_( \
@@ -2854,6 +2854,14 @@
 /* instruction macros for f3dex2 */
 
 #if defined(F3DEX_GBI_2)
+
+# define gsSP1Triangle(v0, v1, v2, flag) \
+	gO_( \
+		G_TRI1, \
+		gF_(gV3_(v0, v1, v2, flag) * 2, 8, 16) | \
+		gF_(gV3_(v1, v2, v0, flag) * 2, 8, 8) | \
+		gF_(gV3_(v2, v0, v1, flag) * 2, 8, 0), \
+		0)
 
 # define gsSP1Quadrangle(v0, v1, v2, v3, flag) \
 	gO_( \

--- a/lib/libgfxd/uc_macrofn.c
+++ b/lib/libgfxd/uc_macrofn.c
@@ -1024,7 +1024,36 @@ UCFUNC int d_SP1Triangle(gfxd_macro_t *m, uint32_t hi, uint32_t lo)
 	}
 	return ret;
 }
-#elif defined(F3DEX_GBI) || defined(F3DEX_GBI_2)
+#elif defined(F3DEX_GBI)
+UCFUNC int d_SP1Triangle(gfxd_macro_t *m, uint32_t hi, uint32_t lo)
+{
+	m->id = gfxd_SP1Triangle;
+	int n0 = getfield(lo, 8, 16);
+	int n1 = getfield(lo, 8, 8);
+	int n2 = getfield(lo, 8, 0);
+	argi(m, 0, "v0", n0 / 2, gfxd_Vtx);
+	argi(m, 1, "v1", n1 / 2, gfxd_Vtx);
+	argi(m, 2, "v2", n2 / 2, gfxd_Vtx);
+	argi(m, 3, "flag", 0, gfxd_Vtxflag);
+	int ret = 0;
+	if (n0 % 2 != 0)
+	{
+		badarg(m, 0);
+		ret = -1;
+	}
+	if (n1 % 2 != 0)
+	{
+		badarg(m, 1);
+		ret = -1;
+	}
+	if (n2 % 2 != 0)
+	{
+		badarg(m, 2);
+		ret = -1;
+	}
+	return ret;
+}
+#elif defined(F3DEX_GBI_2)
 UCFUNC int d_SP1Triangle(gfxd_macro_t *m, uint32_t hi, uint32_t lo)
 {
 	m->id = gfxd_SP1Triangle;
@@ -1053,7 +1082,9 @@ UCFUNC int d_SP1Triangle(gfxd_macro_t *m, uint32_t hi, uint32_t lo)
 	}
 	return ret;
 }
+#endif
 
+#if defined(F3DEX_GBI) || defined(F3DEX_GBI_2)
 UCFUNC int d_SP1Quadrangle(gfxd_macro_t *m, uint32_t hi, uint32_t lo);
 UCFUNC int d_SP2Triangles(gfxd_macro_t *m, uint32_t hi, uint32_t lo)
 {
@@ -2015,10 +2046,6 @@ UCFUNC int c_DPLoadTLUT(gfxd_macro_t *m, int n_macro)
 	argu(m, 2, "dram", dram, gfxd_Tlut);
 	return 0;
 }
-
-#ifdef _MSC_VER
-#pragma warning(disable:4146)
-#endif
 
 #if defined(F3DEX_GBI) || defined(F3DEX_GBI_2)
 UCFUNC int d_BranchZ(gfxd_macro_t *m, uint32_t hi, uint32_t lo)


### PR DESCRIPTION
Updates libgfxd to the latest version. It fixes the `SP1Triangle` macro that was broken for F3DEX.
