### PR TITLE
Improve makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,4 +336,4 @@ lib/libgfxd/libgfxd.a
 ExporterTest/ExporterTest.a
 ZAPDUtils/ZAPDUtils.a
 .vscode/
-ZAPD/BuildInfo.h
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -337,3 +337,4 @@ ExporterTest/ExporterTest.a
 ZAPDUtils/ZAPDUtils.a
 .vscode/
 build/
+ZAPDUtils/build/

--- a/ExporterTest/CollisionExporter.cpp
+++ b/ExporterTest/CollisionExporter.cpp
@@ -1,6 +1,6 @@
 #include "CollisionExporter.h"
 
-void ExporterExample_Collision::Save(ZResource* res, fs::path outPath, BinaryWriter* writer)
+void ExporterExample_Collision::Save(ZResource* res, [[maybe_unused]]fs::path outPath, BinaryWriter* writer)
 {
 	ZCollisionHeader* col = (ZCollisionHeader*)res;
 

--- a/ExporterTest/Main.cpp
+++ b/ExporterTest/Main.cpp
@@ -20,7 +20,7 @@ static void ExporterParseFileMode(std::string buildMode, ZFileMode& fileMode)
 		fileMode = (ZFileMode)ExporterFileMode::ModeExample3;
 }
 
-static void ExporterParseArgs(int argc, char* argv[], int& i)
+static void ExporterParseArgs([[maybe_unused]]int argc, char* argv[], int& i)
 {
 	std::string arg = argv[i];
 

--- a/ExporterTest/Makefile
+++ b/ExporterTest/Makefile
@@ -1,18 +1,17 @@
-CXXFLAGS = -Wall -O2 -g -std=c++17
+CXXFLAGS ?= -Wall -Wextra -O2 -g -std=c++17
 OBJ = Main.o TextureExporter.o RoomExporter.o CollisionExporter.o
 LIB = ExporterTest.a
 
-CPPFLAGS-$(MT) += -DCONFIG_MT
-CPPFLAGS += $(CPPFLAGS-y)
 
-.PHONY: all
 all: $(LIB)
 
-.PHONY: clean
 clean:
 	rm -f $(OBJ) $(LIB)
 
-.INTERMEDIATE: $(OBJ)
+format:
+	clang-format-11 -i $(CPP_FILES) $(H_FILES)
+
+.PHONY: all clean format
 
 $(OBJ): Main.cpp TextureExporter.cpp RoomExporter.cpp CollisionExporter.cpp
 
@@ -20,4 +19,4 @@ $(LIB): $(OBJ)
 	$(AR) rcs $@ $^
 
 %.o: %.cpp
-	$(COMPILE.c) $(OUTPUT_OPTION) $(CXXFLAGS) $< -I ./ -I ../ZAPD -I ../ZAPDUtils -I ../lib/tinyxml2
+	$(CXX) $(OUTPUT_OPTION) $(CXXFLAGS) -c $< -I ./ -I ../ZAPD -I ../ZAPDUtils -I ../lib/tinyxml2

--- a/ExporterTest/Makefile
+++ b/ExporterTest/Makefile
@@ -1,3 +1,4 @@
+# Only used for standalone compilation, usually inherits these from the main makefile
 CXXFLAGS ?= -Wall -Wextra -O2 -g -std=c++17
 
 SRC_DIRS  := $(shell find -type d -not -path "*build*")
@@ -21,7 +22,7 @@ format:
 .PHONY: all clean format
 
 build/%.o: %.cpp
-	$(CXX)  $(CXXFLAGS) -I ./ -I ../ZAPD -I ../ZAPDUtils -I ../lib/tinyxml2 -c $< -c $(OUTPUT_OPTION)
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) -I ./ -I ../ZAPD -I ../ZAPDUtils -I ../lib/tinyxml2 -c $(OUTPUT_OPTION) $<
 
 $(LIB): $(O_FILES)
 	$(AR) rcs $@ $^

--- a/ExporterTest/Makefile
+++ b/ExporterTest/Makefile
@@ -1,22 +1,27 @@
 CXXFLAGS ?= -Wall -Wextra -O2 -g -std=c++17
