### PR TITLE
Add the ability to force textures to be different types

### DIFF
--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -627,12 +627,19 @@ void ZFile::GenerateSourceFiles(fs::path outputDir)
 				(outputDir / Path::GetFileNameWithoutExtension(res->GetOutName())).string();
 			std::string declType = res->GetSourceTypeName();
 
-			std::string incStr = StringHelper::Sprintf("%s.%s.inc", assetOutDir.c_str(),
-			                                           res->GetExternalExtension().c_str());
+			// std::string incStr = StringHelper::Sprintf("%s.%s.inc", assetOutDir.c_str(),
+			//                                           res->GetExternalExtension().c_str());
+			std::string incStr = assetOutDir;
 
-			if (res->GetResourceType() == ZResourceType::Texture)
+			if (res->GetResourceType() != ZResourceType::Texture)
+			{
+				incStr += res->GetExternalExtension() + ".inc";
+			}
+			else if (res->GetResourceType() == ZResourceType::Texture)
 			{
 				ZTexture* tex = static_cast<ZTexture*>(res);
+				incStr +=
+					'.' + tex->GetSourceTypeName() + '.' + res->GetExternalExtension() + ".inc";
 
 				if (!Globals::Instance->cfg.texturePool.empty())
 				{

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -633,7 +633,7 @@ void ZFile::GenerateSourceFiles(fs::path outputDir)
 
 			if (res->GetResourceType() != ZResourceType::Texture)
 			{
-				incStr += res->GetExternalExtension() + ".inc";
+				incStr += '.' + res->GetExternalExtension() + ".inc";
 			}
 			else if (res->GetResourceType() == ZResourceType::Texture)
 			{
@@ -656,8 +656,8 @@ void ZFile::GenerateSourceFiles(fs::path outputDir)
 
 				incStr += ".c";
 			}
-			else if (res->GetResourceType() == ZResourceType::Blob ||
-			         res->GetResourceType() == ZResourceType::Background)
+			if (res->GetResourceType() == ZResourceType::Blob ||
+			    res->GetResourceType() == ZResourceType::Background)
 			{
 				incStr += ".c";
 			}

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -866,6 +866,10 @@ std::string ZTexture::GetSourceTypeName() const
 	case TextureTypeSize::Size64:
 		return "u64";
 		break;
+	default:
+		// Clang doesn't care about this but GCC sometimes generates a warning without this default
+		// statement. Don't remove unless Jenkins doesn't care anymore.
+		throw std::runtime_error("ZTexture::GetSourceTypeName invalid texTypeSize\n");
 	}
 }
 

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -105,7 +105,7 @@ void ZTexture::ParseXML(tinyxml2::XMLElement* reader)
 			                          "\t TexTypeSize was specified but is invalid: %d\n",
 			                          name.c_str(), typeSize));
 		}
-	}
+	}  // TODO detect if texture is not aligned and force a different type
 
 	std::string formatStr = registeredAttributes.at("Format").value;
 	format = GetTextureTypeFromString(formatStr);
@@ -802,9 +802,7 @@ std::string ZTexture::GetBodySourceCode() const
 	TextureTypeSize texTypeSize;
 	if (!typeSizeStr.empty())
 	{
-		texTypeSize =
-			static_cast<TextureTypeSize>(StringHelper::StrToL(typeSizeStr.substr(2)));
-		printf("%s	%hhu\n", typeSizeStr.c_str(), texTypeSize);
+		texTypeSize = static_cast<TextureTypeSize>(StringHelper::StrToL(typeSizeStr.substr(2)));
 	}
 	for (size_t i = 0; i < textureDataRaw.size();
 	     i += (static_cast<uint8_t>(texTypeSize) / 8))  // TODO clean that up
@@ -824,7 +822,7 @@ std::string ZTexture::GetBodySourceCode() const
 			break;
 		case TextureTypeSize::TEX_TYPE_32:
 			sourceOutput +=
