### PR TITLE
Fix compilation with -Wextra

### DIFF
--- a/ExporterTest/CollisionExporter.h
+++ b/ExporterTest/CollisionExporter.h
@@ -6,5 +6,5 @@
 class ExporterExample_Collision : public ZResourceExporter
 {
 public:
-	virtual void Save(ZResource* res, fs::path outPath, BinaryWriter* writer) override;
+	void Save(ZResource* res, fs::path outPath, BinaryWriter* writer) override;
 };

--- a/ExporterTest/RoomExporter.h
+++ b/ExporterTest/RoomExporter.h
@@ -6,5 +6,5 @@
 class ExporterExample_Room : public ZResourceExporter
 {
 public:
-	virtual void Save(ZResource* res, fs::path outPath, BinaryWriter* writer) override;
+	void Save(ZResource* res, fs::path outPath, BinaryWriter* writer) override;
 };

--- a/ExporterTest/TextureExporter.h
+++ b/ExporterTest/TextureExporter.h
@@ -7,5 +7,5 @@
 class ExporterExample_Texture : public ZResourceExporter
 {
 public:
-	virtual void Save(ZResource* res, fs::path outPath, BinaryWriter* writer) override;
+	void Save(ZResource* res, fs::path outPath, BinaryWriter* writer) override;
 };

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ COPYCHECK_ARGS ?=
 
 CXX := g++
 INC := -I ZAPD -I lib/assimp/include -I lib/elfio -I lib/json/include -I lib/stb -I lib/tinygltf -I lib/libgfxd -I lib/tinyxml2 -I ZAPDUtils
-CXXFLAGS += -fpic -std=c++17 -Wall -fno-omit-frame-pointer
+CXXFLAGS += -fpic -std=c++17 -Wall -Wextra -Werror -fno-omit-frame-pointer
 
 ifneq ($(DEBUG),0)
   OPTIMIZATION_ON = 0

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -1,7 +1,7 @@
 #include "Globals.h"
-#include <algorithm>
 #include <Utils/File.h>
 #include <Utils/Path.h>
+#include <algorithm>
 #include "tinyxml2.h"
 
 using namespace tinyxml2;
@@ -204,7 +204,7 @@ ZResourceExporter* Globals::GetExporter(ZResourceType resType)
 	auto exporters = *GetExporterMap();
 
 	if (currentExporter != "" && exporters[currentExporter]->exporters.find(resType) !=
-		exporters[currentExporter]->exporters.end())
+	                                 exporters[currentExporter]->exporters.end())
 		return exporters[currentExporter]->exporters[resType];
 	else
 		return nullptr;

--- a/ZAPD/ImageBackend.cpp
+++ b/ZAPD/ImageBackend.cpp
@@ -216,7 +216,8 @@ void ImageBackend::WritePng(const char* filename)
 
 void ImageBackend::WritePng(const fs::path& filename)
 {
-	// Note: The .string() is necessary for MSVC, due to the implementation of std::filesystem differing from GCC. Do not remove!
+	// Note: The .string() is necessary for MSVC, due to the implementation of std::filesystem
+	// differing from GCC. Do not remove!
 	WritePng(filename.string().c_str());
 }
 

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -1,7 +1,7 @@
-#include "BuildInfo.h"
 #include <Utils/Directory.h>
 #include <Utils/File.h>
 #include <Utils/Path.h>
+#include "BuildInfo.h"
 #include "Globals.h"
 #include "Overlays/ZOverlay.h"
 #include "ZAnimation.h"

--- a/ZAPD/OutputFormatter.cpp
+++ b/ZAPD/OutputFormatter.cpp
@@ -102,9 +102,8 @@ int (*OutputFormatter::StaticWriter())(const char* buf, int count)
 }
 
 OutputFormatter::OutputFormatter(uint32_t tabSize, uint32_t defaultIndent, uint32_t lineLimit)
-	: tabSize{tabSize}, defaultIndent{defaultIndent}, lineLimit{lineLimit}, col{0}, nest{0},
-	  nestIndent{defaultIndent}, currentIndent{defaultIndent},
-	  wordNests(0), wordP{word}, spaceP{space}
+	: tabSize{tabSize}, lineLimit{lineLimit}, col{0}, nest{0}, nestIndent{defaultIndent},
+	  currentIndent{defaultIndent}, wordNests(0), wordP{word}, spaceP{space}
 {
 }
 

--- a/ZAPD/OutputFormatter.h
+++ b/ZAPD/OutputFormatter.h
@@ -8,7 +8,6 @@ class OutputFormatter
 {
 private:
 	const uint32_t tabSize;
-	const uint32_t defaultIndent;
 	const uint32_t lineLimit;
 
 	uint32_t col;

--- a/ZAPD/Overlays/ZOverlay.cpp
+++ b/ZAPD/Overlays/ZOverlay.cpp
@@ -191,6 +191,7 @@ ZOverlay* ZOverlay::FromBuild(std::string buildPath, std::string cfgFolderPath)
 
 std::string ZOverlay::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	std::string output = "";
 
 	output += ".section .ovl\n";

--- a/ZAPD/Overlays/ZOverlay.cpp
+++ b/ZAPD/Overlays/ZOverlay.cpp
@@ -189,9 +189,8 @@ ZOverlay* ZOverlay::FromBuild(std::string buildPath, std::string cfgFolderPath)
 	return ovl;
 }
 
-std::string ZOverlay::GetSourceOutputCode(const std::string& prefix)
+std::string ZOverlay::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	std::string output = "";
 
 	output += ".section .ovl\n";

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -23,9 +23,8 @@ void ZAnimation::ParseRawData()
 	frameCount = BitConverter::ToInt16BE(parent->GetRawData(), rawDataIndex + 0);
 }
 
-std::string ZAnimation::GetSourceOutputCode(const std::string& prefix)
+std::string ZAnimation::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	return "";
 }
 
@@ -41,9 +40,8 @@ ZNormalAnimation::ZNormalAnimation(ZFile* nParent) : ZAnimation(nParent)
 	limit = 0;
 }
 
-std::string ZNormalAnimation::GetSourceOutputCode(const std::string& prefix)
+std::string ZNormalAnimation::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	if (parent != nullptr)
 	{
 		std::string defaultPrefix = name.c_str();
@@ -140,9 +138,8 @@ ZLinkAnimation::ZLinkAnimation(ZFile* nParent) : ZAnimation(nParent)
 	segmentAddress = 0;
 }
 
-std::string ZLinkAnimation::GetSourceOutputCode(const std::string& prefix)
+std::string ZLinkAnimation::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	if (parent != nullptr)
 	{
 		std::string segSymbol =
@@ -198,9 +195,8 @@ TransformData::TransformData(ZFile* parent, const std::vector<uint8_t>& rawData,
 {
 }
 
-std::string TransformData::GetBody(const std::string& prefix) const
+std::string TransformData::GetBody([[maybe_unused]] const std::string& prefix) const
 {
-	(void)prefix;
 	return StringHelper::Sprintf("0x%04X, 0x%04X, %i, %i, %ff", unk_00, unk_02, unk_04, unk_06,
 	                             unk_08);
 }
@@ -581,9 +577,8 @@ std::string ZLegacyAnimation::GetBodySourceCode() const
 	return body;
 }
 
-std::string ZLegacyAnimation::GetSourceOutputCode(const std::string& prefix)
+std::string ZLegacyAnimation::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	std::string body = GetBodySourceCode();
 
 	Declaration* decl = parent->GetDeclaration(rawDataIndex);

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -1,8 +1,8 @@
 #include "ZAnimation.h"
 #include <utility>
+#include "Globals.h"
 #include "Utils/BitConverter.h"
 #include "Utils/File.h"
-#include "Globals.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -25,6 +25,7 @@ void ZAnimation::ParseRawData()
 
 std::string ZAnimation::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	return "";
 }
 
@@ -42,6 +43,7 @@ ZNormalAnimation::ZNormalAnimation(ZFile* nParent) : ZAnimation(nParent)
 
 std::string ZNormalAnimation::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	if (parent != nullptr)
 	{
 		std::string defaultPrefix = name.c_str();
@@ -140,6 +142,7 @@ ZLinkAnimation::ZLinkAnimation(ZFile* nParent) : ZAnimation(nParent)
 
 std::string ZLinkAnimation::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	if (parent != nullptr)
 	{
 		std::string segSymbol =
@@ -197,6 +200,7 @@ TransformData::TransformData(ZFile* parent, const std::vector<uint8_t>& rawData,
 
 std::string TransformData::GetBody(const std::string& prefix) const
 {
+	(void)prefix;
 	return StringHelper::Sprintf("0x%04X, 0x%04X, %i, %i, %ff", unk_00, unk_02, unk_04, unk_06,
 	                             unk_08);
 }
@@ -579,6 +583,7 @@ std::string ZLegacyAnimation::GetBodySourceCode() const
 
 std::string ZLegacyAnimation::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	std::string body = GetBodySourceCode();
 
 	Declaration* decl = parent->GetDeclaration(rawDataIndex);

--- a/ZAPD/ZAnimation.h
+++ b/ZAPD/ZAnimation.h
@@ -51,7 +51,7 @@ public:
 	std::string GetSourceTypeName() const override;
 
 protected:
-	virtual void ParseRawData() override;
+	void ParseRawData() override;
 };
 
 class ZLinkAnimation : public ZAnimation
@@ -66,7 +66,7 @@ public:
 	std::string GetSourceTypeName() const override;
 
 protected:
-	virtual void ParseRawData() override;
+	void ParseRawData() override;
 };
 
 class TransformData

--- a/ZAPD/ZArray.cpp
+++ b/ZAPD/ZArray.cpp
@@ -55,6 +55,7 @@ void ZArray::ParseXML(tinyxml2::XMLElement* reader)
 
 std::string ZArray::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	std::string output = "";
 
 	for (size_t i = 0; i < arrayCnt; i++)

--- a/ZAPD/ZArray.cpp
+++ b/ZAPD/ZArray.cpp
@@ -53,9 +53,8 @@ void ZArray::ParseXML(tinyxml2::XMLElement* reader)
 	}
 }
 
