### PR TITLE
Fix unused enum value warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CXXFLAGS += -fpic -std=c++17 -Wall -fno-omit-frame-pointer
 ifneq ($(DEBUG),0)
   OPTIMIZATION_ON = 0
   DEPRECATION_OFF = 1
-  CFLAGS += -g3 -DDEVELOPMENT
+  CXXFLAGS += -g3 -DDEVELOPMENT
   COPYCHECK_ARGS += --devel
   DEPRECATION_ON = 0
 endif

--- a/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.cpp
+++ b/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.cpp
@@ -281,7 +281,7 @@ std::string FlashingTexture::GenerateSourceCode(ZRoom* zRoom, uint32_t baseAddre
 
 		zRoom->parent->AddDeclarationArray(
 			envColorSegmentOffset, DeclarationAlignment::Align4, envColors.size() * 4,
-			"Color_RGBA8",
+			"F3DEnvColor",
 			StringHelper::Sprintf("%sAnimatedMaterialEnvColors0x%06X", zRoom->GetName().c_str(),
 		                          envColorSegmentOffset),
 			envColors.size(), declaration);

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -1,4 +1,6 @@
 #include "ZSkeleton.h"
+
+#include <cassert>
 #include "BitConverter.h"
 #include "HighLevel/HLModelIntermediette.h"
 #include "StringHelper.h"
@@ -301,8 +303,12 @@ std::string ZLimbTable::GetSourceTypeName() const
 	case ZLimbType::Curve:
 	case ZLimbType::Legacy:
 		return StringHelper::Sprintf("%s*", ZLimb::GetSourceTypeName(limbType));
-		;
+
+	case ZLimbType::Invalid:
+		assert("Invalid limb type.\n");
 	}
+
+	return "ERROR";
 }
 
 ZResourceType ZLimbTable::GetResourceType() const


### PR DESCRIPTION
Currently building ZAPD shows a warning about an unused value of an enum not handled in a switch.
This isn't really an issue for anything, but Jenkins checks new warnings in the MM repo, so Jenkins is mad about it ( zeldaret/mm/pull/226 )

For anybody curious, this is the warning:
```
ZAPD/ZSkeleton.cpp: In member function ‘virtual std::string ZLimbTable::GetSourceTypeName() const’:
ZAPD/ZSkeleton.cpp:294:9: warning: enumeration value ‘Invalid’ not handled in switch [-Wswitch]
  294 |  switch (limbType)
      |         ^
ZAPD/ZSkeleton.cpp:306:1: warning: control reaches end of non-void function [-Wreturn-type]
  306 | }
      | ^
```


