### PR TITLE
Remove `DeclarationPadding` and `DeclarationAlignment::None`

### DIFF
--- a/ZAPD/Declaration.cpp
+++ b/ZAPD/Declaration.cpp
@@ -1,27 +1,15 @@
 #include "Declaration.h"
 
-Declaration::Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding, size_t nSize,
-                         std::string nText)
+Declaration::Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nText)
 {
 	alignment = nAlignment;
-	padding = nPadding;
 	size = nSize;
 	text = nText;
 }
 
 Declaration::Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nVarType,
                          std::string nVarName, bool nIsArray, std::string nText)
-	: Declaration(nAlignment, DeclarationPadding::None, nSize, nText)
-{
-	varType = nVarType;
-	varName = nVarName;
-	isArray = nIsArray;
-}
-
-Declaration::Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding, size_t nSize,
-                         std::string nVarType, std::string nVarName, bool nIsArray,
-                         std::string nText)
-	: Declaration(nAlignment, nPadding, nSize, nText)
+	: Declaration(nAlignment, nSize, nText)
 {
 	varType = nVarType;
 	varName = nVarName;
@@ -31,7 +19,7 @@ Declaration::Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPa
 Declaration::Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nVarType,
                          std::string nVarName, bool nIsArray, size_t nArrayItemCnt,
                          std::string nText)
-	: Declaration(nAlignment, DeclarationPadding::None, nSize, nText)
+	: Declaration(nAlignment, nSize, nText)
 {
 	varType = nVarType;
 	varName = nVarName;
@@ -42,7 +30,7 @@ Declaration::Declaration(DeclarationAlignment nAlignment, size_t nSize, std::str
 Declaration::Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nVarType,
                          std::string nVarName, bool nIsArray, std::string nArrayItemCntStr,
                          std::string nText)
-	: Declaration(nAlignment, DeclarationPadding::None, nSize, nText)
+	: Declaration(nAlignment, nSize, nText)
 {
 	varType = nVarType;
 	varName = nVarName;
@@ -58,20 +46,9 @@ Declaration::Declaration(DeclarationAlignment nAlignment, size_t nSize, std::str
 	isExternal = nIsExternal;
 }
 
-Declaration::Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding, size_t nSize,
-                         std::string nVarType, std::string nVarName, bool nIsArray,
-                         size_t nArrayItemCnt, std::string nText)
-	: Declaration(nAlignment, nPadding, nSize, nText)
-{
-	varType = nVarType;
-	varName = nVarName;
-	isArray = nIsArray;
-	arrayItemCnt = nArrayItemCnt;
-}
-
 Declaration::Declaration(std::string nIncludePath, size_t nSize, std::string nVarType,
                          std::string nVarName)
-	: Declaration(DeclarationAlignment::None, DeclarationPadding::None, nSize, "")
+	: Declaration(DeclarationAlignment::None, nSize, "")
 {
 	includePath = nIncludePath;
 	varType = nVarType;

--- a/ZAPD/Declaration.cpp
+++ b/ZAPD/Declaration.cpp
@@ -48,7 +48,7 @@ Declaration::Declaration(DeclarationAlignment nAlignment, size_t nSize, std::str
 
 Declaration::Declaration(std::string nIncludePath, size_t nSize, std::string nVarType,
                          std::string nVarName)
-	: Declaration(DeclarationAlignment::None, nSize, "")
+	: Declaration(DeclarationAlignment::Align4, nSize, "")
 {
 	includePath = nIncludePath;
 	varType = nVarType;

--- a/ZAPD/Declaration.h
+++ b/ZAPD/Declaration.h
@@ -5,7 +5,6 @@
 
 enum class DeclarationAlignment
 {
-	None,
 	Align4,
 	Align8,
 	Align16

--- a/ZAPD/Declaration.h
+++ b/ZAPD/Declaration.h
@@ -11,19 +11,10 @@ enum class DeclarationAlignment
 	Align16
 };
 
-enum class DeclarationPadding
-{
-	None,
-	Pad4,
-	Pad8,
-	Pad16
-};
-
 class Declaration
 {
 public:
 	DeclarationAlignment alignment;
-	DeclarationPadding padding;
 	size_t size;
 	std::string preText = "";
 	std::string text = "";
@@ -44,8 +35,6 @@ public:
 
 	Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nVarType,
 	            std::string nVarName, bool nIsArray, std::string nText);
-	Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding, size_t nSize,
-	            std::string nVarType, std::string nVarName, bool nIsArray, std::string nText);
 	Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nVarType,
 	            std::string nVarName, bool nIsArray, size_t nArrayItemCnt, std::string nText);
 	Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nVarType,
@@ -54,12 +43,8 @@ public:
 	Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nVarType,
 	            std::string nVarName, bool nIsArray, size_t nArrayItemCnt, std::string nText,
 	            bool nIsExternal);
-	Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding, size_t nSize,
-	            std::string nVarType, std::string nVarName, bool nIsArray, size_t nArrayItemCnt,
-	            std::string nText);
 	Declaration(std::string nIncludePath, size_t nSize, std::string nVarType, std::string nVarName);
 
 protected:
