### PR TITLE
ZPlayerAnimationData extraction

### DIFF
--- a/ZAPD/ZPlayerAnimationData.cpp
+++ b/ZAPD/ZPlayerAnimationData.cpp
@@ -1,0 +1,88 @@
+#include "ZPlayerAnimationData.h"
+
+#include "Utils/BitConverter.h"
+#include "Utils/StringHelper.h"
+#include "ZFile.h"
+
+REGISTER_ZFILENODE(PlayerAnimationData, ZPlayerAnimationData);
+
+ZPlayerAnimationData::ZPlayerAnimationData(ZFile* nParent) : ZResource(nParent)
+{
+	RegisterRequiredAttribute("FrameCount");
+}
+
+void ZPlayerAnimationData::ParseXML(tinyxml2::XMLElement* reader) {
+	ZResource::ParseXML(reader);
+
+	std::string& frameCountXml = registeredAttributes.at("FrameCount").value;
+
+    frameCount = StringHelper::StrToL(frameCountXml);
+}
+
+void ZPlayerAnimationData::ParseRawData() {
+	ZResource::ParseRawData();
+
+	const auto& rawData = parent->GetRawData();
+
+    size_t totalSize = GetRawDataSize();
+    // Divided by 2 because each value is an s16
+    limbRotData.reserve(totalSize * frameCount / 2);
+
+    for (size_t i = 0; i < totalSize; i+=2) {
+        limbRotData.push_back(BitConverter::ToInt16BE(rawData, rawDataIndex + i));
+    }
+}
+
+Declaration* ZPlayerAnimationData::DeclareVar(const std::string& prefix, const std::string& bodyStr) {
+
+	std::string auxName = name;
+
+	if (auxName == "")
+		auxName = GetDefaultName(prefix);
+
+	Declaration* decl =
+		parent->AddDeclarationArray(rawDataIndex, GetDeclarationAlignment(), GetRawDataSize(),
+	                                GetSourceTypeName(), name, limbRotData.size(), bodyStr);
+	decl->staticConf = staticConf;
+	return decl;
+}
+
+std::string ZPlayerAnimationData::GetBodySourceCode() const {
+
+	std::string declaration = "";
+
+	size_t index = 0;
+	for (const auto& entry : limbRotData)
+	{
+        if (index % 8 == 0) {
+            declaration += "\t";
+        }
+
+		declaration += StringHelper::Sprintf("% 6i, ", entry);
+
+        if ((index + 1) % 8 == 0) {
+			declaration += "\n";
+        }
+
+		index++;
+	}
+
+	return declaration;
+}
+
+std::string ZPlayerAnimationData::GetDefaultName(const std::string& prefix) const {
+	return StringHelper::Sprintf("%sPlayerAnimationData_%06X", prefix.c_str(), rawDataIndex);
+}
+
+std::string ZPlayerAnimationData::GetSourceTypeName() const {
+    return "s16";
+}
+
+ZResourceType ZPlayerAnimationData::GetResourceType() const {
+    return ZResourceType::PlayerAnimationData;
+}
+
+size_t ZPlayerAnimationData::GetRawDataSize() const {
+    // (sizeof(Vec3s) * limbCount + 2) * frameCount
+    return (6 * 22 + 2) * frameCount;
+}

--- a/ZAPD/ZPlayerAnimationData.cpp
+++ b/ZAPD/ZPlayerAnimationData.cpp
@@ -11,30 +11,33 @@ ZPlayerAnimationData::ZPlayerAnimationData(ZFile* nParent) : ZResource(nParent)
 	RegisterRequiredAttribute("FrameCount");
 }
 