-				StringHelper::Sprintf("0x%08UX, ", BitConverter::ToUInt32BE(textureDataRaw, i));
+				StringHelper::Sprintf("0x%08X ", BitConverter::ToUInt32BE(textureDataRaw, i));
 			break;
 		case TextureTypeSize::TEX_TYPE_64:
 			sourceOutput +=

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -366,8 +366,9 @@ void ZTexture::DeclareReferences([[maybe_unused]] const std::string& prefix)
 				tlutDim = 4;
 
 			auto filepath = Globals::Instance->outputPath / fs::path(name).stem();
-			std::string incStr = StringHelper::Sprintf("%s.%s.inc.c", filepath.c_str(),
-			                                           GetExternalExtension().c_str());
+			std::string incStr =
+				StringHelper::Sprintf("%s.%s.%s.inc.c", filepath.c_str(),
+			                          GetSourceTypeName().c_str(), GetExternalExtension().c_str());
 
 			tlut = new ZTexture(parent);
 			tlut->ExtractFromBinary(tlutOffset, tlutDim, tlutDim, TextureType::RGBA16bpp, true);
@@ -756,7 +757,8 @@ void ZTexture::Save(const fs::path& outFolder)
 	if (!Directory::Exists(outPath.string()))
 		Directory::CreateDirectory(outPath.string());
 
-	auto outFileName = outPath / (outName + "." + GetExternalExtension() + ".png");
+	auto outFileName =
+		outPath / (outName + "." + GetSourceTypeName() + "." + GetExternalExtension() + ".png");
 
 #ifdef TEXTURE_DEBUG
 	printf("Saving PNG: %s\n", outFileName.c_str());
@@ -783,7 +785,8 @@ Declaration* ZTexture::DeclareVar(const std::string& prefix,
 	auto filepath = Globals::Instance->outputPath / fs::path(auxName).stem();
 
 	std::string incStr =
-		StringHelper::Sprintf("%s.%s.inc.c", filepath.c_str(), GetExternalExtension().c_str());
+		StringHelper::Sprintf("%s.%s.%s.inc.c", filepath.c_str(), GetSourceTypeName().c_str(),
+	                          GetExternalExtension().c_str());
 
 	Declaration* decl = parent->AddDeclarationIncludeArray(rawDataIndex, incStr, GetRawDataSize(),
 	                                                       GetSourceTypeName(), auxName, 0);
@@ -794,7 +797,15 @@ Declaration* ZTexture::DeclareVar(const std::string& prefix,
 std::string ZTexture::GetBodySourceCode() const
 {
 	std::string sourceOutput = "";
-
+	std::string typeSizeStr =
+		Globals::Instance->outputPath.stem().stem().stem().extension().c_str();
+	TextureTypeSize texTypeSize;
+	if (!typeSizeStr.empty())
+	{
+		texTypeSize =
+			static_cast<TextureTypeSize>(StringHelper::StrToL(typeSizeStr.substr(2)));
+		printf("%s	%hhu\n", typeSizeStr.c_str(), texTypeSize);
+	}
 	for (size_t i = 0; i < textureDataRaw.size();
 	     i += (static_cast<uint8_t>(texTypeSize) / 8))  // TODO clean that up
 	{

--- a/ZAPD/ZTexture.h
+++ b/ZAPD/ZTexture.h
@@ -18,6 +18,14 @@ enum class TextureType
 	GrayscaleAlpha16bpp,
 };
 
+enum class TextureTypeSize : uint8_t
+{
+	TEX_TYPE_8 = 8,
+	TEX_TYPE_16 = 16,
+	TEX_TYPE_32 = 32,
+	TEX_TYPE_64 = 64,
+};
+
 class ZTexture : public ZResource
 {
 protected:
@@ -28,6 +36,7 @@ protected:
 	std::vector<uint8_t> textureDataRaw;  // When reading from a PNG file.
 	uint32_t tlutOffset = static_cast<uint32_t>(-1);
 	ZTexture* tlut = nullptr;
+	TextureTypeSize texTypeSize;
 
 	void PrepareBitmapRGBA16();
 	void PrepareBitmapRGBA32();


### PR DESCRIPTION
Since some textures are not aligned to and 8 byte boundary they obviously need to be a non `u64` type.
There is still some work to do regarding the format of the output data so this will be a draft until that is complete.