-	Declaration(DeclarationAlignment nAlignment, DeclarationPadding nPadding, size_t nSize,
-	            std::string nText);
+	Declaration(DeclarationAlignment nAlignment, size_t nSize, std::string nText);
 };

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -51,7 +51,7 @@ std::string ZNormalAnimation::GetSourceOutputCode([[maybe_unused]] const std::st
 		headerStr += StringHelper::Sprintf("\t%sFrameData,\n", defaultPrefix.c_str());
 		headerStr += StringHelper::Sprintf("\t%sJointIndices,\n", defaultPrefix.c_str());
 		headerStr += StringHelper::Sprintf("\t%i\n", limit);
-		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
+		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align4, GetRawDataSize(),
 		                       GetSourceTypeName(), StringHelper::Sprintf("%s", name.c_str()),
 		                       headerStr);
 
@@ -150,7 +150,7 @@ std::string ZLinkAnimation::GetSourceOutputCode([[maybe_unused]] const std::stri
 					StringHelper::Sprintf("%sSeg%06X", name.c_str(), segmentAddress));
 		std::string headerStr =
 			StringHelper::Sprintf("\n\t{ %i },\n\t0x%08X\n", frameCount, segmentAddress);
-		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
+		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align4, GetRawDataSize(),
 		                       GetSourceTypeName(), StringHelper::Sprintf("%s", name.c_str()),
 		                       headerStr);
 	}
@@ -308,7 +308,7 @@ void ZCurveAnimation::DeclareReferences(const std::string& prefix)
 		Declaration* decl = parent->GetDeclaration(refIndexOffset);
 		if (decl == nullptr)
 		{
-			parent->AddDeclarationArray(refIndexOffset, DeclarationAlignment::None,
+			parent->AddDeclarationArray(refIndexOffset, DeclarationAlignment::Align4,
 			                            arrayItemCnt * 1, "u8", refIndexStr, arrayItemCnt,
 			                            entryStr);
 		}
@@ -338,7 +338,7 @@ void ZCurveAnimation::DeclareReferences(const std::string& prefix)
 		Declaration* decl = parent->GetDeclaration(transformDataOffset);
 		if (decl == nullptr)
 		{
-			parent->AddDeclarationArray(transformDataOffset, DeclarationAlignment::None,
+			parent->AddDeclarationArray(transformDataOffset, DeclarationAlignment::Align4,
 			                            arrayItemCnt * transformDataArr.at(0).GetRawDataSize(),
 			                            transformDataArr.at(0).GetSourceTypeName(),
 			                            transformDataStr, arrayItemCnt, entryStr);
@@ -367,7 +367,7 @@ void ZCurveAnimation::DeclareReferences(const std::string& prefix)
 		Declaration* decl = parent->GetDeclaration(copyValuesOffset);
 		if (decl == nullptr)
 		{
-			parent->AddDeclarationArray(copyValuesOffset, DeclarationAlignment::None,
+			parent->AddDeclarationArray(copyValuesOffset, DeclarationAlignment::Align4,
 			                            arrayItemCnt * 2, "s16", copyValuesStr, arrayItemCnt,
 			                            entryStr);
 		}
@@ -444,7 +444,7 @@ std::string ZCurveAnimation::GetSourceOutputCode(const std::string& prefix)
 	Declaration* decl = parent->GetDeclaration(address);
 	if (decl == nullptr)
 	{
-		parent->AddDeclaration(address, DeclarationAlignment::None, GetRawDataSize(),
+		parent->AddDeclaration(address, DeclarationAlignment::Align4, GetRawDataSize(),
 		                       GetSourceTypeName(), name, bodyStr);
 	}
 	else

--- a/ZAPD/ZArray.cpp
+++ b/ZAPD/ZArray.cpp
@@ -66,7 +66,7 @@ std::string ZArray::GetSourceOutputCode([[maybe_unused]] const std::string& pref
 	}
 
 	if (parent != nullptr)
-		parent->AddDeclarationArray(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
+		parent->AddDeclarationArray(rawDataIndex, DeclarationAlignment::Align4, GetRawDataSize(),
 		                            resList.at(0)->GetSourceTypeName(), name, arrayCnt, output);
 
 	return "";

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -184,8 +184,8 @@ void ZCollisionHeader::ParseRawData()
 		name.c_str(), polyTypeDefSegmentOffset, name.c_str(), camDataSegmentOffset, numWaterBoxes,
 		waterBoxStr);
 
-	parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align4, 44,
-	                       GetSourceTypeName(), name, declaration);
+	parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align4, 44, GetSourceTypeName(),
+	                       name, declaration);
 }
 
 std::string ZCollisionHeader::GetSourceTypeName() const

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -184,7 +184,7 @@ void ZCollisionHeader::ParseRawData()
 		name.c_str(), polyTypeDefSegmentOffset, name.c_str(), camDataSegmentOffset, numWaterBoxes,
 		waterBoxStr);
 
-	parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, DeclarationPadding::Pad16, 44,
+	parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, 44,
 	                       GetSourceTypeName(), name, declaration);
 }
 

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -95,7 +95,7 @@ void ZCollisionHeader::ParseRawData()
 
 	if (waterBoxAddress != 0)
 		parent->AddDeclarationArray(
-			waterBoxSegmentOffset, DeclarationAlignment::None, 16 * waterBoxes.size(), "WaterBox",
+			waterBoxSegmentOffset, DeclarationAlignment::Align4, 16 * waterBoxes.size(), "WaterBox",
 			StringHelper::Sprintf("%s_waterBoxes_%06X", name.c_str(), waterBoxSegmentOffset), 0,
 			declaration);
 