-void ZPlayerAnimationData::ParseXML(tinyxml2::XMLElement* reader) {
+void ZPlayerAnimationData::ParseXML(tinyxml2::XMLElement* reader)
+{
 	ZResource::ParseXML(reader);
 
 	std::string& frameCountXml = registeredAttributes.at("FrameCount").value;
 
-    frameCount = StringHelper::StrToL(frameCountXml);
+	frameCount = StringHelper::StrToL(frameCountXml);
 }
 
-void ZPlayerAnimationData::ParseRawData() {
+void ZPlayerAnimationData::ParseRawData()
+{
 	ZResource::ParseRawData();
 
 	const auto& rawData = parent->GetRawData();
 
-    size_t totalSize = GetRawDataSize();
-    // Divided by 2 because each value is an s16
-    limbRotData.reserve(totalSize * frameCount / 2);
+	size_t totalSize = GetRawDataSize();
+	// Divided by 2 because each value is an s16
+	limbRotData.reserve(totalSize * frameCount / 2);
 
-    for (size_t i = 0; i < totalSize; i+=2) {
-        limbRotData.push_back(BitConverter::ToUInt16BE(rawData, rawDataIndex + i));
-    }
+	for (size_t i = 0; i < totalSize; i += 2)
+	{
+		limbRotData.push_back(BitConverter::ToUInt16BE(rawData, rawDataIndex + i));
+	}
 }
 
-Declaration* ZPlayerAnimationData::DeclareVar(const std::string& prefix, const std::string& bodyStr) {
-
+Declaration* ZPlayerAnimationData::DeclareVar(const std::string& prefix, const std::string& bodyStr)
+{
 	std::string auxName = name;
 
 	if (auxName == "")
@@ -47,22 +50,24 @@ Declaration* ZPlayerAnimationData::DeclareVar(const std::string& prefix, const s
 	return decl;
 }
 
-std::string ZPlayerAnimationData::GetBodySourceCode() const {
-
+std::string ZPlayerAnimationData::GetBodySourceCode() const
+{
 	std::string declaration = "";
 
 	size_t index = 0;
 	for (const auto& entry : limbRotData)
 	{
-        if (index % 8 == 0) {
-            declaration += "\t";
-        }
+		if (index % 8 == 0)
+		{
+			declaration += "\t";
+		}
 
-        declaration += StringHelper::Sprintf("0x%04X, ", entry);
+		declaration += StringHelper::Sprintf("0x%04X, ", entry);
 
-        if ((index + 1) % 8 == 0) {
+		if ((index + 1) % 8 == 0)
+		{
 			declaration += "\n";
-        }
+		}
 
 		index++;
 	}
@@ -70,19 +75,23 @@ std::string ZPlayerAnimationData::GetBodySourceCode() const {
 	return declaration;
 }
 
-std::string ZPlayerAnimationData::GetDefaultName(const std::string& prefix) const {
+std::string ZPlayerAnimationData::GetDefaultName(const std::string& prefix) const
+{
 	return StringHelper::Sprintf("%sPlayerAnimationData_%06X", prefix.c_str(), rawDataIndex);
 }
 
-std::string ZPlayerAnimationData::GetSourceTypeName() const {
-    return "s16";
+std::string ZPlayerAnimationData::GetSourceTypeName() const
+{
+	return "s16";
 }
 
-ZResourceType ZPlayerAnimationData::GetResourceType() const {
-    return ZResourceType::PlayerAnimationData;
+ZResourceType ZPlayerAnimationData::GetResourceType() const
+{
+	return ZResourceType::PlayerAnimationData;
 }
 
-size_t ZPlayerAnimationData::GetRawDataSize() const {
-    // (sizeof(Vec3s) * limbCount + 2) * frameCount
-    return (6 * 22 + 2) * frameCount;
+size_t ZPlayerAnimationData::GetRawDataSize() const
+{
+	// (sizeof(Vec3s) * limbCount + 2) * frameCount
+	return (6 * 22 + 2) * frameCount;
 }

--- a/ZAPD/ZPlayerAnimationData.cpp
+++ b/ZAPD/ZPlayerAnimationData.cpp
@@ -29,7 +29,7 @@ void ZPlayerAnimationData::ParseRawData() {
     limbRotData.reserve(totalSize * frameCount / 2);
 
     for (size_t i = 0; i < totalSize; i+=2) {
-        limbRotData.push_back(BitConverter::ToInt16BE(rawData, rawDataIndex + i));
+        limbRotData.push_back(BitConverter::ToUInt16BE(rawData, rawDataIndex + i));
     }
 }
 
@@ -58,7 +58,7 @@ std::string ZPlayerAnimationData::GetBodySourceCode() const {
             declaration += "\t";
         }
 
-		declaration += StringHelper::Sprintf("% 6i, ", entry);
+        declaration += StringHelper::Sprintf("0x%04X, ", entry);
 
         if ((index + 1) % 8 == 0) {
 			declaration += "\n";

--- a/ZAPD/ZPlayerAnimationData.h
+++ b/ZAPD/ZPlayerAnimationData.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "ZResource.h"
+
+class ZPlayerAnimationData : public ZResource {
+public:
+    int16_t frameCount = 0;
+    std::vector<int16_t> limbRotData;
+
+    ZPlayerAnimationData(ZFile* nParent);
+
+	void ParseXML(tinyxml2::XMLElement* reader) override;
+	void ParseRawData() override;
+
+	Declaration* DeclareVar(const std::string& prefix, const std::string& bodyStr) override;
+
+    std::string GetBodySourceCode() const override;
+    std::string GetDefaultName(const std::string& prefix) const override;
+
+    std::string GetSourceTypeName() const override;
+    ZResourceType GetResourceType() const override;
+
+    size_t GetRawDataSize() const override;
+};

--- a/ZAPD/ZPlayerAnimationData.h
+++ b/ZAPD/ZPlayerAnimationData.h
@@ -8,7 +8,7 @@
 class ZPlayerAnimationData : public ZResource {
 public:
     int16_t frameCount = 0;
-    std::vector<int16_t> limbRotData;
+    std::vector<uint16_t> limbRotData;
 
     ZPlayerAnimationData(ZFile* nParent);
 

--- a/ZAPD/ZPlayerAnimationData.h
+++ b/ZAPD/ZPlayerAnimationData.h
@@ -5,23 +5,24 @@
 
 #include "ZResource.h"
 
-class ZPlayerAnimationData : public ZResource {
+class ZPlayerAnimationData : public ZResource
+{
 public:
-    int16_t frameCount = 0;
-    std::vector<uint16_t> limbRotData;
+	int16_t frameCount = 0;
+	std::vector<uint16_t> limbRotData;
 
-    ZPlayerAnimationData(ZFile* nParent);
+	ZPlayerAnimationData(ZFile* nParent);
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;
 	void ParseRawData() override;
 
 	Declaration* DeclareVar(const std::string& prefix, const std::string& bodyStr) override;
 
-    std::string GetBodySourceCode() const override;
-    std::string GetDefaultName(const std::string& prefix) const override;
+	std::string GetBodySourceCode() const override;
+	std::string GetDefaultName(const std::string& prefix) const override;
 
-    std::string GetSourceTypeName() const override;
-    ZResourceType GetResourceType() const override;
+	std::string GetSourceTypeName() const override;
+	ZResourceType GetResourceType() const override;
 
-    size_t GetRawDataSize() const override;
+	size_t GetRawDataSize() const override;
 };

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -38,6 +38,7 @@ enum class ZResourceType
 	LimbTable,
 	Mtx,
 	Path,
+	PlayerAnimationData,
 	Room,
 	RoomCommand,
 	Scalar,

--- a/docs/zapd_extraction_xml_reference.md
+++ b/docs/zapd_extraction_xml_reference.md
@@ -32,6 +32,7 @@ This document aims to be a small reference of how to create a compatible xml fil
     - [Cutscene](#cutscene)
     - [Array](#array)
     - [Path](#path)
+    - [PlayerAnimationData](#playeranimationdata)
 
 ## Basic XML
 
@@ -215,7 +216,6 @@ A.k.a. Display list, or Gfx.
 ### TextureAnimation
 
 A data type exclusive to Majora's Mask, that has scrolling, color changing, and texture changing capabilities. Declaring the main array will generate everything else; textures for the TextureCycle type must be declared manually in the XML to use symbols. (If it does reference any undeclared textures, ZAPD will warn and give the their offsets.)
-
 
 ```xml
 <TextureAnimation Name="gRosaSistersTexAnim" Offset="0xD768"/>
@@ -597,5 +597,22 @@ Currently, only [`Scalar`](#scalar), [`Vector`](#vector) and [`Vtx`](#vtx) suppo
 
   - `Name`: Required. Suxffixed by `Path`.
   - `NumPaths`: Optional. The amount of paths contained in the array. It must be a positive integer.
+
+-------------------------
+
+### PlayerAnimationData
+
+Allows the extraction of the specific data of the player animations which are found in the `link_animetion` file.
+
+- Example:
+
+```xml
+<PlayerAnimationData Name="gPlayerAnimData_000000" FrameCount="20" Offset="0x0"/>
+```
+
+- Attributes:
+
+  - `Name`: Required. Suxffixed by `AnimData`.
+  - `FrameCount`: Required. The length of the animation in frames. It must be a positive integer.
 
 -------------------------

--- a/docs/zapd_xml_spec.md
+++ b/docs/zapd_xml_spec.md
@@ -1,8 +1,9 @@
 # ZAPD XML specification
 
-ZAPD XMLs use a restrictive subset of the XML standard: any ZAPD XML must be a valid XML (All elements starting with `<tag>` ending appropriately with `</tag>`, single "empty-element" tags with `/` at the end, etc.). 
+ZAPD XMLs use a restrictive subset of the XML standard: any ZAPD XML must be a valid XML (All elements starting with `<tag>` ending appropriately with `</tag>`, single "empty-element" tags with `/` at the end, etc.).
 
 Reminder that in
+
 ```xml
 <a>
     <b1>
@@ -14,39 +15,41 @@ Reminder that in
     <e/>
 </a>
 ```
+
 `<b1>`, `<b2>`, `<e/>` are *children* of `<a>`, but `<c/>` is not. `<c/>` is a *descendent* of `<a>` and a child of `<b>`.
 
 - Every XML's outermost element start/end tag is a single `<Root>`.
 - The children of a `<Root>` must be `<File>`s.
 - A `<File>` has *resources* as children. A resource is almost always single empty-element tag, and has one of the types
-    - `<Texture>`
-    - `<Background>`
-    - `<Blob>`
-    - `<DList>`
-    - `<TextureAnimation>`
-    - `<Scene>`
-    - `<Room>`
-    - `<AltHeader>`
-    - `<Animation>`
-    - `<PlayerAnimation>`
-    - `<CurveAnimation>`
-    - `<LegacyAnimation>`
-    - `<Skeleton>`
-    - `<LimbTable>`
-    - `<Limb>`
-    - `<Symbol>`
-    - `<Collision>`
-    - `<Scalar>`
-    - `<Vector>`
-    - `<Vtx>`
-    - `<Mtx>`
-    - `<Cutscene>`
-    - `<Array>`
-    - `<Path>`
+  - `<Texture>`
+  - `<Background>`
+  - `<Blob>`
+  - `<DList>`
+  - `<TextureAnimation>`
+  - `<Scene>`
+  - `<Room>`
+  - `<AltHeader>`
+  - `<Animation>`
+  - `<PlayerAnimation>`
+  - `<CurveAnimation>`
+  - `<LegacyAnimation>`
+  - `<Skeleton>`
+  - `<LimbTable>`
+  - `<Limb>`
+  - `<Symbol>`
+  - `<Collision>`
+  - `<Scalar>`
+  - `<Vector>`
+  - `<Vtx>`
+  - `<Mtx>`
+  - `<Cutscene>`
+  - `<Array>`
+  - `<Path>`
+  - `<PlayerAnimationData>`
 
 - A `<File>` cannot descend from a `<File>`.
 - All resources must be children of a `<File>`.
 - `<Array>` is the only paired resource tag enclosing an element; the element must be a single resource tag, one of
-    - `<Scalar>`
-    - `<Vector>`
-    - `<Vtx>`
+  - `<Scalar>`
+  - `<Vector>`
+  - `<Vtx>`


### PR DESCRIPTION
Allows the extraction of the animetion data in the `link_animetion` file.
Example XML to use this:
```xml
<Root>
    <File Name="link_animetion" Segment="7">
        <PlayerAnimationData Name="gPlayerAnimData_000000" FrameCount="20" Offset="0x0"/>
        <PlayerAnimationData Name="gPlayerAnimData_000A80" FrameCount="20" Offset="0xA80"/>
        <PlayerAnimationData Name="gPlayerAnimData_00D710" FrameCount="51" Offset="0xD710"/>
    </File>
</Root>
```

This animetion data is referenced by the `gameplay_keep` file, which contains the corresponding headers of each animation.
Please note ZAPD cannot currently use the symbols of this XML when extracting `gameplay_keep` because it currently does not have a way to know those symbols exists when extracting it, but this should be fixed when PR #151 is merged.

Addresses issue: #196 