### PR TITLE
Fix floats in cutscene data

### DIFF
--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -554,8 +554,11 @@ std::string CutsceneCommandSetCameraPos::GenerateSourceCode(uint32_t baseAddress
 
 	for (size_t i = 0; i < entries.size(); i++)
 	{
-		result += StringHelper::Sprintf("        %s(%i, %i, %i, %ff, %i, %i, %i, %i),\n",
-		                                posStr.c_str(), entries[i]->continueFlag,
+		std::string continueMacro = "CS_CMD_CONTINUE";
+		if (entries[i]->continueFlag != 0) 
+			continueMacro = "CS_CMD_STOP";
+		result += StringHelper::Sprintf("        %s(%s, 0x%02X, %i, %ff, %i, %i, %i, 0x%04X),\n",
+		                                posStr.c_str(), continueMacro.c_str(),
 		                                entries[i]->cameraRoll, entries[i]->nextPointFrame,
 		                                entries[i]->viewAngle, entries[i]->posX,
 		                                entries[i]->posY, entries[i]->posZ, entries[i]->unused);

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -127,7 +127,7 @@ void ZCutscene::DeclareVar(const std::string& prefix, const std::string& bodyStr
 		auxName = StringHelper::Sprintf("%sCutsceneData0x%06X", prefix.c_str(), rawDataIndex);
 
 	parent->AddDeclarationArray(getSegmentOffset(), DeclarationAlignment::Align4,
-	                            DeclarationPadding::Pad16, GetRawDataSize(), "s32", auxName, 0,
+	                            DeclarationPadding::Pad16, GetRawDataSize(), "CutsceneData", auxName, 0,
 	                            bodyStr);
 }
 
@@ -478,7 +478,7 @@ CutsceneCameraPoint::CutsceneCameraPoint(const std::vector<uint8_t>& rawData, ui
 	continueFlag = data[rawDataIndex + 0];
 	cameraRoll = data[rawDataIndex + 1];
 	nextPointFrame = BitConverter::ToInt16BE(data, rawDataIndex + 2);
-	viewAngle = BitConverter::ToInt32BE(data, rawDataIndex + 4);
+	viewAngle = BitConverter::ToFloatBE(data, rawDataIndex + 4);
 
 	posX = BitConverter::ToInt16BE(data, rawDataIndex + 8);
 	posY = BitConverter::ToInt16BE(data, rawDataIndex + 10);
@@ -554,10 +554,10 @@ std::string CutsceneCommandSetCameraPos::GenerateSourceCode(uint32_t baseAddress
 
 	for (size_t i = 0; i < entries.size(); i++)
 	{
-		result += StringHelper::Sprintf("        %s(%i, %i, %i, 0x%06X, %i, %i, %i, %i),\n",
+		result += StringHelper::Sprintf("        %s(%i, %i, %i, %ff, %i, %i, %i, %i),\n",
 		                                posStr.c_str(), entries[i]->continueFlag,
 		                                entries[i]->cameraRoll, entries[i]->nextPointFrame,
-		                                *(uint32_t*)&entries[i]->viewAngle, entries[i]->posX,
+		                                entries[i]->viewAngle, entries[i]->posX,
 		                                entries[i]->posY, entries[i]->posZ, entries[i]->unused);
 	}
 

--- a/ZAPD/ZCutscene.h
+++ b/ZAPD/ZCutscene.h
@@ -49,7 +49,7 @@ public:
 	int8_t continueFlag;
 	int8_t cameraRoll;
 	int16_t nextPointFrame;
-	uint32_t viewAngle;
+	float viewAngle;
 	int16_t posX, posY, posZ;
 	int16_t unused;
 

--- a/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
+++ b/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
@@ -47,7 +47,7 @@ void SetAlternateHeaders::DeclareReferencesLate(const std::string& prefix)
 		}
 
 		parent->AddDeclarationArray(
-			segmentOffset, DeclarationAlignment::None, headers.size() * 4, "SCmdBase*",
+			segmentOffset, DeclarationAlignment::None, headers.size() * 4, "SceneCmd*",
 			StringHelper::Sprintf("%sAlternateHeaders0x%06X", prefix.c_str(), segmentOffset), 0,
 			declaration);
 	}

--- a/ZAPD/ZRoom/Commands/Unused09.cpp
+++ b/ZAPD/ZRoom/Commands/Unused09.cpp
@@ -12,7 +12,7 @@ std::string Unused09::GetBodySourceCode() const
 
 std::string Unused09::GetCommandCName() const
 {
-	return "SCmdBase";
+	return "SceneCmd";
 }
 
 RoomCommand Unused09::GetRoomCommand() const

--- a/ZAPD/ZRoom/Commands/Unused1D.cpp
+++ b/ZAPD/ZRoom/Commands/Unused1D.cpp
@@ -12,7 +12,7 @@ std::string Unused1D::GetBodySourceCode() const
 
 std::string Unused1D::GetCommandCName() const
 {
-	return "SCmdBase";
+	return "SceneCmd";
 }
 
 RoomCommand Unused1D::GetRoomCommand() const

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -344,7 +344,7 @@ void ZRoom::ProcessCommandSets()
 
 			parent->AddDeclarationArray(
 				GETSEGOFFSET(commandSet), DeclarationAlignment::Align16, 8 * setCommands.size(),
-				"static SCmdBase",
+				"static SceneCmd",
 				StringHelper::Sprintf("%sSet%04X", name.c_str(), GETSEGOFFSET(commandSet)),
 				setCommands.size(), declaration);
 

--- a/ZAPD/ZRoom/ZRoomCommand.cpp
+++ b/ZAPD/ZRoom/ZRoomCommand.cpp
@@ -37,7 +37,7 @@ void ZRoomCommand::DeclareReferencesLate(const std::string& prefix)
 
 std::string ZRoomCommand::GetCommandCName() const
 {
-	return "SCmdBase";
+	return "SceneCmd";
 }
 
 ZResourceType ZRoomCommand::GetResourceType() const


### PR DESCRIPTION
ZAPD was extracting those floats as their hex representation.
Also change `SCmdBase` to `SceneCmd`