-OBJ = Main.o TextureExporter.o RoomExporter.o CollisionExporter.o
-LIB = ExporterTest.a
 
+SRC_DIRS  := $(shell find -type d -not -path "*build*")
+CPP_FILES := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.cpp))
+H_FILES   := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.h))
+
+O_FILES   := $(foreach f,$(CPP_FILES:.cpp=.o),build/$f)
+LIB       := ExporterTest.a
+
+# create build directories
+$(shell mkdir -p $(foreach dir,$(SRC_DIRS),build/$(dir)))
 
 all: $(LIB)
 
 clean:
-	rm -f $(OBJ) $(LIB)
+	rm -rf build $(LIB)
 
 format:
 	clang-format-11 -i $(CPP_FILES) $(H_FILES)
 
 .PHONY: all clean format
 
-$(OBJ): Main.cpp TextureExporter.cpp RoomExporter.cpp CollisionExporter.cpp
+build/%.o: %.cpp
+	$(CXX)  $(CXXFLAGS) -I ./ -I ../ZAPD -I ../ZAPDUtils -I ../lib/tinyxml2 -c $< -c $(OUTPUT_OPTION)
 
-$(LIB): $(OBJ)
+$(LIB): $(O_FILES)
 	$(AR) rcs $@ $^
-
-%.o: %.cpp
-	$(CXX) $(OUTPUT_OPTION) $(CXXFLAGS) -c $< -I ./ -I ../ZAPD -I ../ZAPDUtils -I ../lib/tinyxml2

--- a/ExporterTest/TextureExporter.cpp
+++ b/ExporterTest/TextureExporter.cpp
@@ -1,7 +1,7 @@
 #include "TextureExporter.h"
 #include "../ZAPD/ZFile.h"
 