@@ -116,7 +116,7 @@ void ZCollisionHeader::ParseRawData()
 		if (polyAddress != 0)
 		{
 			parent->AddDeclarationArray(
-				polySegmentOffset, DeclarationAlignment::None, polygons.size() * 16,
+				polySegmentOffset, DeclarationAlignment::Align4, polygons.size() * 16,
 				"CollisionPoly",
 				StringHelper::Sprintf("%s_polygons_%08X", name.c_str(), polySegmentOffset), 0,
 				declaration);
@@ -135,7 +135,7 @@ void ZCollisionHeader::ParseRawData()
 
 	if (polyTypeDefAddress != 0)
 		parent->AddDeclarationArray(
-			polyTypeDefSegmentOffset, DeclarationAlignment::None, polygonTypes.size() * 8,
+			polyTypeDefSegmentOffset, DeclarationAlignment::Align4, polygonTypes.size() * 8,
 			"SurfaceType",
 			StringHelper::Sprintf("%s_surfaceType_%08X", name.c_str(), polyTypeDefSegmentOffset), 0,
 			declaration);
@@ -157,7 +157,7 @@ void ZCollisionHeader::ParseRawData()
 
 		if (vtxAddress != 0)
 			parent->AddDeclarationArray(
-				vtxSegmentOffset, DeclarationAlignment::None, vertices.size() * 6, "Vec3s",
+				vtxSegmentOffset, DeclarationAlignment::Align4, vertices.size() * 6, "Vec3s",
 				StringHelper::Sprintf("%s_vtx_%08X", name.c_str(), vtxSegmentOffset), 0,
 				declaration);
 
@@ -184,7 +184,7 @@ void ZCollisionHeader::ParseRawData()
 		name.c_str(), polyTypeDefSegmentOffset, name.c_str(), camDataSegmentOffset, numWaterBoxes,
 		waterBoxStr);
 
-	parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, 44,
+	parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align4, 44,
 	                       GetSourceTypeName(), name, declaration);
 }
 
@@ -299,7 +299,7 @@ CameraDataList::CameraDataList(ZFile* parent, const std::string& prefix,
 	}
 
 	parent->AddDeclarationArray(
-		rawDataIndex, DeclarationAlignment::None, entries.size() * 8, "CamData",
+		rawDataIndex, DeclarationAlignment::Align4, entries.size() * 8, "CamData",
 		StringHelper::Sprintf("%s_camDataList_%08X", prefix.c_str(), rawDataIndex), entries.size(),
 		declaration);
 
@@ -322,7 +322,7 @@ CameraDataList::CameraDataList(ZFile* parent, const std::string& prefix,
 		int32_t cameraPosDataIndex = GETSEGOFFSET(cameraPosDataSeg);
 		uint32_t entrySize = numDataTotal * 0x6;
 		parent->AddDeclarationArray(
-			cameraPosDataIndex, DeclarationAlignment::None, entrySize, "Vec3s",
+			cameraPosDataIndex, DeclarationAlignment::Align4, entrySize, "Vec3s",
 			StringHelper::Sprintf("%s_camPosData_%08X", prefix.c_str(), cameraPosDataIndex),
 			numDataTotal, declaration);
 	}

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -127,9 +127,8 @@ void ZCutscene::DeclareVar(const std::string& prefix, const std::string& bodyStr
 	if (auxName == "")
 		auxName = StringHelper::Sprintf("%sCutsceneData0x%06X", prefix.c_str(), rawDataIndex);
 
-	parent->AddDeclarationArray(getSegmentOffset(), DeclarationAlignment::Align4,
-	                            GetRawDataSize(), GetSourceTypeName(),
-	                            auxName, 0, bodyStr);
+	parent->AddDeclarationArray(getSegmentOffset(), DeclarationAlignment::Align4, GetRawDataSize(),
+	                            GetSourceTypeName(), auxName, 0, bodyStr);
 }
 
 size_t ZCutscene::GetRawDataSize() const