-std::string ZArray::GetSourceOutputCode(const std::string& prefix)
+std::string ZArray::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	std::string output = "";
 
 	for (size_t i = 0; i < arrayCnt; i++)

--- a/ZAPD/ZBackground.cpp
+++ b/ZAPD/ZBackground.cpp
@@ -160,7 +160,7 @@ void ZBackground::Save(const fs::path& outFolder)
 	File::WriteAllBytes(filepath.string(), data);
 }
 
-std::string ZBackground::GetBodySourceCode()
+std::string ZBackground::GetBodySourceCode() const
 {
 	std::string bodyStr = "    ";
 

--- a/ZAPD/ZBackground.cpp
+++ b/ZAPD/ZBackground.cpp
@@ -1,7 +1,7 @@
 #include "ZBackground.h"
+#include "Globals.h"
 #include "Utils/BitConverter.h"
 #include "Utils/File.h"
-#include "Globals.h"
 #include "Utils/Path.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"

--- a/ZAPD/ZBackground.h
+++ b/ZAPD/ZBackground.h
@@ -26,7 +26,7 @@ public:
 	bool IsExternalResource() const override;
 	std::string GetExternalExtension() const override;
 	void Save(const fs::path& outFolder) override;
-	std::string GetBodySourceCode();
+	std::string GetBodySourceCode() const override;
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 	static std::string GetDefaultName(const std::string& prefix, uint32_t address);
 

--- a/ZAPD/ZBlob.cpp
+++ b/ZAPD/ZBlob.cpp
@@ -51,6 +51,7 @@ void ZBlob::ParseRawData()
 
 std::string ZBlob::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	sourceOutput = "";
 
 	for (size_t i = 0; i < blobData.size(); i += 1)
@@ -74,6 +75,7 @@ std::string ZBlob::GetSourceOutputCode(const std::string& prefix)
 
 std::string ZBlob::GetSourceOutputHeader(const std::string& prefix)
 {
+	(void)prefix;
 	return StringHelper::Sprintf("extern u8 %s[];\n", name.c_str());
 }
 

--- a/ZAPD/ZBlob.cpp
+++ b/ZAPD/ZBlob.cpp
@@ -49,9 +49,8 @@ void ZBlob::ParseRawData()
 	                parent->GetRawData().begin() + rawDataIndex + blobSize);
 }
 
-std::string ZBlob::GetSourceOutputCode(const std::string& prefix)
+std::string ZBlob::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	sourceOutput = "";
 
 	for (size_t i = 0; i < blobData.size(); i += 1)
@@ -73,9 +72,8 @@ std::string ZBlob::GetSourceOutputCode(const std::string& prefix)
 	return sourceOutput;
 }
 
-std::string ZBlob::GetSourceOutputHeader(const std::string& prefix)
+std::string ZBlob::GetSourceOutputHeader([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	return StringHelper::Sprintf("extern u8 %s[];\n", name.c_str());
 }
 

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -1,8 +1,8 @@
 #include "ZCollision.h"
 #include <stdint.h>
 #include <string>
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 
 REGISTER_ZFILENODE(Collision, ZCollisionHeader);
@@ -240,7 +240,8 @@ WaterBoxHeader::WaterBoxHeader(const std::vector<uint8_t>& rawData, uint32_t raw
 
 CameraDataList::CameraDataList(ZFile* parent, const std::string& prefix,
                                const std::vector<uint8_t>& rawData, uint32_t rawDataIndex,
-                               uint32_t polyTypeDefSegmentOffset, [[maybe_unused]] uint32_t polygonTypesCnt)
+                               uint32_t polyTypeDefSegmentOffset,
+                               [[maybe_unused]] uint32_t polygonTypesCnt)
 {
 	std::string declaration = "";
 

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -240,9 +240,8 @@ WaterBoxHeader::WaterBoxHeader(const std::vector<uint8_t>& rawData, uint32_t raw
 
 CameraDataList::CameraDataList(ZFile* parent, const std::string& prefix,
                                const std::vector<uint8_t>& rawData, uint32_t rawDataIndex,
-                               uint32_t polyTypeDefSegmentOffset, uint32_t polygonTypesCnt)
+                               uint32_t polyTypeDefSegmentOffset, [[maybe_unused]] uint32_t polygonTypesCnt)
 {
-	(void)polygonTypesCnt;
 	std::string declaration = "";
 
 	// Parse CameraDataEntries

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -242,6 +242,7 @@ CameraDataList::CameraDataList(ZFile* parent, const std::string& prefix,
                                const std::vector<uint8_t>& rawData, uint32_t rawDataIndex,
                                uint32_t polyTypeDefSegmentOffset, uint32_t polygonTypesCnt)
 {
+	(void)polygonTypesCnt;
 	std::string declaration = "";
 
 	// Parse CameraDataEntries

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -449,6 +449,8 @@ ZResourceType ZCutscene::GetResourceType() const
 
 CutsceneCommand::CutsceneCommand(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
+	(void)rawData;
+	(void)rawDataIndex;
 }
 
 CutsceneCommand::~CutsceneCommand()
@@ -524,6 +526,7 @@ std::string CutsceneCommandSetCameraPos::GetCName()
 
 std::string CutsceneCommandSetCameraPos::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 
 	std::string listStr = "";
@@ -612,6 +615,7 @@ std::string CutsceneCommandFadeBGM::GetCName()
 
 std::string CutsceneCommandFadeBGM::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_FADE_BGM_LIST(%i),\n", entries.size());
@@ -665,6 +669,7 @@ CutsceneCommandPlayBGM::CutsceneCommandPlayBGM(const std::vector<uint8_t>& rawDa
 
 std::string CutsceneCommandPlayBGM::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_PLAY_BGM_LIST(%i),\n", entries.size());
@@ -708,6 +713,7 @@ CutsceneCommandStopBGM::CutsceneCommandStopBGM(const std::vector<uint8_t>& rawDa
 
 std::string CutsceneCommandStopBGM::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_STOP_BGM_LIST(%i),\n", entries.size());
@@ -766,6 +772,7 @@ CutsceneCommandEnvLighting::CutsceneCommandEnvLighting(const std::vector<uint8_t
 
 std::string CutsceneCommandEnvLighting::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_LIGHTING_LIST(%i),\n", entries.size());
@@ -822,6 +829,7 @@ CutsceneCommandUnknown9::CutsceneCommandUnknown9(const std::vector<uint8_t>& raw
 
 std::string CutsceneCommandUnknown9::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_CMD_09_LIST(%i),\n", entries.size());
@@ -880,6 +888,7 @@ CutsceneCommandUnknown::CutsceneCommandUnknown(const std::vector<uint8_t>& rawDa
 
 std::string CutsceneCommandUnknown::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_UNK_DATA_LIST(0x%02X, %i),\n", commandID, entries.size());
@@ -938,6 +947,7 @@ std::string CutsceneCommandDayTime::GetCName()
 
 std::string CutsceneCommandDayTime::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_TIME_LIST(%i),\n", entries.size());
@@ -989,6 +999,7 @@ std::string CutsceneCommandTextbox::GetCName()
 
 std::string CutsceneCommandTextbox::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_TEXT_LIST(%i),\n", entries.size());
@@ -1055,6 +1066,7 @@ CutsceneCommandActorAction::CutsceneCommandActorAction(const std::vector<uint8_t
 
 std::string CutsceneCommandActorAction::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 	std::string subCommand = "";
 
@@ -1113,6 +1125,7 @@ std::string CutsceneCommandTerminator::GetCName()
 
 std::string CutsceneCommandTerminator::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_TERMINATOR(0x%04X, %i, %i),\n", base, startFrame, endFrame);
@@ -1135,6 +1148,7 @@ CutsceneCommandEnd::CutsceneCommandEnd(const std::vector<uint8_t>& rawData, uint
 
 std::string CutsceneCommandEnd::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_END(),\n");
@@ -1189,6 +1203,7 @@ CutsceneCommandSpecialAction::CutsceneCommandSpecialAction(const std::vector<uin
 
 std::string CutsceneCommandSpecialAction::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_MISC_LIST(%i),\n", entries.size());
@@ -1248,6 +1263,7 @@ CutsceneCommandSceneTransFX::CutsceneCommandSceneTransFX(const std::vector<uint8
 
 std::string CutsceneCommandSceneTransFX::GenerateSourceCode(uint32_t baseAddress)
 {
+	(void)baseAddress;
 	return StringHelper::Sprintf("CS_SCENE_TRANS_FX(%i, %i, %i),\n", base, startFrame, endFrame);
 }
 

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -447,10 +447,8 @@ ZResourceType ZCutscene::GetResourceType() const
 	return ZResourceType::Cutscene;
 }
 
-CutsceneCommand::CutsceneCommand(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
+CutsceneCommand::CutsceneCommand([[maybe_unused]] const std::vector<uint8_t>& rawData, [[maybe_unused]] uint32_t rawDataIndex)
 {
-	(void)rawData;
-	(void)rawDataIndex;
 }
 
 CutsceneCommand::~CutsceneCommand()
@@ -524,9 +522,8 @@ std::string CutsceneCommandSetCameraPos::GetCName()
 	return "";
 }
 
-std::string CutsceneCommandSetCameraPos::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandSetCameraPos::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 
 	std::string listStr = "";
@@ -613,9 +610,8 @@ std::string CutsceneCommandFadeBGM::GetCName()
 	return "CsCmdMusicFade";
 }
 
-std::string CutsceneCommandFadeBGM::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandFadeBGM::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_FADE_BGM_LIST(%i),\n", entries.size());
@@ -667,9 +663,8 @@ CutsceneCommandPlayBGM::CutsceneCommandPlayBGM(const std::vector<uint8_t>& rawDa
 	}
 }
 
-std::string CutsceneCommandPlayBGM::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandPlayBGM::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_PLAY_BGM_LIST(%i),\n", entries.size());
@@ -711,9 +706,8 @@ CutsceneCommandStopBGM::CutsceneCommandStopBGM(const std::vector<uint8_t>& rawDa
 	}
 }
 
-std::string CutsceneCommandStopBGM::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandStopBGM::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_STOP_BGM_LIST(%i),\n", entries.size());
@@ -770,9 +764,8 @@ CutsceneCommandEnvLighting::CutsceneCommandEnvLighting(const std::vector<uint8_t
 	}
 }
 
-std::string CutsceneCommandEnvLighting::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandEnvLighting::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_LIGHTING_LIST(%i),\n", entries.size());
@@ -827,9 +820,8 @@ CutsceneCommandUnknown9::CutsceneCommandUnknown9(const std::vector<uint8_t>& raw
 	}
 }
 
-std::string CutsceneCommandUnknown9::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandUnknown9::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_CMD_09_LIST(%i),\n", entries.size());
@@ -886,9 +878,8 @@ CutsceneCommandUnknown::CutsceneCommandUnknown(const std::vector<uint8_t>& rawDa
 	}
 }
 
-std::string CutsceneCommandUnknown::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandUnknown::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_UNK_DATA_LIST(0x%02X, %i),\n", commandID, entries.size());
@@ -945,9 +936,8 @@ std::string CutsceneCommandDayTime::GetCName()
 	return "CsCmdDayTime";
 }
 
-std::string CutsceneCommandDayTime::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandDayTime::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_TIME_LIST(%i),\n", entries.size());
@@ -997,9 +987,8 @@ std::string CutsceneCommandTextbox::GetCName()
 	return "CsCmdTextbox";
 }
 
-std::string CutsceneCommandTextbox::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandTextbox::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_TEXT_LIST(%i),\n", entries.size());
@@ -1064,9 +1053,8 @@ CutsceneCommandActorAction::CutsceneCommandActorAction(const std::vector<uint8_t
 	}
 }
 
-std::string CutsceneCommandActorAction::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandActorAction::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 	std::string subCommand = "";
 
@@ -1123,9 +1111,8 @@ std::string CutsceneCommandTerminator::GetCName()
 	return "CsCmdBase";
 }
 
-std::string CutsceneCommandTerminator::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandTerminator::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_TERMINATOR(0x%04X, %i, %i),\n", base, startFrame, endFrame);
@@ -1146,9 +1133,8 @@ CutsceneCommandEnd::CutsceneCommandEnd(const std::vector<uint8_t>& rawData, uint
 	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
 }
 
-std::string CutsceneCommandEnd::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandEnd::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_END(),\n");
@@ -1201,9 +1187,8 @@ CutsceneCommandSpecialAction::CutsceneCommandSpecialAction(const std::vector<uin
 	}
 }
 
-std::string CutsceneCommandSpecialAction::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandSpecialAction::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	std::string result = "";
 
 	result += StringHelper::Sprintf("CS_MISC_LIST(%i),\n", entries.size());
@@ -1261,9 +1246,8 @@ CutsceneCommandSceneTransFX::CutsceneCommandSceneTransFX(const std::vector<uint8
 	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
 }
 
-std::string CutsceneCommandSceneTransFX::GenerateSourceCode(uint32_t baseAddress)
+std::string CutsceneCommandSceneTransFX::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	return StringHelper::Sprintf("CS_SCENE_TRANS_FX(%i, %i, %i),\n", base, startFrame, endFrame);
 }
 

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -447,7 +447,8 @@ ZResourceType ZCutscene::GetResourceType() const
 	return ZResourceType::Cutscene;
 }
 
