### PR TITLE
Fix reloc generation for GCC builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,5 +111,6 @@ ZAPD also accepts the following list of extra parameters:
 - `-wno` / `--warn-no-offsets` : Enable warnings for nodes that dont have offsets specified. Takes priority over `-eno`/ `--error-no-offsets`.
 - `-eno`/ `--error-no-offsets` : Enable errors for nodes that dont have offsets specified.
 - `-se` / `--set-exporter` : Sets which exporter to use.
+- `--gcc-compat` : Enables GCC compatible mode. Slower.
 
 Additionally, you can pass the flag `--version` to see the current ZAPD version. If that flag is passed, ZAPD will ignore any other parameter passed.

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -75,6 +75,7 @@ public:
 	bool warnNoOffset = false;
 	bool errorNoOffset = false;
 	bool verboseUnaccounted = false;
+	bool gccCompat = false;
 
 	std::vector<ZFile*> files;
 	std::vector<int32_t> segments;

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -213,6 +213,10 @@ int main(int argc, char* argv[])
 		{
 			Globals::Instance->currentExporter = argv[++i];
 		}
+		else if (arg == "--gcc-compat")  // GCC compatibility
+		{
+			Globals::Instance->gccCompat = true;
+		}
 	}
 
 	// Parse File Mode

--- a/ZAPD/Overlays/ZOverlay.cpp
+++ b/ZAPD/Overlays/ZOverlay.cpp
@@ -139,22 +139,6 @@ ZOverlay* ZOverlay::FromBuild(std::string buildPath, std::string cfgFolderPath)
 						printf(".word 0x%08X  # %s %s 0x%04X\n", reloc.CalcRelocationWord(), reloc.GetSectionName(), reloc.GetRelocTypeName(), reloc.offset);
 					}
 
-					if(offset == 0x0874) {
-						int bp = 0;
-					}
-					if(offset == 0x089C) {
-						int bp = 0;
-					}
-					if(offset == 0x08A0) {
-						int bp = 0;
-					}
-					if(offset == 0x0990) {
-						int bp = 0;
-					}
-					if(offset == 0x0994) {
-						int bp = 0;
-					}
-
 					std::string curSymName;
 					Elf_Half curSymShndx = SHN_UNDEF;
 					{
@@ -179,9 +163,6 @@ ZOverlay* ZOverlay::FromBuild(std::string buildPath, std::string cfgFolderPath)
 
 							if (reader == curReader)
 								continue;
-
-							//Elf_Half sectionIdx = pSec->get_link();
-							//auto sectionData = reader->sections[sectionIdx];
 
 							Elf_Half sec_num = reader->sections.size();
 							for (int32_t j = 0; j < sec_num; j++)
@@ -225,19 +206,6 @@ ZOverlay* ZOverlay::FromBuild(std::string buildPath, std::string cfgFolderPath)
 					{
 						RelocationType typeConverted = (RelocationType)type;
 						offset += sectionOffs[static_cast<size_t>(sectionType)];
-
-					if(offset == 0x089C) {
-						int bp = 0;
-					}
-					if(offset == 0x08A0) {
-						int bp = 0;
-					}
-					if(offset == 0x0990) {
-						int bp = 0;
-					}
-					if(offset == 0x0994) {
-						int bp = 0;
-					}
 
 						RelocationEntry* reloc =
 							new RelocationEntry(sectionType, typeConverted, offset);
@@ -287,12 +255,15 @@ std::string ZOverlay::GetSourceOutputCode(const std::string& prefix)
 
 	output += ".section .ovl\n";
 
+	output += StringHelper::Sprintf("# %sOverlayInfo\n", name.c_str());
 	output += StringHelper::Sprintf(".word _%sSegmentTextSize\n", name.c_str());
 	output += StringHelper::Sprintf(".word _%sSegmentDataSize\n", name.c_str());
 	output += StringHelper::Sprintf(".word _%sSegmentRoDataSize\n", name.c_str());
 	output += StringHelper::Sprintf(".word _%sSegmentBssSize\n", name.c_str());
 
+	output += "\n";
 	output += StringHelper::Sprintf(".word %i # reloc_count\n", entries.size());
+	output += "\n";
 
 	for (size_t i = 0; i < entries.size(); i++)
 	{
@@ -308,7 +279,8 @@ std::string ZOverlay::GetSourceOutputCode(const std::string& prefix)
 		offset += 4;
 	}
 
-	output += StringHelper::Sprintf(".word 0x%08X\n", offset + 4);
+	output += "\n";
+	output += StringHelper::Sprintf(".word 0x%08X # %sOverlayInfoOffset\n", offset + 4);
 	return output;
 }
 

--- a/ZAPD/Overlays/ZOverlay.cpp
+++ b/ZAPD/Overlays/ZOverlay.cpp
@@ -171,18 +171,21 @@ ZOverlay* ZOverlay::FromBuild(fs::path buildPath, fs::path cfgFolderPath)
 						if (curSymShndx != SHN_UNDEF)
 							break;
 
-						// Symbol wasn't found, try checking every section
-						Elf_Half sec_num = reader->sections.size();
-						for (int32_t otherSectionIdx = 0; otherSectionIdx < sec_num; otherSectionIdx++)
-						{
-							if (curSymShndx != SHN_UNDEF)
+						if (Globals::Instance->gccCompat) {
+							// Symbol wasn't found, try checking every section
+							Elf_Half sec_num = reader->sections.size();
+							for (int32_t otherSectionIdx = 0; otherSectionIdx < sec_num; otherSectionIdx++)
 							{
-								break;
+								if (curSymShndx != SHN_UNDEF)
+								{
+									break;
+									
+								}
+
+								auto sectionDataIter = reader->sections[otherSectionIdx];
+
+								curSymShndx = ovl->FindSymbolInSection(curSymName, sectionDataIter, *reader, readerId);
 							}
-
-							auto sectionDataIter = reader->sections[otherSectionIdx];
-
-							curSymShndx = ovl->FindSymbolInSection(curSymName, sectionDataIter, *reader, readerId);
 						}
 					}
 				}

