### PR TITLE
Fix ZNormalAnimation extraction from overlays

### DIFF
--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -78,12 +78,12 @@ std::string ZNormalAnimation::GetSourceOutputCode([[maybe_unused]] const std::st
 				indicesStr += "\n";
 		}
 
-		parent->AddDeclarationArray(rotationValuesSeg, DeclarationAlignment::Align16,
+		parent->AddDeclarationArray(rotationValuesOffset, DeclarationAlignment::Align16,
 		                            rotationValues.size() * 2, "static s16",
 		                            StringHelper::Sprintf("%sFrameData", defaultPrefix.c_str()),
 		                            rotationValues.size(), valuesStr);
 
-		parent->AddDeclarationArray(rotationIndicesSeg, DeclarationAlignment::Align16,
+		parent->AddDeclarationArray(rotationIndicesOffset, DeclarationAlignment::Align16,
 		                            rotationIndices.size() * 6, "static JointIndex",
 		                            StringHelper::Sprintf("%sJointIndices", defaultPrefix.c_str()),
 		                            rotationIndices.size(), indicesStr);
@@ -108,23 +108,26 @@ void ZNormalAnimation::ParseRawData()
 
 	const uint8_t* data = parent->GetRawData().data();
 
-	rotationValuesSeg = BitConverter::ToInt32BE(data, rawDataIndex + 4) & 0x00FFFFFF;
-	rotationIndicesSeg = BitConverter::ToInt32BE(data, rawDataIndex + 8) & 0x00FFFFFF;
+	rotationValuesSeg = BitConverter::ToInt32BE(data, rawDataIndex + 4);
+	rotationIndicesSeg = BitConverter::ToInt32BE(data, rawDataIndex + 8);
 	limit = BitConverter::ToInt16BE(data, rawDataIndex + 12);
 
-	uint32_t currentPtr = rotationValuesSeg;
+	rotationValuesOffset = Seg2Filespace(rotationValuesSeg, parent->baseAddress);
+	rotationIndicesOffset = Seg2Filespace(rotationIndicesSeg, parent->baseAddress);
+
+	uint32_t currentPtr = rotationValuesOffset;
 
 	// Read the Rotation Values
-	for (uint32_t i = 0; i < ((rotationIndicesSeg - rotationValuesSeg) / 2); i++)
+	for (uint32_t i = 0; i < ((rotationIndicesOffset - rotationValuesOffset) / 2); i++)
 	{
 		rotationValues.push_back(BitConverter::ToInt16BE(data, currentPtr));
 		currentPtr += 2;
 	}
 
-	currentPtr = rotationIndicesSeg;
+	currentPtr = rotationIndicesOffset;
 
 	// Read the Rotation Indices
-	for (uint32_t i = 0; i < ((rawDataIndex - rotationIndicesSeg) / 6); i++)
+	for (uint32_t i = 0; i < ((rawDataIndex - rotationIndicesOffset) / 6); i++)
 	{
 		rotationIndices.push_back(RotationIndex(BitConverter::ToInt16BE(data, currentPtr),
 		                                        BitConverter::ToInt16BE(data, currentPtr + 2),

--- a/ZAPD/ZAnimation.h
+++ b/ZAPD/ZAnimation.h
@@ -35,8 +35,10 @@ class ZNormalAnimation : public ZAnimation
 public:
 	std::vector<uint16_t> rotationValues;
 	std::vector<RotationIndex> rotationIndices;
-	uint32_t rotationValuesSeg;
-	uint32_t rotationIndicesSeg;
+	segptr_t rotationValuesSeg;
+	segptr_t rotationIndicesSeg;
+	uint32_t rotationValuesOffset;
+	uint32_t rotationIndicesOffset;
 	int16_t limit;
 
 	ZNormalAnimation(ZFile* nParent);


### PR DESCRIPTION
Currently ZAPD can't extract normal animations from overlays because of an oversight.

To replicate: Extract using this XML in the OoT repo
```xml
<Root>
    <File Name="ovl_En_Sth" BaseAddress="0x80B07540" RangeStart="0xEF0" Segment="128">
        <Animation Name="sChildDanceAnim" Offset="0x3620"/>
    </File>
</Root>
```