-CutsceneCommand::CutsceneCommand([[maybe_unused]] const std::vector<uint8_t>& rawData, [[maybe_unused]] uint32_t rawDataIndex)
+CutsceneCommand::CutsceneCommand([[maybe_unused]] const std::vector<uint8_t>& rawData,
+                                 [[maybe_unused]] uint32_t rawDataIndex)
 {
 }
 

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -84,7 +84,7 @@ CutsceneCommandSceneTransFX::~CutsceneCommandSceneTransFX()
 {
 }
 
-std::string ZCutscene::GetBodySourceCode()
+std::string ZCutscene::GetBodySourceCode() const
 {
 	std::string output = "";
 	size_t size = 0;

--- a/ZAPD/ZCutscene.h
+++ b/ZAPD/ZCutscene.h
@@ -412,7 +412,7 @@ class ZCutsceneBase : public ZResource
 {
 public:
 	ZCutsceneBase(ZFile* nParent);
-	virtual std::string GetBodySourceCode() = 0;
+	std::string GetBodySourceCode() const override = 0;
 	virtual void DeclareVar(const std::string& prefix, const std::string& bodyStr) const = 0;
 	virtual uint32_t getSegmentOffset() const = 0;
 };
@@ -425,7 +425,7 @@ public:
 
 	void ParseRawData() override;
 
-	std::string GetBodySourceCode() override;
+	std::string GetBodySourceCode() const override;
 	void DeclareVar(const std::string& prefix, const std::string& bodyStr) const override;
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 	size_t GetRawDataSize() const override;

--- a/ZAPD/ZCutsceneMM.cpp
+++ b/ZAPD/ZCutsceneMM.cpp
@@ -12,7 +12,7 @@ ZCutsceneMM::~ZCutsceneMM()
 		delete cmd;
 }
 
-std::string ZCutsceneMM::GetBodySourceCode()
+std::string ZCutsceneMM::GetBodySourceCode() const
 {
 	std::string output = "";
 

--- a/ZAPD/ZCutsceneMM.h
+++ b/ZAPD/ZCutsceneMM.h
@@ -15,7 +15,7 @@ public:
 	ZCutsceneMM(ZFile* nParent);
 	virtual ~ZCutsceneMM();
 
-	std::string GetBodySourceCode() override;
+	std::string GetBodySourceCode() const override;
 	void DeclareVar(const std::string& prefix, const std::string& bodyStr) const override;
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 	size_t GetRawDataSize() const override;

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -6,9 +6,9 @@
 #include <cassert>
 #include <chrono>
 #include <math.h>
-#include "Utils/BitConverter.h"
 #include "Globals.h"
 #include "OutputFormatter.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "gfxd.h"
 
@@ -78,7 +78,8 @@ void ZDisplayList::ParseRawData()
 	}
 }
 