@@ -1078,8 +1077,7 @@ std::string CutsceneCommandActorAction::GenerateSourceCode([[maybe_unused]] uint
 	{
 		result += StringHelper::Sprintf(
 			"\t\t%s(0x%04X, %i, %i, 0x%04X, 0x%04X, 0x%04X, %i, %i, %i, %i, %i, %i, %.11ef, "
-		    "%.11ef, "
-			"%.11ef),\n",
+			"%.11ef, %.11ef),\n",
 			subCommand.c_str(), entries[i]->action, entries[i]->startFrame, entries[i]->endFrame,
 			entries[i]->rotX, entries[i]->rotY, entries[i]->rotZ, entries[i]->startPosX,
 			entries[i]->startPosY, entries[i]->startPosZ, entries[i]->endPosX, entries[i]->endPosY,

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -128,7 +128,7 @@ void ZCutscene::DeclareVar(const std::string& prefix, const std::string& bodyStr
 		auxName = StringHelper::Sprintf("%sCutsceneData0x%06X", prefix.c_str(), rawDataIndex);
 
 	parent->AddDeclarationArray(getSegmentOffset(), DeclarationAlignment::Align4,
-	                            DeclarationPadding::Pad16, GetRawDataSize(), GetSourceTypeName(),
+	                            GetRawDataSize(), GetSourceTypeName(),
 	                            auxName, 0, bodyStr);
 }
 

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -1836,7 +1836,7 @@ std::string ZDisplayList::GetSourceOutputCode(const std::string& prefix)
 
 			if (parent != nullptr)
 			{
-				parent->AddDeclarationArray(item.first, DeclarationAlignment::None,
+				parent->AddDeclarationArray(item.first, DeclarationAlignment::Align16,
 				                            item.second.size() * 16, "static Vtx",
 				                            StringHelper::Sprintf("%sVtx_%06X", prefix.c_str(),
 				                                                  item.first, item.second.size()),
@@ -1931,7 +1931,7 @@ std::string ZDisplayList::GetSourceOutputCode(const std::string& prefix)
 				auto filepath = Globals::Instance->outputPath / vtxName;
 				std::string incStr = StringHelper::Sprintf("%s.%s.inc", filepath.c_str(), "vtx");
 
-				parent->AddDeclarationArray(vtxKeys[i], DeclarationAlignment::None,
+				parent->AddDeclarationArray(vtxKeys[i], DeclarationAlignment::Align16,
 				                            item.size() * 16, "static Vtx", vtxName, item.size(),
 				                            declaration);
 

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -374,8 +374,7 @@ Declaration* ZFile::AddDeclaration(uint32_t address, DeclarationAlignment alignm
 }
 
 Declaration* ZFile::AddDeclarationArray(uint32_t address, DeclarationAlignment alignment,
-                                    	size_t size,
-                                        std::string varType, std::string varName,
+                                        size_t size, std::string varType, std::string varName,
                                         size_t arrayItemCnt, std::string body)
 {
 	assert(GETSEGNUM(address) == 0);
@@ -384,8 +383,7 @@ Declaration* ZFile::AddDeclarationArray(uint32_t address, DeclarationAlignment a
 	Declaration* decl = GetDeclaration(address);
 	if (decl == nullptr)
 	{
-		decl =
-			new Declaration(alignment, size, varType, varName, true, arrayItemCnt, body);
+		decl = new Declaration(alignment, size, varType, varName, true, arrayItemCnt, body);
 		declarations[address] = decl;
 	}
 	else
@@ -414,8 +412,7 @@ Declaration* ZFile::AddDeclarationArray(uint32_t address, DeclarationAlignment a
 	Declaration* decl = GetDeclaration(address);
 	if (decl == nullptr)
 	{
-		decl = new Declaration(alignment, size, varType, varName, true, arrayItemCntStr,
-		                       body);
+		decl = new Declaration(alignment, size, varType, varName, true, arrayItemCntStr, body);
 		declarations[address] = decl;
 	}
 	else

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -369,6 +369,7 @@ Declaration* ZFile::AddDeclaration(uint32_t address, DeclarationAlignment alignm
 		decl->varType = varType;
 		decl->varName = varName;
 		decl->text = body;
+		decl->isPlaceholder = false;
 	}
 	return decl;
 }
@@ -388,15 +389,14 @@ Declaration* ZFile::AddDeclarationArray(uint32_t address, DeclarationAlignment a
 	}
 	else
 	{
-		if (decl->isPlaceholder)
-			decl->varName = varName;
+		decl->varName = varName;
 		decl->alignment = alignment;
 		decl->size = size;
 		decl->varType = varType;
 		decl->isArray = true;
 		decl->arrayItemCnt = arrayItemCnt;
-		if (body != "" && decl->text == "")
-			decl->text = body;
+		decl->text = body;
+		decl->isPlaceholder = false;
 	}
 
 	return decl;
@@ -424,6 +424,7 @@ Declaration* ZFile::AddDeclarationArray(uint32_t address, DeclarationAlignment a
 		decl->isArray = true;
 		decl->arrayItemCntStr = arrayItemCntStr;
 		decl->text = body;
+		decl->isPlaceholder = false;
 	}
 	return decl;
 }
@@ -437,24 +438,6 @@ Declaration* ZFile::AddDeclarationPlaceholder(uint32_t address)
 	if (declarations.find(address) == declarations.end())
 	{
 		decl = new Declaration(DeclarationAlignment::Align4, 0, "", "", false, "");
-		decl->isPlaceholder = true;
-		declarations[address] = decl;
-	}
-	else
-		decl = declarations[address];
-
-	return decl;
-}
-
-Declaration* ZFile::AddDeclarationPlaceholder(uint32_t address, std::string varName)
-{
-	assert(GETSEGNUM(address) == 0);
-	AddDeclarationDebugChecks(address);
-	Declaration* decl;
-
-	if (declarations.find(address) == declarations.end())
-	{
-		decl = new Declaration(DeclarationAlignment::Align4, 0, "", varName, false, "");
 		decl->isPlaceholder = true;
 		declarations[address] = decl;
 	}
@@ -482,6 +465,7 @@ Declaration* ZFile::AddDeclarationInclude(uint32_t address, std::string includeP
 		decl->size = size;
 		decl->varType = varType;
 		decl->varName = varName;
+		decl->isPlaceholder = false;
 	}
 	return decl;
 }
@@ -516,6 +500,7 @@ Declaration* ZFile::AddDeclarationIncludeArray(uint32_t address, std::string inc
 		decl->size = size;
 		decl->isArray = true;
 		decl->arrayItemCnt = arrayItemCnt;
+		decl->isPlaceholder = false;
 	}
 	return decl;
 }
@@ -714,7 +699,7 @@ void ZFile::GeneratePlaceholderDeclarations()
 	for (ZResource* res : resources)
 	{
 		if (GetDeclaration(res->GetRawDataIndex()) == nullptr)
-			AddDeclarationPlaceholder(res->GetRawDataIndex(), res->GetName());
+			AddDeclarationPlaceholder(res->GetRawDataIndex());
 	}
 }
 

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -412,7 +412,7 @@ Declaration* ZFile::AddDeclarationPlaceholder(uint32_t address)
 
 	if (declarations.find(address) == declarations.end())
 	{
-		decl = new Declaration(DeclarationAlignment::None, 0, "", "", false, "");
+		decl = new Declaration(DeclarationAlignment::Align4, 0, "", "", false, "");
 		decl->isPlaceholder = true;
 		declarations[address] = decl;
 	}
@@ -430,7 +430,7 @@ Declaration* ZFile::AddDeclarationPlaceholder(uint32_t address, std::string varN
 
 	if (declarations.find(address) == declarations.end())
 	{
-		decl = new Declaration(DeclarationAlignment::None, 0, "", varName, false, "");
+		decl = new Declaration(DeclarationAlignment::Align4, 0, "", varName, false, "");
 		decl->isPlaceholder = true;
 		declarations[address] = decl;
 	}
@@ -928,7 +928,7 @@ std::string ZFile::ProcessDeclarations()
 					}
 
 					Declaration* decl = AddDeclarationArray(
-						unaccountedAddress, DeclarationAlignment::None, diff, "static u8",
+						unaccountedAddress, DeclarationAlignment::Align4, diff, "static u8",
 						StringHelper::Sprintf("%s_%06X", unaccountedPrefix.c_str(),
 					                          unaccountedAddress),
 						diff, src);

--- a/ZAPD/ZFile.h
+++ b/ZAPD/ZFile.h
@@ -58,7 +58,6 @@ public:
 	                                 std::string varType, std::string varName,
 	                                 std::string arrayItemCntStr, std::string body);
 	Declaration* AddDeclarationPlaceholder(uint32_t address);
-	Declaration* AddDeclarationPlaceholder(uint32_t address, std::string varName);
 	Declaration* AddDeclarationInclude(uint32_t address, std::string includePath, size_t size,
 	                                   std::string varType, std::string varName);
 	Declaration* AddDeclarationIncludeArray(uint32_t address, std::string includePath, size_t size,

--- a/ZAPD/ZFile.h
+++ b/ZAPD/ZFile.h
@@ -58,6 +58,7 @@ public:
 	                                 std::string varType, std::string varName,
 	                                 std::string arrayItemCntStr, std::string body);
 	Declaration* AddDeclarationPlaceholder(uint32_t address);
+	Declaration* AddDeclarationPlaceholder(uint32_t address, std::string varName);
 	Declaration* AddDeclarationInclude(uint32_t address, std::string includePath, size_t size,
 	                                   std::string varType, std::string varName);
 	Declaration* AddDeclarationIncludeArray(uint32_t address, std::string includePath, size_t size,

--- a/ZAPD/ZFile.h
+++ b/ZAPD/ZFile.h
@@ -51,18 +51,12 @@ public:
 
 	Declaration* AddDeclaration(uint32_t address, DeclarationAlignment alignment, size_t size,
 	                            std::string varType, std::string varName, std::string body);
-	Declaration* AddDeclaration(uint32_t address, DeclarationAlignment alignment,
-	                            DeclarationPadding padding, size_t size, std::string varType,
-	                            std::string varName, std::string body);
 	Declaration* AddDeclarationArray(uint32_t address, DeclarationAlignment alignment, size_t size,
 	                                 std::string varType, std::string varName, size_t arrayItemCnt,
 	                                 std::string body);
 	Declaration* AddDeclarationArray(uint32_t address, DeclarationAlignment alignment, size_t size,
 	                                 std::string varType, std::string varName,
 	                                 std::string arrayItemCntStr, std::string body);
-	Declaration* AddDeclarationArray(uint32_t address, DeclarationAlignment alignment,
-	                                 DeclarationPadding padding, size_t size, std::string varType,
-	                                 std::string varName, size_t arrayItemCnt, std::string body);
 	Declaration* AddDeclarationPlaceholder(uint32_t address);
 	Declaration* AddDeclarationPlaceholder(uint32_t address, std::string varName);
 	Declaration* AddDeclarationInclude(uint32_t address, std::string includePath, size_t size,

--- a/ZAPD/ZLimb.cpp
+++ b/ZAPD/ZLimb.cpp
@@ -126,7 +126,7 @@ void Struct_800A598C::DeclareReferences(const std::string& prefix)
 
 		if (decl == nullptr)
 		{
-			parent->AddDeclarationArray(unk_8_Offset, DeclarationAlignment::None,
+			parent->AddDeclarationArray(unk_8_Offset, DeclarationAlignment::Align4,
 			                            arrayItemCnt * Struct_800A57C0::GetRawDataSize(),
 			                            Struct_800A57C0::GetSourceTypeName(), unk_8_Str,
 			                            arrayItemCnt, entryStr);
@@ -157,7 +157,7 @@ void Struct_800A598C::DeclareReferences(const std::string& prefix)
 		Declaration* decl = parent->GetDeclaration(unk_C_Offset);
 		if (decl == nullptr)
 		{
-			parent->AddDeclarationArray(unk_C_Offset, DeclarationAlignment::None,
+			parent->AddDeclarationArray(unk_C_Offset, DeclarationAlignment::Align4,
 			                            arrayItemCnt * Struct_800A598C_2::GetRawDataSize(),
 			                            Struct_800A598C_2::GetSourceTypeName(), unk_C_Str,
 			                            arrayItemCnt, entryStr);
@@ -266,7 +266,7 @@ void Struct_800A5E28::DeclareReferences(const std::string& prefix)
 
 		if (decl == nullptr)
 		{
-			parent->AddDeclarationArray(unk_4_Offset, DeclarationAlignment::None,
+			parent->AddDeclarationArray(unk_4_Offset, DeclarationAlignment::Align4,
 			                            arrayItemCnt * Struct_800A598C::GetRawDataSize(),
 			                            Struct_800A598C::GetSourceTypeName(), unk_4_Str,
 			                            arrayItemCnt, entryStr);
@@ -370,7 +370,7 @@ void ZLimb::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
 	ZResource::ExtractFromXML(reader, nRawDataIndex);
 
-	parent->AddDeclaration(GetFileAddress(), DeclarationAlignment::None, GetRawDataSize(),
+	parent->AddDeclaration(GetFileAddress(), DeclarationAlignment::Align4, GetRawDataSize(),
 	                       GetSourceTypeName(), name, "");
 }
 
@@ -586,7 +586,7 @@ std::string ZLimb::GetSourceOutputCode(const std::string& prefix)
 	Declaration* decl = parent->GetDeclaration(GetFileAddress());
 
 	if (decl == nullptr)
-		parent->AddDeclaration(GetFileAddress(), DeclarationAlignment::None, GetRawDataSize(),
+		parent->AddDeclaration(GetFileAddress(), DeclarationAlignment::Align4, GetRawDataSize(),
 		                       GetSourceTypeName(), name, entryStr);
 	else
 		decl->text = entryStr;
@@ -736,7 +736,7 @@ std::string ZLimb::GetSourceOutputCodeSkin_Type_4(const std::string& prefix)
 		segmentStruct.DeclareReferences(prefix);
 		std::string entryStr = segmentStruct.GetSourceOutputCode(prefix);
 
-		parent->AddDeclaration(skinSegmentOffset, DeclarationAlignment::None,
+		parent->AddDeclaration(skinSegmentOffset, DeclarationAlignment::Align4,
 		                       Struct_800A5E28::GetRawDataSize(),
 		                       Struct_800A5E28::GetSourceTypeName(), struct_800A5E28_Str, entryStr);
 	}

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -167,8 +167,7 @@ void PathwayEntry::DeclareReferences(const std::string& prefix)
 	if (decl == nullptr)
 	{
 		parent->AddDeclarationArray(GETSEGOFFSET(listSegmentAddress), DeclarationAlignment::Align4,
-		                            points.size() * 6,
-		                            points.at(0).GetSourceTypeName(),
+		                            points.size() * 6, points.at(0).GetSourceTypeName(),
 		                            StringHelper::Sprintf("%sPathwayList0x%06X", prefix.c_str(),
 		                                                  GETSEGOFFSET(listSegmentAddress)),
 		                            points.size(), declaration);

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -167,7 +167,7 @@ void PathwayEntry::DeclareReferences(const std::string& prefix)
 	if (decl == nullptr)
 	{
 		parent->AddDeclarationArray(GETSEGOFFSET(listSegmentAddress), DeclarationAlignment::Align4,
-		                            DeclarationPadding::Pad4, points.size() * 6,
+		                            points.size() * 6,
 		                            points.at(0).GetSourceTypeName(),
 		                            StringHelper::Sprintf("%sPathwayList0x%06X", prefix.c_str(),
 		                                                  GETSEGOFFSET(listSegmentAddress)),

--- a/ZAPD/ZRoom/Commands/SetActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetActorList.cpp
@@ -17,13 +17,11 @@ void SetActorList::ParseRawData()
 	numActors = cmdArg1;
 }
 
-void SetActorList::DeclareReferences(const std::string& prefix)
+void SetActorList::DeclareReferences([[maybe_unused]] const std::string& prefix)
 {
 	if (numActors != 0 && cmdArg2 != 0)
 	{
-		std::string varName =
-			StringHelper::Sprintf("%sActorList_%06X", prefix.c_str(), segmentOffset);
-		parent->AddDeclarationPlaceholder(segmentOffset, varName);
+		parent->AddDeclarationPlaceholder(segmentOffset);
 	}
 }
 

--- a/ZAPD/ZRoom/Commands/SetActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetActorList.cpp
@@ -17,11 +17,13 @@ void SetActorList::ParseRawData()
 	numActors = cmdArg1;
 }
 
-void SetActorList::DeclareReferences([[maybe_unused]] const std::string& prefix)
+void SetActorList::DeclareReferences(const std::string& prefix)
 {
 	if (numActors != 0 && cmdArg2 != 0)
 	{
-		parent->AddDeclarationPlaceholder(segmentOffset);
+		std::string varName =
+			StringHelper::Sprintf("%sActorList_%06X", prefix.c_str(), segmentOffset);
+		parent->AddDeclarationPlaceholder(segmentOffset, varName);
 	}
 }
 

--- a/ZAPD/ZRoom/Commands/SetActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetActorList.cpp
@@ -72,12 +72,8 @@ void SetActorList::DeclareReferencesLate(const std::string& prefix)
 
 	const auto& entry = actors.front();
 
-	DeclarationPadding padding = DeclarationPadding::Pad16;
-	if (Globals::Instance->game == ZGame::MM_RETAIL)
-		padding = DeclarationPadding::None;
-
 	std::string varName = StringHelper::Sprintf("%sActorList_%06X", prefix.c_str(), segmentOffset);
-	parent->AddDeclarationArray(segmentOffset, DeclarationAlignment::Align4, padding,
+	parent->AddDeclarationArray(segmentOffset, DeclarationAlignment::Align4,
 	                            actors.size() * entry.GetRawDataSize(), entry.GetSourceTypeName(),
 	                            varName, GetActorListArraySize(), declaration);
 }

--- a/ZAPD/ZRoom/Commands/SetCsCamera.cpp
+++ b/ZAPD/ZRoom/Commands/SetCsCamera.cpp
@@ -98,8 +98,8 @@ void SetCsCamera::DeclareReferences(const std::string& prefix)
 		std::string camTypename = entry.GetSourceTypeName();
 
 		parent->AddDeclarationArray(
-			segmentOffset, DeclarationAlignment::Align4,
-			cameras.size() * entry.GetRawDataSize(), camTypename,
+			segmentOffset, DeclarationAlignment::Align4, cameras.size() * entry.GetRawDataSize(),
+			camTypename,
 			StringHelper::Sprintf("%s%s_%06X", prefix.c_str(), camTypename.c_str(), segmentOffset),
 			cameras.size(), declaration);
 	}

--- a/ZAPD/ZRoom/Commands/SetCsCamera.cpp
+++ b/ZAPD/ZRoom/Commands/SetCsCamera.cpp
@@ -42,9 +42,6 @@ void SetCsCamera::ParseRawData()
 			points.push_back(vec);
 		}
 	}
-
-	if (segmentOffset != 0)
-		parent->AddDeclarationPlaceholder(segmentOffset);
 }
 
 void SetCsCamera::DeclareReferences(const std::string& prefix)

--- a/ZAPD/ZRoom/Commands/SetCsCamera.cpp
+++ b/ZAPD/ZRoom/Commands/SetCsCamera.cpp
@@ -98,7 +98,7 @@ void SetCsCamera::DeclareReferences(const std::string& prefix)
 		std::string camTypename = entry.GetSourceTypeName();
 
 		parent->AddDeclarationArray(
-			segmentOffset, DeclarationAlignment::Align4, DeclarationPadding::Pad16,
+			segmentOffset, DeclarationAlignment::Align4,
 			cameras.size() * entry.GetRawDataSize(), camTypename,
 			StringHelper::Sprintf("%s%s_%06X", prefix.c_str(), camTypename.c_str(), segmentOffset),
 			cameras.size(), declaration);

--- a/ZAPD/ZRoom/Commands/SetCsCamera.cpp
+++ b/ZAPD/ZRoom/Commands/SetCsCamera.cpp
@@ -42,6 +42,9 @@ void SetCsCamera::ParseRawData()
 			points.push_back(vec);
 		}
 	}
+
+	if (segmentOffset != 0)
+		parent->AddDeclarationPlaceholder(segmentOffset);
 }
 
 void SetCsCamera::DeclareReferences(const std::string& prefix)

--- a/ZAPD/ZRoom/Commands/SetEntranceList.cpp
+++ b/ZAPD/ZRoom/Commands/SetEntranceList.cpp
@@ -49,7 +49,7 @@ void SetEntranceList::DeclareReferencesLate([[maybe_unused]] const std::string& 
 		}
 
 		parent->AddDeclarationArray(
-			segmentOffset, DeclarationAlignment::None, entrances.size() * 2, "EntranceEntry",
+			segmentOffset, DeclarationAlignment::Align4, entrances.size() * 2, "EntranceEntry",
 			StringHelper::Sprintf("%sEntranceList0x%06X", prefix.c_str(), segmentOffset),
 			entrances.size(), declaration);
 	}

--- a/ZAPD/ZRoom/Commands/SetLightList.cpp
+++ b/ZAPD/ZRoom/Commands/SetLightList.cpp
@@ -40,7 +40,7 @@ void SetLightList::DeclareReferences(const std::string& prefix)
 		const auto& light = lights.front();
 
 		parent->AddDeclarationArray(
-			segmentOffset, DeclarationAlignment::None, lights.size() * light.GetRawDataSize(),
+			segmentOffset, DeclarationAlignment::Align4, lights.size() * light.GetRawDataSize(),
 			light.GetSourceTypeName(),
 			StringHelper::Sprintf("%sLightInfo0x%06X", prefix.c_str(), segmentOffset),
 			lights.size(), declarations);

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -67,7 +67,8 @@ void GenDListDeclarations(ZRoom* zRoom, ZFile* parent, ZDisplayList* dList)
 	for (const auto& vtxEntry : dList->vtxDeclarations)
 	{
 		parent->AddDeclarationArray(
-			vtxEntry.first, DeclarationAlignment::Align16, dList->vertices[vtxEntry.first].size() * 16, "static Vtx",
+			vtxEntry.first, DeclarationAlignment::Align16,
+			dList->vertices[vtxEntry.first].size() * 16, "static Vtx",
 			StringHelper::Sprintf("%sVtx_%06X", zRoom->GetName().c_str(), vtxEntry.first),
 			dList->vertices[vtxEntry.first].size(), vtxEntry.second);
 	}

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -66,11 +66,8 @@ void GenDListDeclarations(ZRoom* zRoom, ZFile* parent, ZDisplayList* dList)
 
 	for (const auto& vtxEntry : dList->vtxDeclarations)
 	{
-		DeclarationAlignment alignment = DeclarationAlignment::Align4;
-		if (Globals::Instance->game == ZGame::MM_RETAIL)
-			alignment = DeclarationAlignment::None;
 		parent->AddDeclarationArray(
-			vtxEntry.first, alignment, dList->vertices[vtxEntry.first].size() * 16, "static Vtx",
+			vtxEntry.first, DeclarationAlignment::Align16, dList->vertices[vtxEntry.first].size() * 16, "static Vtx",
 			StringHelper::Sprintf("%sVtx_%06X", zRoom->GetName().c_str(), vtxEntry.first),
 			dList->vertices[vtxEntry.first].size(), vtxEntry.second);
 	}

--- a/ZAPD/ZRoom/Commands/SetMinimapChests.cpp
+++ b/ZAPD/ZRoom/Commands/SetMinimapChests.cpp
@@ -42,7 +42,7 @@ void SetMinimapChests::DeclareReferences(const std::string& prefix)
 	}
 
 	parent->AddDeclarationArray(
-		segmentOffset, DeclarationAlignment::None, chests.size() * 10, "MinimapChest",
+		segmentOffset, DeclarationAlignment::Align4, chests.size() * 10, "MinimapChest",
 		StringHelper::Sprintf("%sMinimapChests0x%06X", prefix.c_str(), segmentOffset),
 		chests.size(), declaration);
 }

--- a/ZAPD/ZRoom/Commands/SetObjectList.cpp
+++ b/ZAPD/ZRoom/Commands/SetObjectList.cpp
@@ -45,7 +45,7 @@ void SetObjectList::DeclareReferences(const std::string& prefix)
 		}
 
 		parent->AddDeclarationArray(
-			segmentOffset, DeclarationAlignment::None, objects.size() * 2, "s16",
+			segmentOffset, DeclarationAlignment::Align4, objects.size() * 2, "s16",
 			StringHelper::Sprintf("%sObjectList_%06X", prefix.c_str(), segmentOffset),
 			objects.size(), declaration);
 	}

--- a/ZAPD/ZRoom/Commands/SetTransitionActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetTransitionActorList.cpp
@@ -43,7 +43,7 @@ void SetTransitionActorList::DeclareReferences(const std::string& prefix)
 	}
 
 	parent->AddDeclarationArray(
-		segmentOffset, DeclarationAlignment::None, transitionActors.size() * 16,
+		segmentOffset, DeclarationAlignment::Align4, transitionActors.size() * 16,
 		"TransitionActorEntry",
 		StringHelper::Sprintf("%sTransitionActorList_%06X", prefix.c_str(), segmentOffset), 0,
 		declaration);

--- a/ZAPD/ZScalar.cpp
+++ b/ZAPD/ZScalar.cpp
@@ -250,7 +250,7 @@ std::string ZScalar::GetBodySourceCode() const
 std::string ZScalar::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
 	if (parent != nullptr)
-		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
+		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align4, GetRawDataSize(),
 		                       GetSourceTypeName(), GetName(), GetBodySourceCode());
 
 	return "";

