### PR TITLE
Fix DLists' IA4 format detection 

### DIFF
--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -2147,7 +2147,7 @@ TextureType ZDisplayList::TexFormatToTexType(F3DZEXTexFormats fmt, F3DZEXTexSize
 	else if (fmt == F3DZEXTexFormats::G_IM_FMT_IA)
 	{
 		if (siz == F3DZEXTexSizes::G_IM_SIZ_4b)
-			return TextureType::Grayscale4bpp;
+			return TextureType::GrayscaleAlpha4bpp;
 		else if (siz == F3DZEXTexSizes::G_IM_SIZ_8b)
 			return TextureType::GrayscaleAlpha8bpp;
 		else if (siz == F3DZEXTexSizes::G_IM_SIZ_16b)


### PR DESCRIPTION
Properly extract IA4 textures with their correct format, instead of I4.
This bug seems to only happen in textures that are not declared in the XML, but are referenced by a dlist.
One example of this issue is the only texture in `object_gi_butterfly`.