-Declaration* ZDisplayList::DeclareVar([[maybe_unused]] const std::string& prefix, const std::string& bodyStr)
+Declaration* ZDisplayList::DeclareVar([[maybe_unused]] const std::string& prefix,
+                                      const std::string& bodyStr)
 {
 	return parent->AddDeclarationArray(rawDataIndex, DeclarationAlignment::Align8, GetRawDataSize(),
 	                                   GetSourceTypeName(), name, 0, bodyStr, true);

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -80,6 +80,7 @@ void ZDisplayList::ParseRawData()
 
 Declaration* ZDisplayList::DeclareVar(const std::string& prefix, const std::string& bodyStr)
 {
+	(void)prefix;
 	return parent->AddDeclarationArray(rawDataIndex, DeclarationAlignment::Align8, GetRawDataSize(),
 	                                   GetSourceTypeName(), name, 0, bodyStr, true);
 }
@@ -1539,6 +1540,7 @@ void ZDisplayList::Opcode_G_ENDDL(std::string prefix, char* line)
 
 std::string ZDisplayList::GetSourceOutputHeader(const std::string& prefix)
 {
+	(void)prefix;
 	return "";
 }
 
@@ -1657,6 +1659,7 @@ static int32_t GfxdCallback_Vtx(uint32_t seg, int32_t count)
 static int32_t GfxdCallback_Texture(segptr_t seg, int32_t fmt, int32_t siz, int32_t width,
                                     int32_t height, int32_t pal)
 {
+	(void)pal;
 	ZDisplayList* self = static_cast<ZDisplayList*>(gfxd_udata_get());
 	uint32_t texOffset = Seg2Filespace(seg, self->parent->baseAddress);
 	uint32_t texSegNum = GETSEGNUM(seg);
@@ -1693,6 +1696,7 @@ static int32_t GfxdCallback_Texture(segptr_t seg, int32_t fmt, int32_t siz, int3
 
 static int32_t GfxdCallback_Palette(uint32_t seg, int32_t idx, int32_t count)
 {
+	(void)idx;
 	ZDisplayList* self = static_cast<ZDisplayList*>(gfxd_udata_get());
 	uint32_t palOffset = Seg2Filespace(seg, self->parent->baseAddress);
 	uint32_t palSegNum = GETSEGNUM(seg);
@@ -2049,6 +2053,7 @@ bool ZDisplayList::TextureGenCheck(ZRoom* scene, ZFile* parent, std::string pref
                                    uint32_t texSeg, F3DZEXTexFormats texFmt, F3DZEXTexSizes texSiz,
                                    bool texLoaded, bool texIsPalette, ZDisplayList* self)
 {
+	(void)prefix;
 	int32_t segmentNumber = GETSEGNUM(texSeg);
 
 	if (!texIsPalette)

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -1544,7 +1544,7 @@ std::string ZDisplayList::GetSourceOutputHeader(const std::string& prefix)
 	return "";
 }
 
-static int32_t GfxdCallback_FormatSingleEntry(void)
+static int32_t GfxdCallback_FormatSingleEntry()
 {
 	ZDisplayList* self = static_cast<ZDisplayList*>(gfxd_udata_get());
 	gfxd_puts("\t");

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -78,9 +78,8 @@ void ZDisplayList::ParseRawData()
 	}
 }
 
-Declaration* ZDisplayList::DeclareVar(const std::string& prefix, const std::string& bodyStr)
+Declaration* ZDisplayList::DeclareVar([[maybe_unused]] const std::string& prefix, const std::string& bodyStr)
 {
-	(void)prefix;
 	return parent->AddDeclarationArray(rawDataIndex, DeclarationAlignment::Align8, GetRawDataSize(),
 	                                   GetSourceTypeName(), name, 0, bodyStr, true);
 }
@@ -1538,9 +1537,8 @@ void ZDisplayList::Opcode_G_ENDDL(std::string prefix, char* line)
 	TextureGenCheck(prefix);
 }
 
-std::string ZDisplayList::GetSourceOutputHeader(const std::string& prefix)
+std::string ZDisplayList::GetSourceOutputHeader([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	return "";
 }
 
@@ -1657,9 +1655,8 @@ static int32_t GfxdCallback_Vtx(uint32_t seg, int32_t count)
 }
 
 static int32_t GfxdCallback_Texture(segptr_t seg, int32_t fmt, int32_t siz, int32_t width,
-                                    int32_t height, int32_t pal)
+                                    int32_t height, [[maybe_unused]] int32_t pal)
 {
-	(void)pal;
 	ZDisplayList* self = static_cast<ZDisplayList*>(gfxd_udata_get());
 	uint32_t texOffset = Seg2Filespace(seg, self->parent->baseAddress);
 	uint32_t texSegNum = GETSEGNUM(seg);
@@ -1694,9 +1691,8 @@ static int32_t GfxdCallback_Texture(segptr_t seg, int32_t fmt, int32_t siz, int3
 	return 1;
 }
 
-static int32_t GfxdCallback_Palette(uint32_t seg, int32_t idx, int32_t count)
+static int32_t GfxdCallback_Palette(uint32_t seg, [[maybe_unused]] int32_t idx, int32_t count)
 {
-	(void)idx;
 	ZDisplayList* self = static_cast<ZDisplayList*>(gfxd_udata_get());
 	uint32_t palOffset = Seg2Filespace(seg, self->parent->baseAddress);
 	uint32_t palSegNum = GETSEGNUM(seg);
@@ -2048,12 +2044,11 @@ void ZDisplayList::TextureGenCheck(std::string prefix)
 	}
 }
 
-bool ZDisplayList::TextureGenCheck(ZRoom* scene, ZFile* parent, std::string prefix,
+bool ZDisplayList::TextureGenCheck(ZRoom* scene, ZFile* parent, [[maybe_unused]] std::string prefix,
                                    int32_t texWidth, int32_t texHeight, uint32_t texAddr,
                                    uint32_t texSeg, F3DZEXTexFormats texFmt, F3DZEXTexSizes texSiz,
                                    bool texLoaded, bool texIsPalette, ZDisplayList* self)
 {
-	(void)prefix;
 	int32_t segmentNumber = GETSEGNUM(texSeg);
 
 	if (!texIsPalette)

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -373,7 +373,7 @@ public:
 	std::string ProcessGfxDis(const std::string& prefix);
 
 	bool IsExternalResource() const override;
-	virtual std::string GetExternalExtension() const override;
+	std::string GetExternalExtension() const override;
 	std::string GetSourceTypeName() const override;
 
 	ZResourceType GetResourceType() const override;

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -73,6 +73,7 @@ ZFile::~ZFile()
 
 void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, bool placeholderMode)
 {
+	(void)placeholderMode;
 	if (filename == "")
 		name = reader->Attribute("Name");
 	else
@@ -1227,6 +1228,7 @@ std::string ZFile::ProcessExterns()
 
 std::string ZFile::ProcessTextureIntersections(std::string prefix)
 {
+	(void)prefix;
 	if (texturesResources.empty())
 		return "";
 

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -71,9 +71,8 @@ ZFile::~ZFile()
 	}
 }
 
-void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, bool placeholderMode)
+void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, [[maybe_unused]] bool placeholderMode)
 {
-	(void)placeholderMode;
 	if (filename == "")
 		name = reader->Attribute("Name");
 	else
@@ -1226,9 +1225,8 @@ std::string ZFile::ProcessExterns()
 	return output;
 }
 
-std::string ZFile::ProcessTextureIntersections(std::string prefix)
+std::string ZFile::ProcessTextureIntersections([[maybe_unused]] std::string prefix)
 {
-	(void)prefix;
 	if (texturesResources.empty())
 		return "";
 

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -4,10 +4,10 @@
 #include <algorithm>
 #include <cassert>
 #include <unordered_set>
-#include "Utils/Directory.h"
-#include "Utils/File.h"
 #include "Globals.h"
 #include "OutputFormatter.h"
+#include "Utils/Directory.h"
+#include "Utils/File.h"
 #include "Utils/Path.h"
 #include "ZAnimation.h"
 #include "ZArray.h"
@@ -71,7 +71,8 @@ ZFile::~ZFile()
 	}
 }
 
-void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename, [[maybe_unused]] bool placeholderMode)
+void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename,
+                     [[maybe_unused]] bool placeholderMode)
 {
 	if (filename == "")
 		name = reader->Attribute("Name");
@@ -306,8 +307,10 @@ void ZFile::ExtractResources()
 
 	if (memStream->GetLength() > 0)
 	{
-		File::WriteAllBytes(StringHelper::Sprintf("%s%s.bin", Globals::Instance->outputPath.string().c_str(), GetName().c_str()),
-			memStream->ToVector());
+		File::WriteAllBytes(StringHelper::Sprintf("%s%s.bin",
+		                                          Globals::Instance->outputPath.string().c_str(),
+		                                          GetName().c_str()),
+		                    memStream->ToVector());
 	}
 
 	writer.Close();

--- a/ZAPD/ZFile.h
+++ b/ZAPD/ZFile.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <Utils/Directory.h>
 #include <string>
 #include <vector>
-#include <Utils/Directory.h>
 #include "ZTexture.h"
 #include "tinyxml2.h"
 

--- a/ZAPD/ZLimb.cpp
+++ b/ZAPD/ZLimb.cpp
@@ -447,7 +447,6 @@ void ZLimb::ParseRawData()
 	case ZLimbType::LOD:
 		dList2Ptr = BitConverter::ToUInt32BE(rawData, rawDataIndex + 12);
 		[[fallthrough]];
-		// Intended fallthrough
 	case ZLimbType::Standard:
 		dListPtr = BitConverter::ToUInt32BE(rawData, rawDataIndex + 8);
 		break;

--- a/ZAPD/ZLimb.cpp
+++ b/ZAPD/ZLimb.cpp
@@ -446,6 +446,7 @@ void ZLimb::ParseRawData()
 	{
 	case ZLimbType::LOD:
 		dList2Ptr = BitConverter::ToUInt32BE(rawData, rawDataIndex + 12);
+		[[fallthrough]];
 		// Intended fallthrough
 	case ZLimbType::Standard:
 		dListPtr = BitConverter::ToUInt32BE(rawData, rawDataIndex + 8);

--- a/ZAPD/ZLimb.cpp
+++ b/ZAPD/ZLimb.cpp
@@ -1,7 +1,7 @@
 #include "ZLimb.h"
 #include <cassert>
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 
 REGISTER_ZFILENODE(Limb, ZLimb);

--- a/ZAPD/ZMtx.cpp
+++ b/ZAPD/ZMtx.cpp
@@ -48,7 +48,7 @@ void ZMtx::DeclareVar(const std::string& prefix, const std::string& bodyStr) con
 	                       GetSourceTypeName(), auxName, bodyStr);
 }
 
-std::string ZMtx::GetBodySourceCode()
+std::string ZMtx::GetBodySourceCode() const
 {
 	std::string bodyStr = "\n";
 

--- a/ZAPD/ZMtx.h
+++ b/ZAPD/ZMtx.h
@@ -17,7 +17,7 @@ public:
 
 	void DeclareVar(const std::string& prefix, const std::string& bodyStr) const;
 
-	std::string GetBodySourceCode();
+	std::string GetBodySourceCode() const override;
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 	static std::string GetDefaultName(const std::string& prefix, uint32_t address);
 

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -82,6 +82,7 @@ std::string ZPath::GetBodySourceCode() const
 
 std::string ZPath::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	std::string declaration = GetBodySourceCode();
 
 	Declaration* decl = parent->GetDeclaration(rawDataIndex);

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -80,9 +80,8 @@ std::string ZPath::GetBodySourceCode() const
 	return declaration;
 }
 