--- a/ZAPD/Overlays/ZOverlay.cpp
+++ b/ZAPD/Overlays/ZOverlay.cpp
@@ -1,6 +1,7 @@
 #include "ZOverlay.h"
 
 #include <assert.h>
+#include <unordered_set>
 
 #include <Utils/Directory.h>
 #include <Utils/File.h>
@@ -72,8 +73,8 @@ ZOverlay* ZOverlay::FromBuild(std::string buildPath, std::string cfgFolderPath)
 
 	ZOverlay* ovl = new ZOverlay(StringHelper::Strip(cfgLines[0], "\r"));
 
-	std::vector<std::string> relSections = {".rel.text", ".rel.data", ".rel.rodata"};
-	std::vector<std::string> sections = { ".text", ".data", ".symtab", ".rodata", ".rodata.str1.4", ".rodata.cst4" };
+	std::unordered_set<std::string> relSections = {".rel.text", ".rel.data", ".rel.rodata"};
+	std::unordered_set<std::string> sections = { ".text", ".data", ".symtab", ".rodata", ".rodata.str1.4", ".rodata.cst4" };
 
 	int32_t sectionOffs[5] = {0};
 	std::vector<RelocationEntry*> textRelocs;

--- a/ZAPD/Overlays/ZOverlay.cpp
+++ b/ZAPD/Overlays/ZOverlay.cpp
@@ -73,7 +73,7 @@ ZOverlay* ZOverlay::FromBuild(std::string buildPath, std::string cfgFolderPath)
 	ZOverlay* ovl = new ZOverlay(StringHelper::Strip(cfgLines[0], "\r"));
 
 	std::vector<std::string> relSections = {".rel.text", ".rel.data", ".rel.rodata"};
-	std::vector<std::string> sections = {".text", ".data", ".rodata"};
+	std::vector<std::string> sections = { ".text", ".data", ".rodata", ".rodata.str1.4", ".rodata.cst4" };
 
 	int32_t sectionOffs[5] = {0};
 	std::vector<RelocationEntry*> textRelocs;

--- a/ZAPD/Overlays/ZOverlay.cpp
+++ b/ZAPD/Overlays/ZOverlay.cpp
@@ -64,10 +64,14 @@ ZOverlay::~ZOverlay()
 	entries.clear();
 }
 
