### PR TITLE
Add automatic clang and ld.lld support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ ASAN ?= 0
 DEPRECATION_ON ?= 1
 DEBUG ?= 0
 COPYCHECK_ARGS ?=
+LLD ?= 0
 
 # Use clang++ if available, else use g++
 ifeq ($(shell command -v clang++ >/dev/null 2>&1; echo $$?),0)

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,14 @@ ASAN ?= 0
 DEPRECATION_ON ?= 1
 DEBUG ?= 0
 COPYCHECK_ARGS ?=
-# Set LLD=1 to use ld.lld as the linker
-LLD ?= 0
 
-CXX := g++
+# Use clang++ if available, else use g++
+ifeq ($(shell command -v clang++ >/dev/null 2>&1; echo $$?),0)
+  CXX := clang++
+else
+  CXX := g++
+endif
+
 INC := -I ZAPD -I lib/elfio -I lib/libgfxd -I lib/tinyxml2 -I ZAPDUtils
 CXXFLAGS := -fpic -std=c++17 -Wall -Wextra -fno-omit-frame-pointer
 OPTFLAGS :=
@@ -37,6 +41,11 @@ endif
 # CXXFLAGS += -DTEXTURE_DEBUG
 
 LDFLAGS := -lm -ldl -lpng
+
+# Use LLD if available. Set LLD=0 to not use it
+ifeq ($(shell command -v ld.lld >/dev/null 2>&1; echo $$?),0)
+  LLD := 1
+endif
 
 ifneq ($(LLD),0)
   LDFLAGS += -fuse-ld=lld


### PR DESCRIPTION
Added functions to automatically set `CXX` based on whether `clang++` is available, and `LDFLAGS` if `ld.lld` is. Both options can be overridden if desired: `CXX` in the usual way, `LDFLAGS` using `LLD=0`.