-std::string ZPath::GetSourceOutputCode(const std::string& prefix)
+std::string ZPath::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	std::string declaration = GetBodySourceCode();
 
 	Declaration* decl = parent->GetDeclaration(rawDataIndex);

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -1,7 +1,7 @@
 #include "ZPath.h"
 
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 

--- a/ZAPD/ZPath.h
+++ b/ZAPD/ZPath.h
@@ -11,12 +11,12 @@ public:
 	void ParseRawData() override;
 	void DeclareReferences(const std::string& prefix) override;
 
-	std::string GetBodySourceCode() const;
+	std::string GetBodySourceCode() const override;
 
 	std::string GetSourceTypeName() const override;
 	ZResourceType GetResourceType() const override;
 
-	size_t GetRawDataSize() const;
+	size_t GetRawDataSize() const override;
 	segptr_t GetListAddress() const;
 
 protected:
@@ -32,13 +32,13 @@ class ZPath : public ZResource
 public:
 	ZPath(ZFile* nParent);
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex);
+	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;
 	void DeclareReferences(const std::string& prefix) override;
 
-	std::string GetBodySourceCode() const;
+	std::string GetBodySourceCode() const override;
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 
 	std::string GetSourceTypeName() const override;

--- a/ZAPD/ZResource.cpp
+++ b/ZAPD/ZResource.cpp
@@ -114,9 +114,8 @@ void ZResource::ParseXML(tinyxml2::XMLElement* reader)
 	}
 }
 
-void ZResource::Save(const fs::path& outFolder)
+void ZResource::Save([[maybe_unused]] const fs::path& outFolder)
 {
-	(void)outFolder;
 }
 
 void ZResource::PreGenSourceFiles()
@@ -178,15 +177,13 @@ std::string ZResource::GetBodySourceCode() const
 	return "ERROR";
 }
 
-std::string ZResource::GetSourceOutputCode(const std::string& prefix)
+std::string ZResource::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	return "";
 }
 