--- a/ZAPD/ZString.cpp
+++ b/ZAPD/ZString.cpp
@@ -36,7 +36,7 @@ std::string ZString::GetBodySourceCode() const
 
 std::string ZString::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
-	parent->AddDeclarationArray(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
+	parent->AddDeclarationArray(rawDataIndex, DeclarationAlignment::Align4, GetRawDataSize(),
 	                            GetSourceTypeName(), name, 0, GetBodySourceCode());
 
 	return "";

--- a/ZAPD/ZVector.cpp
+++ b/ZAPD/ZVector.cpp
@@ -95,7 +95,7 @@ std::string ZVector::GetBodySourceCode() const
 std::string ZVector::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 {
 	if (parent != nullptr)
-		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::None, GetRawDataSize(),
+		parent->AddDeclaration(rawDataIndex, DeclarationAlignment::Align4, GetRawDataSize(),
 		                       GetSourceTypeName(), GetName(), GetBodySourceCode());
 
 	return "";


### PR DESCRIPTION
- Remove `DeclarationPadding`.
  - It just made some random `pad` variables which doesn't seem to be needed to match
- Remove `DeclarationAlignment::None`.
  - There's nothing that can be aligned to something smaller than 4 bytes.
  - It was behaving the same as `DeclarationAlignment::Align4`, so it was redundant.
  - Addresses #110 
- Fix some memory leaks in the `AddDeclaration` family of methods.
  - Related issue: #52 