-void ExporterExample_Texture::Save(ZResource* res, fs::path outPath, BinaryWriter* writer)
+void ExporterExample_Texture::Save(ZResource* res, [[maybe_unused]]fs::path outPath, BinaryWriter* writer)
 {
 	ZTexture* tex = (ZTexture*)res;
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OPTIMIZATION_ON ?= 1
 ASAN ?= 0
 DEPRECATION_ON ?= 1
 DEBUG ?= 0
-COPYCHECK_ARGS ?= 
+COPYCHECK_ARGS ?=
 # Set LLD=1 to use ld.lld as the linker
 LLD ?= 0
 
@@ -36,7 +36,7 @@ ifneq ($(DEPRECATION_ON),0)
 endif
 # CXXFLAGS += -DTEXTURE_DEBUG
 
-LDFLAGS := -lm -ldl -lpng 
+LDFLAGS := -lm -ldl -lpng
 
 ifneq ($(LLD),0)
   LDFLAGS += -fuse-ld=lld
@@ -66,7 +66,7 @@ all: ZAPD.out copycheck
 
 build/ZAPD/BuildInfo.o:
 	python3 ZAPD/genbuildinfo.py $(COPYCHECK_ARGS)
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(INC) -c build/ZAPD/BuildInfo.cpp -o build/ZAPD/BuildInfo.o
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(INC) -c $(OUTPUT_OPTION) build/ZAPD/BuildInfo.cpp
 
 copycheck: ZAPD.out
 	python3 copycheck.py
@@ -87,7 +87,7 @@ format:
 .PHONY: all build/ZAPD/BuildInfo.o copycheck clean rebuild format
 
 build/%.o: %.cpp
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(INC) -c $< $(OUTPUT_OPTION)
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(INC) -c $(OUTPUT_OPTION) $<
 
 
 # Submakes
@@ -105,4 +105,4 @@ ZAPDUtils:
 
 # Linking
 ZAPD.out: $(O_FILES) lib/libgfxd/libgfxd.a ExporterTest ZAPDUtils
-	$(CXX) $(O_FILES) lib/libgfxd/libgfxd.a ZAPDUtils/ZAPDUtils.a -Wl,--whole-archive ExporterTest/ExporterTest.a -Wl,--no-whole-archive -o $@ $(LDFLAGS)
+	$(CXX) $(O_FILES) lib/libgfxd/libgfxd.a ZAPDUtils/ZAPDUtils.a -Wl,--whole-archive ExporterTest/ExporterTest.a -Wl,--no-whole-archive $(LDFLAGS) $(OUTPUT_OPTION)

--- a/Makefile
+++ b/Makefile
@@ -87,10 +87,7 @@ format:
 .PHONY: all build/ZAPD/BuildInfo.o copycheck clean rebuild format
 
 build/%.o: %.cpp
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(INC) -c $< -o $@
-
-build/ZAPD/Main.o: ZAPD/Main.cpp build/ZAPD/BuildInfo.o
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(INC) -c $< -o $@
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(INC) -c $< $(OUTPUT_OPTION)
 
 
 # Submakes

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You can configure a bit your ZAPD build with the following options:
   - Debugging symbols enabled (`-g3`). They are disabled by default.
   - `OPTIMIZATION_ON=0`: Disables optimizations (`-O0`).
   - `DEPRECATION_OFF=1`: Disables deprecation warnings.
+- `LLD=1`: builds with the LLVM linker `ld.lld` instead of the system default.
 
 As an example, if you want to build ZAPD with optimizations disabled and use the address sanitizer, you could use the following command:
 

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -1,7 +1,6 @@
 #include <Utils/Directory.h>
 #include <Utils/File.h>
 #include <Utils/Path.h>
-#include "BuildInfo.h"
 #include "Globals.h"
 #include "Overlays/ZOverlay.h"
 #include "ZAnimation.h"
@@ -24,6 +23,8 @@
 #include "tinyxml2.h"
 
 using namespace tinyxml2;
+
+extern const char gBuildHash[];
 
 bool Parse(const fs::path& xmlFilePath, const fs::path& basePath, ZFileMode fileMode);
 

--- a/ZAPD/ZRoom/Commands/SetRoomList.h
+++ b/ZAPD/ZRoom/Commands/SetRoomList.h
@@ -23,7 +23,7 @@ public:
 	void ParseRawData() override;
 
 	void DeclareVar(const std::string& prefix, const std::string body);
-	std::string GetBodySourceCode() const;
+	std::string GetBodySourceCode() const override;
 	std::string GetSourceOutputCode(const std::string& prefix) override;
 
 	std::string GetSourceTypeName() const override;

--- a/ZAPD/ZRoom/ZRoom.h
+++ b/ZAPD/ZRoom/ZRoom.h
@@ -34,7 +34,7 @@ public:
 	void DeclareReferencesLate(const std::string& prefix) override;
 
 	void DeclareVar(const std::string& prefix, const std::string body);
-	std::string GetBodySourceCode() const;
+	std::string GetBodySourceCode() const override;
 
 	std::string GetDefaultName(const std::string& prefix) const;
 	size_t GetDeclarationSizeFromNeighbor(uint32_t declarationAddress);

--- a/ZAPD/genbuildinfo.py
+++ b/ZAPD/genbuildinfo.py
@@ -9,10 +9,10 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--devel", action="store_true")
 args = parser.parse_args()
 
-with open("ZAPD/BuildInfo.h", "w+") as buildFile:
+with open("build/ZAPD/BuildInfo.cpp", "w+") as buildFile:
     label = subprocess.check_output(["git", "describe", "--always"]).strip().decode("utf-8")
     now = datetime.now()
     if args.devel:
         label += " ~ Development version"
-    buildFile.write("const char gBuildHash[] = \"" + label + "\";\n")
-    #buildFile.write("const char gBuildDate[] = \"" + now.strftime("%Y-%m-%d %H:%M:%S") + "\";\n")
+    buildFile.write("extern const char gBuildHash[] = \"" + label + "\";\n")
+    #buildFile.write("extern const char gBuildDate[] = \"" + now.strftime("%Y-%m-%d %H:%M:%S") + "\";\n")

--- a/ZAPDUtils/Makefile
+++ b/ZAPDUtils/Makefile
@@ -1,11 +1,11 @@
 CXXFLAGS ?= -Wall -Wextra -O2 -g -std=c++17
 
-SRC_DIRS := $(shell find -type d -not -path "*build*")
+SRC_DIRS  := $(shell find -type d -not -path "*build*")
 CPP_FILES := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.cpp))