-static const std::unordered_set<std::string> sRelSections = {".rel.text", ".rel.data",
-                                                             ".rel.rodata"};
+static const std::unordered_set<std::string> sRelSections = {
+	".rel.text",
+	".rel.data",
+	".rel.rodata",
+};
 static const std::unordered_set<std::string> sSections = {
-	".text", ".data", ".symtab", ".rodata", ".rodata.str1.4", ".rodata.cst4"};
+	".text", ".data", ".symtab", ".rodata", ".rodata.str1.4", ".rodata.cst4", ".rodata.cst8",
+};
 
 ZOverlay* ZOverlay::FromBuild(fs::path buildPath, fs::path cfgFolderPath)
 {

--- a/ZAPD/Overlays/ZOverlay.h
+++ b/ZAPD/Overlays/ZOverlay.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "elfio/elfio.hpp"
-#include "ZResource.h"
 #include "Utils/Directory.h"
+#include "ZResource.h"
+#include "elfio/elfio.hpp"
 #include "tinyxml2.h"
 
 enum class SectionType
@@ -70,5 +70,6 @@ private:
 	static SectionType GetSectionTypeFromStr(std::string sectionName);
 	// static std::string GetOverlayNameFromElf(ELFIO::elfio& reader);
 
-	ELFIO::Elf_Half FindSymbolInSection(const std::string& curSymName, ELFIO::section* sectionData, ELFIO::elfio& reader, size_t readerId);
+	ELFIO::Elf_Half FindSymbolInSection(const std::string& curSymName, ELFIO::section* sectionData,
+	                                    ELFIO::elfio& reader, size_t readerId);
 };

--- a/ZAPD/Overlays/ZOverlay.h
+++ b/ZAPD/Overlays/ZOverlay.h
@@ -62,9 +62,12 @@ public:
 
 private:
 	std::vector<RelocationEntry*> entries;
+	std::vector<std::string> cfgLines;
 
 	ZOverlay();
 
 	static SectionType GetSectionTypeFromStr(std::string sectionName);
 	// static std::string GetOverlayNameFromElf(ELFIO::elfio& reader);
+
+	ELFIO::Elf_Half FindSymbolInSection(const std::string& curSymName, ELFIO::section* sectionData, ELFIO::elfio& reader, size_t readerId);
 };

--- a/ZAPD/Overlays/ZOverlay.h
+++ b/ZAPD/Overlays/ZOverlay.h
@@ -4,7 +4,7 @@
 #include "../ZResource.h"
 #include "tinyxml2.h"
 
-enum SectionType
+enum class SectionType
 {
 	Text = 1,
 	Data = 2,
@@ -13,7 +13,7 @@ enum SectionType
 	ERROR = 255
 };
 
-enum RelocationType
+enum class RelocationType
 {
 	R_MIPS_32 = 2,
 	R_MIPS_26 = 4,
@@ -39,12 +39,15 @@ public:
 	{
 		uint32_t relocationWord = 0;
 
-		relocationWord |= sectionType << 30;
-		relocationWord |= relocationType << 24;
+		relocationWord |= static_cast<uint32_t>(sectionType) << 30;
+		relocationWord |= static_cast<uint32_t>(relocationType) << 24;
 		relocationWord |= offset;
 
 		return relocationWord;
 	}
+
+	const char* GetSectionName() const;
+	const char* GetRelocTypeName() const;
 };
 
 class ZOverlay

--- a/ZAPD/Overlays/ZOverlay.h
+++ b/ZAPD/Overlays/ZOverlay.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <elfio/elfio.hpp>
-#include "../ZResource.h"
+#include "elfio/elfio.hpp"
+#include "ZResource.h"
+#include "Utils/Directory.h"
 #include "tinyxml2.h"
 
 enum class SectionType
@@ -57,7 +58,7 @@ public:
 
 	ZOverlay(std::string nName);
 	~ZOverlay();
-	static ZOverlay* FromBuild(std::string buildPath, std::string cfgFolderPath);
+	static ZOverlay* FromBuild(fs::path buildPath, fs::path cfgFolderPath);
 	std::string GetSourceOutputCode(const std::string& prefix);
 
 private:


### PR DESCRIPTION
GCC uses some non-standard sections which aren't being accounted when generating relocs.
The current way ZAPD finds out which symbols need to relocate is by processing the generated `.o` file and searching it in any of object files specified in the `overlay.cfg` file. 
Because of GCC using some non-standard section, some symbols are not in the expected section they should be, so ZAPD now will fall back to search in every section of every `.o` file in case it can't find it. This is slow, so this method will only be used in case the flag `--gcc-compat` is used.