### PR TITLE
Show `rawDataSize` when `GetDListLength` errors

### DIFF
--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -426,7 +426,7 @@ int32_t ZDisplayList::GetDListLength(const std::vector<uint8_t>& rawData, uint32
 				StringHelper::Sprintf("%s: Fatal error.\n"
 			                          "\t End of file found when trying to find the end of the "
 			                          "DisplayList at offset: '0x%X'.\n",
-			                          "Raw data size: 0x%X.\n",
+			                          "Raw data size: 0x%zX.\n",
 			                          __PRETTY_FUNCTION__, rawDataIndex, rawDataSize));
 			throw std::runtime_error("");
 		}

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -426,7 +426,8 @@ int32_t ZDisplayList::GetDListLength(const std::vector<uint8_t>& rawData, uint32
 				StringHelper::Sprintf("%s: Fatal error.\n"
 			                          "\t End of file found when trying to find the end of the "
 			                          "DisplayList at offset: '0x%X'.\n",
-			                          __PRETTY_FUNCTION__, rawDataIndex));
+			                          "Raw data size: 0x%X.\n",
+			                          __PRETTY_FUNCTION__, rawDataIndex, rawDataSize));
 			throw std::runtime_error("");
 		}
 


### PR DESCRIPTION
Would have made figuring out a dumb issue I ran across faster.

The issue was using the wrong file in the xml. Namely, `<File Name="testcube_flat.xml" Segment="6">` instead of `<File Name="testcube_flat.zobj" Segment="6">`.