-H_FILES := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.h))
+H_FILES   := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.h))
 
 O_FILES   := $(foreach f,$(CPP_FILES:.cpp=.o),build/$f)
-LIB = ZAPDUtils.a
+LIB       := ZAPDUtils.a
 
 # create build directories
 $(shell mkdir -p $(foreach dir,$(SRC_DIRS),build/$(dir)))
@@ -20,10 +20,10 @@ format:
 
 .PHONY: all clean format
 
-$(O_FILES): $(CPP_FILES)
+# $(O_FILES): $(CPP_FILES)
+
+build/%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $< $(OUTPUT_OPTION) 
 
 $(LIB): $(O_FILES)
 	$(AR) rcs $@ $^
-
-build/%.o: %.cpp
-	$(CXX) -c $(OUTPUT_OPTION) $(CXXFLAGS) $<

--- a/ZAPDUtils/Makefile
+++ b/ZAPDUtils/Makefile
@@ -1,23 +1,29 @@
-CXXFLAGS = -Wall -O2 -g -std=c++17
-OBJ = Utils/BinaryWriter.o Utils/MemoryStream.o
+CXXFLAGS ?= -Wall -Wextra -O2 -g -std=c++17
+
+SRC_DIRS := $(shell find -type d -not -path "*build*")
+CPP_FILES := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.cpp))
+H_FILES := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.h))
+
+O_FILES   := $(foreach f,$(CPP_FILES:.cpp=.o),build/$f)
 LIB = ZAPDUtils.a
 
-CPPFLAGS-$(MT) += -DCONFIG_MT
-CPPFLAGS += $(CPPFLAGS-y)
+# create build directories
+$(shell mkdir -p $(foreach dir,$(SRC_DIRS),build/$(dir)))
 
-.PHONY: all
 all: $(LIB)
 
-.PHONY: clean
 clean:
-	rm -f $(OBJ) $(LIB)
+	rm -rf build $(LIB)
 
-.INTERMEDIATE: $(OBJ)
+format:
+	clang-format-11 -i $(CPP_FILES) $(H_FILES)
 
-$(OBJ): Utils/BinaryReader.cpp Utils/BinaryWriter.cpp Utils/MemoryStream.cpp
+.PHONY: all clean format
 
-$(LIB): $(OBJ)
+$(O_FILES): $(CPP_FILES)
+
+$(LIB): $(O_FILES)
 	$(AR) rcs $@ $^
 
-%.o: %.cpp
-	$(COMPILE.c) $(OUTPUT_OPTION) $(CXXFLAGS) $< -I ./ -I ../ZAPD -I ../lib/tinyxml2
+build/%.o: %.cpp
+	$(CXX) -c $(OUTPUT_OPTION) $(CXXFLAGS) $<

--- a/ZAPDUtils/Makefile
+++ b/ZAPDUtils/Makefile
@@ -1,3 +1,4 @@
+# Only used for standalone compilation, usually inherits these from the main makefile
 CXXFLAGS ?= -Wall -Wextra -O2 -g -std=c++17
 
 SRC_DIRS  := $(shell find -type d -not -path "*build*")
@@ -20,10 +21,8 @@ format:
 
 .PHONY: all clean format
 
-# $(O_FILES): $(CPP_FILES)
-
 build/%.o: %.cpp
-	$(CXX) $(CXXFLAGS) -c $< $(OUTPUT_OPTION) 
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) -c $(OUTPUT_OPTION) $<
 
 $(LIB): $(O_FILES)
 	$(AR) rcs $@ $^

--- a/ZAPDUtils/Utils/BinaryReader.cpp
+++ b/ZAPDUtils/Utils/BinaryReader.cpp
@@ -1,7 +1,6 @@
-#pragma once
-
 #include "BinaryReader.h"
 #include "Stream.h"