-std::string ZResource::GetSourceOutputHeader(const std::string& prefix)
+std::string ZResource::GetSourceOutputHeader([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	return "";
 }
 
@@ -194,9 +191,8 @@ void ZResource::ParseRawData()
 {
 }
 
-void ZResource::DeclareReferences(const std::string& prefix)
+void ZResource::DeclareReferences([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 }
 
 std::string ZResource::GetSourceTypeName() const

--- a/ZAPD/ZResource.cpp
+++ b/ZAPD/ZResource.cpp
@@ -116,6 +116,7 @@ void ZResource::ParseXML(tinyxml2::XMLElement* reader)
 
 void ZResource::Save(const fs::path& outFolder)
 {
+	(void)outFolder;
 }
 
 void ZResource::PreGenSourceFiles()
@@ -179,11 +180,13 @@ std::string ZResource::GetBodySourceCode() const
 
 std::string ZResource::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	return "";
 }
 
 std::string ZResource::GetSourceOutputHeader(const std::string& prefix)
 {
+	(void)prefix;
 	return "";
 }
 
@@ -193,6 +196,7 @@ void ZResource::ParseRawData()
 
 void ZResource::DeclareReferences(const std::string& prefix)
 {
+	(void)prefix;
 }
 
 std::string ZResource::GetSourceTypeName() const

--- a/ZAPD/ZRoom/Commands/SetActorCutsceneList.cpp
+++ b/ZAPD/ZRoom/Commands/SetActorCutsceneList.cpp
@@ -1,7 +1,7 @@
 #include "SetActorCutsceneList.h"
 
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 #include "ZRoom/ZRoom.h"

--- a/ZAPD/ZRoom/Commands/SetActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetActorList.cpp
@@ -1,7 +1,7 @@
 #include "SetActorList.h"
 
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 #include "ZRoom/ZNames.h"

--- a/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
+++ b/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
@@ -8,9 +8,8 @@ SetAlternateHeaders::SetAlternateHeaders(ZFile* nParent) : ZRoomCommand(nParent)
 {
 }
 
-void SetAlternateHeaders::DeclareReferences(const std::string& prefix)
+void SetAlternateHeaders::DeclareReferences([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	if (segmentOffset != 0)
 		parent->AddDeclarationPlaceholder(segmentOffset);
 }

--- a/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
+++ b/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
@@ -10,6 +10,7 @@ SetAlternateHeaders::SetAlternateHeaders(ZFile* nParent) : ZRoomCommand(nParent)
 
 void SetAlternateHeaders::DeclareReferences(const std::string& prefix)
 {
+	(void)prefix;
 	if (segmentOffset != 0)
 		parent->AddDeclarationPlaceholder(segmentOffset);
 }

--- a/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.cpp
+++ b/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.cpp
@@ -178,6 +178,8 @@ ScrollingTexture::ScrollingTexture(const std::vector<uint8_t>& rawData, uint32_t
 
 std::string ScrollingTexture::GenerateSourceCode(ZRoom* zRoom, uint32_t baseAddress)
 {
+	(void)zRoom;
+	(void)baseAddress;
 	return StringHelper::Sprintf("    { %i, %i, 0x%02X, 0x%02X },", xStep, yStep, width, height);
 }
 
@@ -239,6 +241,7 @@ FlashingTexture::FlashingTexture(const std::vector<uint8_t>& rawData, uint32_t r
 
 std::string FlashingTexture::GenerateSourceCode(ZRoom* zRoom, uint32_t baseAddress)
 {
+	(void)baseAddress;
 	if (primColorSegmentOffset != 0)
 	{
 		std::string declaration = "";
@@ -354,6 +357,7 @@ AnimatedMatTexCycleParams::AnimatedMatTexCycleParams(const std::vector<uint8_t>&
 
 std::string AnimatedMatTexCycleParams::GenerateSourceCode(ZRoom* zRoom, uint32_t baseAddress)
 {
+	(void)baseAddress;
 	if (textureSegmentOffsetsSegmentOffset != 0)
 	{
 		std::string declaration = "";

--- a/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.cpp
+++ b/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.cpp
@@ -176,10 +176,8 @@ ScrollingTexture::ScrollingTexture(const std::vector<uint8_t>& rawData, uint32_t
 {
 }
 
-std::string ScrollingTexture::GenerateSourceCode(ZRoom* zRoom, uint32_t baseAddress)
+std::string ScrollingTexture::GenerateSourceCode([[maybe_unused]] ZRoom* zRoom, [[maybe_unused]] uint32_t baseAddress)
 {
-	(void)zRoom;
-	(void)baseAddress;
 	return StringHelper::Sprintf("    { %i, %i, 0x%02X, 0x%02X },", xStep, yStep, width, height);
 }
 
@@ -239,9 +237,8 @@ FlashingTexture::FlashingTexture(const std::vector<uint8_t>& rawData, uint32_t r
 	}
 }
 
-std::string FlashingTexture::GenerateSourceCode(ZRoom* zRoom, uint32_t baseAddress)
+std::string FlashingTexture::GenerateSourceCode(ZRoom* zRoom, [[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	if (primColorSegmentOffset != 0)
 	{
 		std::string declaration = "";
@@ -355,9 +352,8 @@ AnimatedMatTexCycleParams::AnimatedMatTexCycleParams(const std::vector<uint8_t>&
 	}
 }
 
-std::string AnimatedMatTexCycleParams::GenerateSourceCode(ZRoom* zRoom, uint32_t baseAddress)
+std::string AnimatedMatTexCycleParams::GenerateSourceCode(ZRoom* zRoom, [[maybe_unused]] uint32_t baseAddress)
 {
-	(void)baseAddress;
 	if (textureSegmentOffsetsSegmentOffset != 0)
 	{
 		std::string declaration = "";

--- a/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.cpp
+++ b/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.cpp
@@ -1,7 +1,7 @@
 #include "SetAnimatedMaterialList.h"
 
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 #include "ZRoom/ZRoom.h"
@@ -176,7 +176,8 @@ ScrollingTexture::ScrollingTexture(const std::vector<uint8_t>& rawData, uint32_t
 {
 }
 
-std::string ScrollingTexture::GenerateSourceCode([[maybe_unused]] ZRoom* zRoom, [[maybe_unused]] uint32_t baseAddress)
+std::string ScrollingTexture::GenerateSourceCode([[maybe_unused]] ZRoom* zRoom,
+                                                 [[maybe_unused]] uint32_t baseAddress)
 {
 	return StringHelper::Sprintf("    { %i, %i, 0x%02X, 0x%02X },", xStep, yStep, width, height);
 }
@@ -352,7 +353,8 @@ AnimatedMatTexCycleParams::AnimatedMatTexCycleParams(const std::vector<uint8_t>&
 	}
 }
 
-std::string AnimatedMatTexCycleParams::GenerateSourceCode(ZRoom* zRoom, [[maybe_unused]] uint32_t baseAddress)
+std::string AnimatedMatTexCycleParams::GenerateSourceCode(ZRoom* zRoom,
+                                                          [[maybe_unused]] uint32_t baseAddress)
 {
 	if (textureSegmentOffsetsSegmentOffset != 0)
 	{

--- a/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.h
+++ b/ZAPD/ZRoom/Commands/SetAnimatedMaterialList.h
@@ -4,14 +4,15 @@
 #include "ZRoom/ZRoomCommand.h"
 
 // TODO move into header and add all types
-class AnitmatedTextureParams
+class AnimatedTextureParams
 {
 public:
+	virtual ~AnimatedTextureParams() = default;
 	virtual std::string GenerateSourceCode(ZRoom* zRoom, uint32_t baseAddress) = 0;
 	virtual size_t GetParamsSize() = 0;
 };
 
-class ScrollingTexture : public AnitmatedTextureParams
+class ScrollingTexture : public AnimatedTextureParams
 {
 public:
 	ScrollingTexture(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex);
@@ -47,7 +48,7 @@ public:
 	uint8_t a;
 };
 
-class FlashingTexture : public AnitmatedTextureParams
+class FlashingTexture : public AnimatedTextureParams
 {
 public:
 	FlashingTexture(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex, int32_t type);
@@ -70,7 +71,7 @@ public:
 	std::vector<uint16_t> keyFrames;
 };
 
-class AnimatedMatTexCycleParams : public AnitmatedTextureParams
+class AnimatedMatTexCycleParams : public AnimatedTextureParams
 {
 public:
 	AnimatedMatTexCycleParams(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex);
@@ -97,7 +98,7 @@ public:
 	int16_t type;
 	segptr_t segmentAddress;
 	uint32_t segmentOffset;
-	std::vector<std::shared_ptr<AnitmatedTextureParams>> params;
+	std::vector<std::shared_ptr<AnimatedTextureParams>> params;
 };
 
 class SetAnimatedMaterialList : public ZRoomCommand

--- a/ZAPD/ZRoom/Commands/SetCameraSettings.h
+++ b/ZAPD/ZRoom/Commands/SetCameraSettings.h
@@ -16,5 +16,6 @@ public:
 
 	std::string GetCommandCName() const override;
 	RoomCommand GetRoomCommand() const override;
+
 private:
 };

--- a/ZAPD/ZRoom/Commands/SetCutscenes.cpp
+++ b/ZAPD/ZRoom/Commands/SetCutscenes.cpp
@@ -1,7 +1,7 @@
 #include "SetCutscenes.h"
 
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 #include "ZRoom/ZRoom.h"

--- a/ZAPD/ZRoom/Commands/SetCutscenes.h
+++ b/ZAPD/ZRoom/Commands/SetCutscenes.h
@@ -21,7 +21,7 @@ public:
 	std::vector<ZCutsceneBase*> cutscenes;
 	std::vector<CutsceneEntry> cutsceneEntries;  // (MM Only)
 	uint8_t numCutscenes;                        // (MM Only)
-	
+
 	SetCutscenes(ZFile* nParent);
 	~SetCutscenes();
 

--- a/ZAPD/ZRoom/Commands/SetEntranceList.cpp
+++ b/ZAPD/ZRoom/Commands/SetEntranceList.cpp
@@ -11,6 +11,7 @@ SetEntranceList::SetEntranceList(ZFile* nParent) : ZRoomCommand(nParent)
 
 void SetEntranceList::DeclareReferences(const std::string& prefix)
 {
+	(void)prefix;
 	if (segmentOffset != 0)
 		parent->AddDeclarationPlaceholder(segmentOffset);
 }
@@ -32,6 +33,7 @@ void SetEntranceList::ParseRawDataLate()
 
 void SetEntranceList::DeclareReferencesLate(const std::string& prefix)
 {
+	(void)prefix;
 	if (!entrances.empty())
 	{
 		std::string declaration = "";

--- a/ZAPD/ZRoom/Commands/SetEntranceList.cpp
+++ b/ZAPD/ZRoom/Commands/SetEntranceList.cpp
@@ -9,9 +9,8 @@ SetEntranceList::SetEntranceList(ZFile* nParent) : ZRoomCommand(nParent)
 {
 }
 
-void SetEntranceList::DeclareReferences(const std::string& prefix)
+void SetEntranceList::DeclareReferences([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	if (segmentOffset != 0)
 		parent->AddDeclarationPlaceholder(segmentOffset);
 }
@@ -31,9 +30,8 @@ void SetEntranceList::ParseRawDataLate()
 	}
 }
 
-void SetEntranceList::DeclareReferencesLate(const std::string& prefix)
+void SetEntranceList::DeclareReferencesLate([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	if (!entrances.empty())
 	{
 		std::string declaration = "";

--- a/ZAPD/ZRoom/Commands/SetEntranceList.cpp
+++ b/ZAPD/ZRoom/Commands/SetEntranceList.cpp
@@ -1,6 +1,6 @@
 #include "SetEntranceList.h"
-#include "Utils/BitConverter.h"
 #include "SetStartPositionList.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 #include "ZRoom/ZRoom.h"

--- a/ZAPD/ZRoom/Commands/SetExitList.cpp
+++ b/ZAPD/ZRoom/Commands/SetExitList.cpp
@@ -9,9 +9,8 @@ SetExitList::SetExitList(ZFile* nParent) : ZRoomCommand(nParent)
 {
 }
 
-void SetExitList::DeclareReferences(const std::string& prefix)
+void SetExitList::DeclareReferences([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	if (segmentOffset != 0)
 		parent->AddDeclarationPlaceholder(segmentOffset);
 }
@@ -31,9 +30,8 @@ void SetExitList::ParseRawDataLate()
 	}
 }
 
-void SetExitList::DeclareReferencesLate(const std::string& prefix)
+void SetExitList::DeclareReferencesLate([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	if (!exits.empty())
 	{
 		std::string declaration = "";

--- a/ZAPD/ZRoom/Commands/SetExitList.cpp
+++ b/ZAPD/ZRoom/Commands/SetExitList.cpp
@@ -11,6 +11,7 @@ SetExitList::SetExitList(ZFile* nParent) : ZRoomCommand(nParent)
 
 void SetExitList::DeclareReferences(const std::string& prefix)
 {
+	(void)prefix;
 	if (segmentOffset != 0)
 		parent->AddDeclarationPlaceholder(segmentOffset);
 }
@@ -32,6 +33,7 @@ void SetExitList::ParseRawDataLate()
 
 void SetExitList::DeclareReferencesLate(const std::string& prefix)
 {
+	(void)prefix;
 	if (!exits.empty())
 	{
 		std::string declaration = "";

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -113,7 +113,8 @@ RoomCommand SetMesh::GetRoomCommand() const
 	return RoomCommand::SetMesh;
 }
 
-PolygonDlist::PolygonDlist(const std::string& prefix, [[maybe_unused]] const std::vector<uint8_t>& nRawData,
+PolygonDlist::PolygonDlist(const std::string& prefix,
+                           [[maybe_unused]] const std::vector<uint8_t>& nRawData,
                            uint32_t nRawDataIndex, ZFile* nParent, ZRoom* nRoom)
 {
 	rawDataIndex = nRawDataIndex;
@@ -268,8 +269,9 @@ std::string PolygonDlist::GetName()
 	return name;
 }
 
-BgImage::BgImage(bool nIsSubStruct, const std::string& prefix, [[maybe_unused]] const std::vector<uint8_t>& nRawData,
-                 uint32_t nRawDataIndex, ZFile* nParent)
+BgImage::BgImage(bool nIsSubStruct, const std::string& prefix,
+                 [[maybe_unused]] const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex,
+                 ZFile* nParent)
 {
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
@@ -404,7 +406,8 @@ std::string BgImage::GetName()
 
 /* PolygonType section */
 
-PolygonTypeBase::PolygonTypeBase(ZFile* nParent, [[maybe_unused]] const std::vector<uint8_t>& nRawData,
+PolygonTypeBase::PolygonTypeBase(ZFile* nParent,
+                                 [[maybe_unused]] const std::vector<uint8_t>& nRawData,
                                  uint32_t nRawDataIndex, ZRoom* nRoom)
 	: rawDataIndex{nRawDataIndex}, parent{nParent}, zRoom{nRoom}
 {

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -113,10 +113,9 @@ RoomCommand SetMesh::GetRoomCommand() const
 	return RoomCommand::SetMesh;
 }
 
-PolygonDlist::PolygonDlist(const std::string& prefix, const std::vector<uint8_t>& nRawData,
+PolygonDlist::PolygonDlist(const std::string& prefix, [[maybe_unused]] const std::vector<uint8_t>& nRawData,
                            uint32_t nRawDataIndex, ZFile* nParent, ZRoom* nRoom)
 {
-	(void)nRawData;
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
 	zRoom = nRoom;
@@ -152,9 +151,8 @@ void PolygonDlist::DeclareReferences(const std::string& prefix)
 	xluDList = MakeDlist(xlu, prefix);
 }
 
-ZDisplayList* PolygonDlist::MakeDlist(segptr_t ptr, const std::string& prefix)
+ZDisplayList* PolygonDlist::MakeDlist(segptr_t ptr, [[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	if (ptr == 0)
 	{
 		return nullptr;
@@ -270,10 +268,9 @@ std::string PolygonDlist::GetName()
 	return name;
 }
 
-BgImage::BgImage(bool nIsSubStruct, const std::string& prefix, const std::vector<uint8_t>& nRawData,
+BgImage::BgImage(bool nIsSubStruct, const std::string& prefix, [[maybe_unused]] const std::vector<uint8_t>& nRawData,
                  uint32_t nRawDataIndex, ZFile* nParent)
 {
-	(void)nRawData;
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
 	isSubStruct = nIsSubStruct;
@@ -407,11 +404,10 @@ std::string BgImage::GetName()
 
 /* PolygonType section */
 
-PolygonTypeBase::PolygonTypeBase(ZFile* nParent, const std::vector<uint8_t>& nRawData,
+PolygonTypeBase::PolygonTypeBase(ZFile* nParent, [[maybe_unused]] const std::vector<uint8_t>& nRawData,
                                  uint32_t nRawDataIndex, ZRoom* nRoom)
 	: rawDataIndex{nRawDataIndex}, parent{nParent}, zRoom{nRoom}
 {
-	(void)nRawData;
 	type = BitConverter::ToUInt8BE(parent->GetRawData(), rawDataIndex);
 }
 

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -116,6 +116,7 @@ RoomCommand SetMesh::GetRoomCommand() const
 PolygonDlist::PolygonDlist(const std::string& prefix, const std::vector<uint8_t>& nRawData,
                            uint32_t nRawDataIndex, ZFile* nParent, ZRoom* nRoom)
 {
+	(void)nRawData;
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
 	zRoom = nRoom;
@@ -153,6 +154,7 @@ void PolygonDlist::DeclareReferences(const std::string& prefix)
 
 ZDisplayList* PolygonDlist::MakeDlist(segptr_t ptr, const std::string& prefix)
 {
+	(void)prefix;
 	if (ptr == 0)
 	{
 		return nullptr;
@@ -271,6 +273,7 @@ std::string PolygonDlist::GetName()
 BgImage::BgImage(bool nIsSubStruct, const std::string& prefix, const std::vector<uint8_t>& nRawData,
                  uint32_t nRawDataIndex, ZFile* nParent)
 {
+	(void)nRawData;
 	rawDataIndex = nRawDataIndex;
 	parent = nParent;
 	isSubStruct = nIsSubStruct;
@@ -408,6 +411,7 @@ PolygonTypeBase::PolygonTypeBase(ZFile* nParent, const std::vector<uint8_t>& nRa
                                  uint32_t nRawDataIndex, ZRoom* nRoom)
 	: rawDataIndex{nRawDataIndex}, parent{nParent}, zRoom{nRoom}
 {
+	(void)nRawData;
 	type = BitConverter::ToUInt8BE(parent->GetRawData(), rawDataIndex);
 }
 

--- a/ZAPD/ZRoom/Commands/SetMesh.h
+++ b/ZAPD/ZRoom/Commands/SetMesh.h
@@ -95,6 +95,7 @@ public:
 
 	PolygonTypeBase(ZFile* nParent, const std::vector<uint8_t>& nRawData, uint32_t nRawDataIndex,
 	                ZRoom* nRoom);
+	virtual ~PolygonTypeBase() = default;
 
 	virtual void ParseRawData() = 0;
 	virtual void DeclareReferences(const std::string& prefix) = 0;
@@ -112,7 +113,6 @@ public:
 	std::string GetDefaultName(const std::string& prefix) const;
 
 protected:
-
 	uint32_t rawDataIndex;
 	ZFile* parent;
 	ZRoom* zRoom;

--- a/ZAPD/ZRoom/Commands/SetMinimapChests.cpp
+++ b/ZAPD/ZRoom/Commands/SetMinimapChests.cpp
@@ -1,7 +1,7 @@
 #include "SetMinimapChests.h"
 
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 #include "ZRoom/ZRoom.h"

--- a/ZAPD/ZRoom/Commands/SetMinimapList.cpp
+++ b/ZAPD/ZRoom/Commands/SetMinimapList.cpp
@@ -1,7 +1,7 @@
 #include "SetMinimapList.h"
 
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 #include "ZRoom/ZRoom.h"

--- a/ZAPD/ZRoom/Commands/SetObjectList.cpp
+++ b/ZAPD/ZRoom/Commands/SetObjectList.cpp
@@ -1,7 +1,7 @@
 #include "SetObjectList.h"
 
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 #include "ZRoom/ZNames.h"

--- a/ZAPD/ZRoom/Commands/SetObjectList.h
+++ b/ZAPD/ZRoom/Commands/SetObjectList.h
@@ -10,7 +10,7 @@ public:
 	SetObjectList(ZFile* nParent);
 
 	void ParseRawData() override;
-	void DeclareReferences(const std::string& prefix);
+	void DeclareReferences(const std::string& prefix) override;
 
 	std::string GetBodySourceCode() const override;
 

--- a/ZAPD/ZRoom/Commands/SetPathways.cpp
+++ b/ZAPD/ZRoom/Commands/SetPathways.cpp
@@ -1,6 +1,6 @@
 #include "SetPathways.h"
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 #include "ZRoom/ZRoom.h"

--- a/ZAPD/ZRoom/Commands/SetPathways.cpp
+++ b/ZAPD/ZRoom/Commands/SetPathways.cpp
@@ -11,6 +11,7 @@ SetPathways::SetPathways(ZFile* nParent) : ZRoomCommand(nParent), pathwayList(nP
 
 void SetPathways::DeclareReferences(const std::string& prefix)
 {
+	(void)prefix;
 	if (segmentOffset != 0)
 		parent->AddDeclarationPlaceholder(segmentOffset);
 }

--- a/ZAPD/ZRoom/Commands/SetPathways.cpp
+++ b/ZAPD/ZRoom/Commands/SetPathways.cpp
@@ -9,9 +9,8 @@ SetPathways::SetPathways(ZFile* nParent) : ZRoomCommand(nParent), pathwayList(nP
 {
 }
 
-void SetPathways::DeclareReferences(const std::string& prefix)
+void SetPathways::DeclareReferences([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	if (segmentOffset != 0)
 		parent->AddDeclarationPlaceholder(segmentOffset);
 }

--- a/ZAPD/ZRoom/Commands/SetRoomBehavior.cpp
+++ b/ZAPD/ZRoom/Commands/SetRoomBehavior.cpp
@@ -1,6 +1,6 @@
 #include "SetRoomBehavior.h"
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 
 SetRoomBehavior::SetRoomBehavior(ZFile* nParent) : ZRoomCommand(nParent)

--- a/ZAPD/ZRoom/Commands/SetRoomList.cpp
+++ b/ZAPD/ZRoom/Commands/SetRoomList.cpp
@@ -1,7 +1,7 @@
 #include "SetRoomList.h"
 
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 #include "ZRoom/ZRoom.h"

--- a/ZAPD/ZRoom/Commands/SetRoomList.h
+++ b/ZAPD/ZRoom/Commands/SetRoomList.h
@@ -20,7 +20,7 @@ public:
 	SetRoomList(ZFile* nParent);
 
 	void ParseRawData() override;
-	virtual void DeclareReferences(const std::string& prefix);
+	void DeclareReferences(const std::string& prefix) override;
 
 	std::string GetBodySourceCode() const override;
 	void PreGenSourceFiles() override;

--- a/ZAPD/ZRoom/Commands/SetStartPositionList.cpp
+++ b/ZAPD/ZRoom/Commands/SetStartPositionList.cpp
@@ -1,7 +1,7 @@
 #include "SetStartPositionList.h"
 
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 #include "ZRoom/ZNames.h"

--- a/ZAPD/ZRoom/Commands/SetTransitionActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetTransitionActorList.cpp
@@ -1,7 +1,7 @@
 #include "SetTransitionActorList.h"
 
-#include "Utils/BitConverter.h"
 #include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 #include "ZRoom/ZNames.h"

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -421,15 +421,13 @@ size_t ZRoom::GetCommandSizeFromNeighbor(ZRoomCommand* cmd)
 	return 0;
 }
 
-std::string ZRoom::GetSourceOutputHeader(const std::string& prefix)
+std::string ZRoom::GetSourceOutputHeader([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	return "\n" + extDefines + "\n\n";
 }
 
-std::string ZRoom::GetSourceOutputCode(const std::string& prefix)
+std::string ZRoom::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	sourceOutput = "";
 
 	sourceOutput += "#include \"segment_symbols.h\"\n";

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -423,11 +423,13 @@ size_t ZRoom::GetCommandSizeFromNeighbor(ZRoomCommand* cmd)
 
 std::string ZRoom::GetSourceOutputHeader(const std::string& prefix)
 {
+	(void)prefix;
 	return "\n" + extDefines + "\n\n";
 }
 
 std::string ZRoom::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	sourceOutput = "";
 
 	sourceOutput += "#include \"segment_symbols.h\"\n";

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -1,9 +1,9 @@
 #include "ZRoom.h"
+#include <Utils/File.h>
 #include <Utils/Path.h>
+#include <Utils/StringHelper.h>
 #include <algorithm>
 #include <chrono>
-#include <Utils/File.h>
-#include <Utils/StringHelper.h>
 #include "../Globals.h"
 #include "../ZBlob.h"
 #include "Commands/EndMarker.h"

--- a/ZAPD/ZRoom/ZRoomCommand.cpp
+++ b/ZAPD/ZRoom/ZRoomCommand.cpp
@@ -31,9 +31,8 @@ void ZRoomCommand::ParseRawDataLate()
 {
 }
 
-void ZRoomCommand::DeclareReferencesLate(const std::string& prefix)
+void ZRoomCommand::DeclareReferencesLate([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 }
 
 std::string ZRoomCommand::GetCommandCName() const

--- a/ZAPD/ZRoom/ZRoomCommand.cpp
+++ b/ZAPD/ZRoom/ZRoomCommand.cpp
@@ -33,6 +33,7 @@ void ZRoomCommand::ParseRawDataLate()
 
 void ZRoomCommand::DeclareReferencesLate(const std::string& prefix)
 {
+	(void)prefix;
 }
 
 std::string ZRoomCommand::GetCommandCName() const

--- a/ZAPD/ZRoom/ZRoomCommand.h
+++ b/ZAPD/ZRoom/ZRoomCommand.h
@@ -69,7 +69,7 @@ public:
 	virtual void ParseRawDataLate();
 	virtual void DeclareReferencesLate(const std::string& prefix);
 
-	virtual std::string GetBodySourceCode() const = 0;
+	std::string GetBodySourceCode() const override = 0;
 
 	ZResourceType GetResourceType() const override;
 

--- a/ZAPD/ZScalar.cpp
+++ b/ZAPD/ZScalar.cpp
@@ -249,6 +249,7 @@ std::string ZScalar::GetBodySourceCode() const
 
 std::string ZScalar::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	if (parent != nullptr)
 		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
 		                       GetSourceTypeName(), GetName(), GetBodySourceCode());

--- a/ZAPD/ZScalar.cpp
+++ b/ZAPD/ZScalar.cpp
@@ -247,9 +247,8 @@ std::string ZScalar::GetBodySourceCode() const
 	}
 }
 
-std::string ZScalar::GetSourceOutputCode(const std::string& prefix)
+std::string ZScalar::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	if (parent != nullptr)
 		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
 		                       GetSourceTypeName(), GetName(), GetBodySourceCode());

--- a/ZAPD/ZScalar.cpp
+++ b/ZAPD/ZScalar.cpp
@@ -1,7 +1,7 @@
 #include "ZScalar.h"
+#include "Globals.h"
 #include "Utils/BitConverter.h"
 #include "Utils/File.h"
-#include "Globals.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -121,9 +121,8 @@ size_t ZSkeleton::GetRawDataSize() const
 	}
 }
 
-std::string ZSkeleton::GetSourceOutputCode(const std::string& prefix)
+std::string ZSkeleton::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	std::string headerStr = GetBodySourceCode();
 
 	Declaration* decl = parent->GetDeclaration(GetAddress());
@@ -270,9 +269,8 @@ std::string ZLimbTable::GetBodySourceCode() const
 	return body;
 }
 
-std::string ZLimbTable::GetSourceOutputCode(const std::string& prefix)
+std::string ZLimbTable::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	std::string body = GetBodySourceCode();
 
 	Declaration* decl = parent->GetDeclaration(rawDataIndex);

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -123,6 +123,7 @@ size_t ZSkeleton::GetRawDataSize() const
 
 std::string ZSkeleton::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	std::string headerStr = GetBodySourceCode();
 
 	Declaration* decl = parent->GetDeclaration(GetAddress());
@@ -271,6 +272,7 @@ std::string ZLimbTable::GetBodySourceCode() const
 
 std::string ZLimbTable::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	std::string body = GetBodySourceCode();
 
 	Declaration* decl = parent->GetDeclaration(rawDataIndex);

--- a/ZAPD/ZString.cpp
+++ b/ZAPD/ZString.cpp
@@ -36,6 +36,7 @@ std::string ZString::GetBodySourceCode() const
 
 std::string ZString::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	parent->AddDeclarationArray(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
 	                            GetSourceTypeName(), name, 0, GetBodySourceCode());
 
@@ -44,6 +45,7 @@ std::string ZString::GetSourceOutputCode(const std::string& prefix)
 
 std::string ZString::GetSourceOutputHeader(const std::string& prefix)
 {
+	(void)prefix;
 	return StringHelper::Sprintf("#define %s_macro \"%s\"", name.c_str(), strData.data());
 }
 

--- a/ZAPD/ZString.cpp
+++ b/ZAPD/ZString.cpp
@@ -34,18 +34,16 @@ std::string ZString::GetBodySourceCode() const
 	return StringHelper::Sprintf("\t\"%s\"", strData.data());
 }
 
-std::string ZString::GetSourceOutputCode(const std::string& prefix)
+std::string ZString::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	parent->AddDeclarationArray(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
 	                            GetSourceTypeName(), name, 0, GetBodySourceCode());
 
 	return "";
 }
 
-std::string ZString::GetSourceOutputHeader(const std::string& prefix)
+std::string ZString::GetSourceOutputHeader([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	return StringHelper::Sprintf("#define %s_macro \"%s\"", name.c_str(), strData.data());
 }
 

--- a/ZAPD/ZString.h
+++ b/ZAPD/ZString.h
@@ -9,7 +9,7 @@ public:
 	ZString(ZFile* nParent);
 
 	void ParseRawData() override;
-	std::string GetBodySourceCode() const;
+	std::string GetBodySourceCode() const override;
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 
 	std::string GetSourceOutputHeader(const std::string& prefix) override;

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -1,11 +1,11 @@
 #include "ZTexture.h"
 
 #include <cassert>
-#include "Utils/BitConverter.h"
 #include "CRC32.h"
+#include "Globals.h"
+#include "Utils/BitConverter.h"
 #include "Utils/Directory.h"
 #include "Utils/File.h"
-#include "Globals.h"
 #include "Utils/Path.h"
 
 REGISTER_ZFILENODE(Texture, ZTexture);

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -324,6 +324,7 @@ void ZTexture::PrepareBitmapPalette8()
 
 void ZTexture::DeclareReferences(const std::string& prefix)
 {
+	(void)prefix;
 	if (tlutOffset != static_cast<uint32_t>(-1))
 	{
 		tlut = parent->GetTextureResource(tlutOffset);

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -322,9 +322,8 @@ void ZTexture::PrepareBitmapPalette8()
 	}
 }
 
-void ZTexture::DeclareReferences(const std::string& prefix)
+void ZTexture::DeclareReferences([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	if (tlutOffset != static_cast<uint32_t>(-1))
 	{
 		tlut = parent->GetTextureResource(tlutOffset);

--- a/ZAPD/ZTexture.h
+++ b/ZAPD/ZTexture.h
@@ -64,7 +64,7 @@ public:
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;
 	void DeclareReferences(const std::string& prefix) override;
-	std::string GetBodySourceCode() const;
+	std::string GetBodySourceCode() const override;
 	void CalcHash() override;
 	void Save(const fs::path& outFolder) override;
 

--- a/ZAPD/ZVector.cpp
+++ b/ZAPD/ZVector.cpp
@@ -91,9 +91,8 @@ std::string ZVector::GetBodySourceCode() const
 	return "{ " + body + "}";
 }
 
-std::string ZVector::GetSourceOutputCode(const std::string& prefix)
+std::string ZVector::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	if (parent != nullptr)
 		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
 		                       GetSourceTypeName(), GetName(), GetBodySourceCode());

--- a/ZAPD/ZVector.cpp
+++ b/ZAPD/ZVector.cpp
@@ -1,8 +1,8 @@
 #include "ZVector.h"
 #include <assert.h>
+#include "Globals.h"
 #include "Utils/BitConverter.h"
 #include "Utils/File.h"
-#include "Globals.h"
 #include "Utils/StringHelper.h"
 #include "ZFile.h"
 

--- a/ZAPD/ZVector.cpp
+++ b/ZAPD/ZVector.cpp
@@ -93,6 +93,7 @@ std::string ZVector::GetBodySourceCode() const
 
 std::string ZVector::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	if (parent != nullptr)
 		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
 		                       GetSourceTypeName(), GetName(), GetBodySourceCode());

--- a/ZAPD/ZVtx.cpp
+++ b/ZAPD/ZVtx.cpp
@@ -42,9 +42,8 @@ std::string ZVtx::GetBodySourceCode() const
 	                             a);
 }
 
-std::string ZVtx::GetSourceOutputCode(const std::string& prefix)
+std::string ZVtx::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	(void)prefix;
 	std::string output = GetBodySourceCode();
 
 	if (parent != nullptr)

--- a/ZAPD/ZVtx.cpp
+++ b/ZAPD/ZVtx.cpp
@@ -44,6 +44,7 @@ std::string ZVtx::GetBodySourceCode() const
 
 std::string ZVtx::GetSourceOutputCode(const std::string& prefix)
 {
+	(void)prefix;
 	std::string output = GetBodySourceCode();
 
 	if (parent != nullptr)

--- a/ZAPDUtils/StrHash.h
+++ b/ZAPDUtils/StrHash.h
@@ -6,6 +6,7 @@
 
 typedef uint32_t strhash;
 
+[[maybe_unused]]
 static strhash CRC32B(unsigned char* message, int32_t size)
 {
 	int32_t byte = 0, crc = 0;
@@ -28,6 +29,7 @@ static strhash CRC32B(unsigned char* message, int32_t size)
 	return ~(uint32_t)(crc);
 }
 
+[[maybe_unused]]
 constexpr static strhash CRC32BCT(const char* message, int32_t size)
 {
 	int32_t byte = 0, crc = 0;


### PR DESCRIPTION
This PR:

- Adds `-Wextra -Werror` to the compilation flags and fixes all the errors associated.
- Marks `CRC32B` and `CRC32BCT` as `maybe_unused`
- Replaces `GfxdCallback_FormatSingleEntry(void)` with `GfxdCallback_FormatSingleEntry()` since this is not required in C++.