### PR TITLE
Error if RangeStart is after RangeEnd

### DIFF
--- a/ZAPD/BuildInfo.h
+++ b/ZAPD/BuildInfo.h
@@ -1,1 +1,0 @@
-const char gBuildHash[] = "e02e151";

--- a/ZAPD/BuildInfo.h
+++ b/ZAPD/BuildInfo.h
@@ -1,0 +1,1 @@
+const char gBuildHash[] = "e02e151";

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -109,6 +109,9 @@ void ZFile::ParseXML(ZFileMode mode, XMLElement* reader, std::string filename,
 	if (reader->Attribute("RangeEnd") != nullptr)
 		rangeEnd = StringHelper::StrToL(reader->Attribute("RangeEnd"), 16);
 
+	if( rangeStart > rangeEnd )
+		throw std::runtime_error("Error: RangeStart must be before than RangeEnd.");
+
 	// Commented until ZArray doesn't use a ZFile to parse it's contents anymore.
 	/*
 	if (reader->Attribute("Segment") == nullptr)


### PR DESCRIPTION
Currently ZAPD will just extract nothing and create an empty source file if the `RangeStart` value is greater than `RangeEnd`.