+#include <math.h>
 
 BinaryReader::BinaryReader(Stream* nStream)
 {
@@ -23,7 +22,7 @@ uint32_t BinaryReader::GetBaseAddress()
 	return stream->GetBaseAddress();
 }
 
-void BinaryReader::Read(char* buffer, int32_t length)
+void BinaryReader::Read([[maybe_unused]]char* buffer, int32_t length)
 {
 	stream->Read(length);
 }
@@ -45,7 +44,7 @@ uint8_t BinaryReader::ReadUByte()
 
 int16_t BinaryReader::ReadInt16()
 {
-	int16_t result;
+	int16_t result = 0;
 
 	stream->Read((char*)&result, sizeof(int16_t));
 	return result;
@@ -53,7 +52,7 @@ int16_t BinaryReader::ReadInt16()
 
 int32_t BinaryReader::ReadInt32()
 {
-	int32_t result;
+	int32_t result = 0;
 
 	stream->Read((char*)&result, sizeof(int32_t));
 	return result;
@@ -61,7 +60,7 @@ int32_t BinaryReader::ReadInt32()
 
 uint16_t BinaryReader::ReadUInt16()
 {
-	uint16_t result;
+	uint16_t result = 0;
 
 	stream->Read((char*)&result, sizeof(uint16_t));
 	return result;
@@ -69,7 +68,7 @@ uint16_t BinaryReader::ReadUInt16()
 
 uint32_t BinaryReader::ReadUInt32()
 {
-	uint32_t result;
+	uint32_t result = 0;
 
 	stream->Read((char*)&result, sizeof(uint32_t));
 	return result;
@@ -77,7 +76,7 @@ uint32_t BinaryReader::ReadUInt32()
 
 uint64_t BinaryReader::ReadUInt64()
 {
-	uint64_t result;
+	uint64_t result = 0;
 
 	stream->Read((char*)&result, sizeof(uint64_t));
 	return result;
@@ -85,17 +84,24 @@ uint64_t BinaryReader::ReadUInt64()
 
 float BinaryReader::ReadSingle()
 {
-	float result;
+	float result = NAN;
 
 	stream->Read((char*)&result, sizeof(float));
+
+	if (isnan(result))
+		throw std::runtime_error("BinaryReader::ReadSingle(): Error reading stream");
+
 	return result;
 }
 
 double BinaryReader::ReadDouble()
 {
-	double result;
+	double result = NAN;
 
 	stream->Read((char*)&result, sizeof(double));
+	if (isnan(result))
+		throw std::runtime_error("BinaryReader::ReadDouble(): Error reading stream");
+
 	return result;
 }
 

--- a/ZAPDUtils/Utils/BinaryReader.cpp
+++ b/ZAPDUtils/Utils/BinaryReader.cpp
@@ -1,6 +1,7 @@
 #include "BinaryReader.h"
 #include "Stream.h"
 #include <math.h>
+#include <stdexcept>
 
 BinaryReader::BinaryReader(Stream* nStream)
 {

--- a/ZAPDUtils/Utils/Stream.h
+++ b/ZAPDUtils/Utils/Stream.h
@@ -20,6 +20,7 @@ enum class Endianess
 class Stream
 {
 public:
+	virtual ~Stream() = default;
 	virtual uint64_t GetLength() = 0;
 	uint64_t GetBaseAddress() { return baseAddress; }
 


### PR DESCRIPTION
Made sigificant improvements to the project's three makefiles:
- Move to using build folders to keep everything better-organised.
- Use automatic searching to find files to build rather than mentioning individuals that would need to change if things are moved or extra files are added.
- Integrate the submakes correctly in `clean` and give them their own `.PHONY` rules so that they are always run and are responsible for their own files.
- `export` variables from the main makefile to the submakes, allowing things like the optimisation flags and warnings to be consistent.
- Add an option for using `ld.lld` easily if the user desires, since `LDFLAGS` can't be practically edited from a terminal invocation.
- Remove unused headers.

Also fixed a number of warnings that were missed since -Wextra was not being passed to submakes before, and made the buildinfo into a cpp file, since it contains data.,