### PR TITLE
Fix gsSPBranchList intersection warning

### DIFF
--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -1078,8 +1078,7 @@ std::string CutsceneCommandActorAction::GenerateSourceCode([[maybe_unused]] uint
 	{
 		result += StringHelper::Sprintf(
 			"\t\t%s(0x%04X, %i, %i, 0x%04X, 0x%04X, 0x%04X, %i, %i, %i, %i, %i, %i, %.11ef, "
-		    "%.11ef, "
-			"%.11ef),\n",
+		    "%.11ef, %.11ef),\n",
 			subCommand.c_str(), entries[i]->action, entries[i]->startFrame, entries[i]->endFrame,
 			entries[i]->rotX, entries[i]->rotY, entries[i]->rotZ, entries[i]->startPosX,
 			entries[i]->startPosY, entries[i]->startPosZ, entries[i]->endPosX, entries[i]->endPosY,

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -1,18 +1,17 @@
 #include "ZDisplayList.h"
 
-#include <Utils/File.h>
-#include <Utils/Path.h>
 #include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <math.h>
+
+#include "Utils/File.h"
+#include "Utils/Path.h"
 #include "Globals.h"
 #include "OutputFormatter.h"
 #include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 #include "gfxd.h"
-
-using namespace tinyxml2;
 
 REGISTER_ZFILENODE(DList, ZDisplayList);
 
@@ -412,11 +411,18 @@ int32_t ZDisplayList::GetDListLength(const std::vector<uint8_t>& rawData, uint32
                                      DListType dListType)
 {
 	uint8_t endDLOpcode;
+	uint8_t branchListOpcode;
 
 	if (dListType == DListType::F3DZEX)
-		endDLOpcode = (uint8_t)F3DZEXOpcode::G_ENDDL;
+	{
+		endDLOpcode = static_cast<uint8_t>(F3DZEXOpcode::G_ENDDL);
+		branchListOpcode = static_cast<uint8_t>(F3DZEXOpcode::G_DL);
+	}
 	else
-		endDLOpcode = (uint8_t)F3DEXOpcode::G_ENDDL;
+	{
+		endDLOpcode = static_cast<uint8_t>(F3DEXOpcode::G_ENDDL);
+		branchListOpcode = static_cast<uint8_t>(F3DEXOpcode::G_DL);
+	}
 
 	uint32_t ptr = rawDataIndex;
 	size_t rawDataSize = rawData.size();
@@ -429,14 +435,16 @@ int32_t ZDisplayList::GetDListLength(const std::vector<uint8_t>& rawData, uint32
 				"\t End of file found when trying to find the end of the "
 				"DisplayList at offset: '0x%X'.\n",
 				"Raw data size: 0x%zX.\n", __PRETTY_FUNCTION__, rawDataIndex, rawDataSize));
-			throw std::runtime_error("");
 		}
 
 		uint8_t opcode = rawData.at(ptr);
+		bool dlNoPush = rawData.at(ptr+1) == 1;
 		ptr += 8;
 
-		if (opcode == endDLOpcode)
+		if (opcode == endDLOpcode || (opcode == branchListOpcode && dlNoPush))
+		{
 			return ptr - rawDataIndex;
+		}
 	}
 }
 
@@ -1573,9 +1581,15 @@ static int32_t GfxdCallback_FormatSingleEntry()
 	}
 
 	// dont print a new line after the last command
-	if (macroId != gfxd_SPEndDisplayList)
+	switch (macroId)
 	{
+	case gfxd_SPEndDisplayList:
+	case gfxd_SPBranchList:
+		break;
+
+	default:
 		gfxd_puts("\n");
+		break;
 	}
 
 	return 0;

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -5,11 +5,11 @@
 #include <chrono>
 #include <math.h>
 
-#include "Utils/File.h"
-#include "Utils/Path.h"
 #include "Globals.h"
 #include "OutputFormatter.h"
 #include "Utils/BitConverter.h"
+#include "Utils/File.h"
+#include "Utils/Path.h"
 #include "Utils/StringHelper.h"
 #include "gfxd.h"
 
@@ -438,7 +438,7 @@ int32_t ZDisplayList::GetDListLength(const std::vector<uint8_t>& rawData, uint32
 		}
 
 		uint8_t opcode = rawData.at(ptr);
-		bool dlNoPush = rawData.at(ptr+1) == 1;
+		bool dlNoPush = rawData.at(ptr + 1) == 1;
 		ptr += 8;
 
 		if (opcode == endDLOpcode || (opcode == branchListOpcode && dlNoPush))


### PR DESCRIPTION
ZAPD wasn't detecting `gsSPBranchList` as the end of a dlist, so it calculated the wrong size of dlists with that macro and it ended up reporting fake intersection warnings.