### PR TITLE
Fix static forward declarations for remaining resources

### DIFF
--- a/ZAPD/ZBackground.cpp
+++ b/ZAPD/ZBackground.cpp
@@ -118,7 +118,8 @@ size_t ZBackground::GetRawDataSize() const
 	return Globals::Instance->cfg.bgScreenHeight * Globals::Instance->cfg.bgScreenWidth * 2;
 }
 
-Declaration* ZBackground::DeclareVar(const std::string& prefix, [[maybe_unused]]const std::string& bodyStr)
+Declaration* ZBackground::DeclareVar(const std::string& prefix,
+                                     [[maybe_unused]] const std::string& bodyStr)
 {
 	std::string auxName = name;
 	std::string auxOutName = outName;

--- a/ZAPD/ZBackground.cpp
+++ b/ZAPD/ZBackground.cpp
@@ -11,6 +11,7 @@ REGISTER_ZFILENODE(Background, ZBackground);
 
 #define JPEG_MARKER 0xFFD8FFE0
 #define MARKER_DQT 0xFFDB
+#define MARKER_EOI 0xFFD9
 
 ZBackground::ZBackground(ZFile* nParent) : ZResource(nParent)
 {
@@ -27,7 +28,7 @@ void ZBackground::ParseRawData()
 		uint8_t val = rawData.at(rawDataIndex + i);
 		data.push_back(val);
 
-		if (BitConverter::ToUInt16BE(rawData, rawDataIndex + i) == 0xFFD9)
+		if (BitConverter::ToUInt16BE(rawData, rawDataIndex + i) == MARKER_EOI)
 		{
 			data.push_back(rawData.at(rawDataIndex + i + 1));
 			break;
@@ -117,16 +118,25 @@ size_t ZBackground::GetRawDataSize() const
 	return Globals::Instance->cfg.bgScreenHeight * Globals::Instance->cfg.bgScreenWidth * 2;
 }
 
-Declaration* ZBackground::DeclareVar(const std::string& prefix, const std::string& bodyStr)
+Declaration* ZBackground::DeclareVar(const std::string& prefix, [[maybe_unused]]const std::string& bodyStr)
 {
 	std::string auxName = name;
+	std::string auxOutName = outName;
 
-	if (name == "")
+	if (auxName == "")
 		auxName = GetDefaultName(prefix);
 
-	Declaration* decl = parent->AddDeclarationArray(rawDataIndex, GetDeclarationAlignment(),
-	                                                GetRawDataSize(), GetSourceTypeName(), auxName,
-	                                                "SCREEN_WIDTH * SCREEN_HEIGHT / 4", bodyStr);
+	if (auxOutName == "")
+		auxOutName = GetDefaultName(prefix);
+
+	auto filepath = Globals::Instance->outputPath / fs::path(auxOutName).stem();
+
+	std::string incStr =
+		StringHelper::Sprintf("%s.%s.inc.c", filepath.c_str(), GetExternalExtension().c_str());
+
+	Declaration* decl = parent->AddDeclarationIncludeArray(rawDataIndex, incStr, GetRawDataSize(),
+	                                                       GetSourceTypeName(), auxName, 0);
+	decl->arrayItemCntStr = "SCREEN_WIDTH * SCREEN_HEIGHT / 4";
 	decl->staticConf = staticConf;
 	return decl;
 }

--- a/ZAPD/ZBlob.cpp
+++ b/ZAPD/ZBlob.cpp
@@ -40,17 +40,21 @@ Declaration* ZBlob::DeclareVar(const std::string& prefix,
                                [[maybe_unused]] const std::string& bodyStr)
 {
 	std::string auxName = name;
+	std::string auxOutName = outName;
 
-	if (name == "")
+	if (auxName == "")
 		auxName = GetDefaultName(prefix);
 
-	std::string path = Path::GetFileNameWithoutExtension(auxName);
+	if (auxOutName == "")
+		auxOutName = GetDefaultName(prefix);
+
+	std::string path = Path::GetFileNameWithoutExtension(auxOutName);
 
 	std::string assetOutDir =
 		(Globals::Instance->outputPath / Path::GetFileNameWithoutExtension(GetOutName())).string();
 
 	std::string incStr =
-		StringHelper::Sprintf("%s.%s.inc", assetOutDir.c_str(), GetExternalExtension().c_str());
+		StringHelper::Sprintf("%s.%s.inc.c", assetOutDir.c_str(), GetExternalExtension().c_str());
 
 	return parent->AddDeclarationIncludeArray(rawDataIndex, incStr, GetRawDataSize(),
 	                                          GetSourceTypeName(), auxName, blobData.size());

--- a/ZAPD/ZBlob.cpp
+++ b/ZAPD/ZBlob.cpp
@@ -53,7 +53,7 @@ Declaration* ZBlob::DeclareVar(const std::string& prefix,
 		StringHelper::Sprintf("%s.%s.inc", assetOutDir.c_str(), GetExternalExtension().c_str());
 
 	return parent->AddDeclarationIncludeArray(rawDataIndex, incStr, GetRawDataSize(),
-	                                          GetSourceTypeName(), auxName, 0);
+	                                          GetSourceTypeName(), auxName, blobData.size());
 }
 
 std::string ZBlob::GetBodySourceCode() const

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -106,8 +106,8 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 
 		parent->AddDeclarationArray(
 			waterBoxSegmentOffset, DeclarationAlignment::Align4, 16 * waterBoxes.size(), "WaterBox",
-			StringHelper::Sprintf("%s_waterBoxes_%06X", auxName.c_str(), waterBoxSegmentOffset), waterBoxes.size(),
-			declaration);
+			StringHelper::Sprintf("%s_waterBoxes_%06X", auxName.c_str(), waterBoxSegmentOffset),
+			waterBoxes.size(), declaration);
 	}
 
 	if (polygons.size() > 0)
@@ -126,8 +126,8 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 
 		parent->AddDeclarationArray(
 			polySegmentOffset, DeclarationAlignment::Align4, polygons.size() * 16, "CollisionPoly",
-			StringHelper::Sprintf("%s_polygons_%08X", auxName.c_str(), polySegmentOffset), polygons.size(),
-			declaration);
+			StringHelper::Sprintf("%s_polygons_%08X", auxName.c_str(), polySegmentOffset),
+			polygons.size(), declaration);
 	}
 
 	declaration.clear();
@@ -167,8 +167,8 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 			parent->AddDeclarationArray(
 				vtxSegmentOffset, first.GetDeclarationAlignment(),
 				vertices.size() * first.GetRawDataSize(), first.GetSourceTypeName(),
-				StringHelper::Sprintf("%s_vtx_%08X", auxName.c_str(), vtxSegmentOffset), vertices.size(),
-				declaration);
+				StringHelper::Sprintf("%s_vtx_%08X", auxName.c_str(), vtxSegmentOffset),
+				vertices.size(), declaration);
 	}
 }
 

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -106,7 +106,7 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 
 		parent->AddDeclarationArray(
 			waterBoxSegmentOffset, DeclarationAlignment::Align4, 16 * waterBoxes.size(), "WaterBox",
-			StringHelper::Sprintf("%s_waterBoxes_%06X", auxName.c_str(), waterBoxSegmentOffset), 0,
+			StringHelper::Sprintf("%s_waterBoxes_%06X", auxName.c_str(), waterBoxSegmentOffset), waterBoxes.size(),
 			declaration);
 	}
 
@@ -126,7 +126,7 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 
 		parent->AddDeclarationArray(
 			polySegmentOffset, DeclarationAlignment::Align4, polygons.size() * 16, "CollisionPoly",
-			StringHelper::Sprintf("%s_polygons_%08X", auxName.c_str(), polySegmentOffset), 0,
+			StringHelper::Sprintf("%s_polygons_%08X", auxName.c_str(), polySegmentOffset), polygons.size(),
 			declaration);
 	}
 
@@ -167,7 +167,7 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 			parent->AddDeclarationArray(
 				vtxSegmentOffset, first.GetDeclarationAlignment(),
 				vertices.size() * first.GetRawDataSize(), first.GetSourceTypeName(),
-				StringHelper::Sprintf("%s_vtx_%08X", auxName.c_str(), vtxSegmentOffset), 0,
+				StringHelper::Sprintf("%s_vtx_%08X", auxName.c_str(), vtxSegmentOffset), vertices.size(),
 				declaration);
 	}
 }

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -639,7 +639,12 @@ void ZFile::GenerateSourceFiles()
 	for (size_t i = 0; i < resources.size(); i++)
 	{
 		ZResource* res = resources.at(i);
-		res->GetSourceOutputCode(name);
+		std::string resSrc = res->GetSourceOutputCode(name);
+
+		sourceOutput += resSrc;
+
+		if (resSrc != "" && !res->IsExternalResource())
+			sourceOutput += "\n";
 	}
 
 	sourceOutput += ProcessDeclarations();
@@ -1127,6 +1132,7 @@ std::string ZFile::ProcessTextureIntersections([[maybe_unused]] const std::strin
 				// Shrink palette so it doesn't overlap
 				currentTex->SetDimensions(offsetDiff / currentTex->GetPixelMultiplyer(), 1);
 				declarations.at(currentOffset)->size = currentTex->GetRawDataSize();
+				currentTex->DeclareVar(GetName(), "");
 			}
 			else
 			{

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -243,7 +243,7 @@ void ZFile::BuildSourceFile()
 	if (!Directory::Exists(Globals::Instance->outputPath))
 		Directory::CreateDirectory(Globals::Instance->outputPath.string());
 
-	GenerateSourceFiles(Globals::Instance->outputPath);
+	GenerateSourceFiles();
 }
 
 std::string ZFile::GetVarName(uint32_t address)
@@ -286,7 +286,7 @@ void ZFile::ExtractResources()
 		resources[i]->DeclareReferencesLate(name);
 
 	if (Globals::Instance->genSourceFile)
-		GenerateSourceFiles(Globals::Instance->outputPath);
+		GenerateSourceFiles();
 
 	MemoryStream* memStream = new MemoryStream();
 	BinaryWriter writer = BinaryWriter(memStream);
@@ -607,7 +607,7 @@ bool ZFile::HasDeclaration(uint32_t address)
 	return declarations.find(address) != declarations.end();
 }
 
-void ZFile::GenerateSourceFiles(fs::path outputDir)
+void ZFile::GenerateSourceFiles()
 {
 	std::string sourceOutput;
 
@@ -616,60 +616,30 @@ void ZFile::GenerateSourceFiles(fs::path outputDir)
 	sourceOutput += "#include \"macros.h\"\n";
 	sourceOutput += GetHeaderInclude();
 
+	bool hasZRoom = false;
+	for (const auto& res : resources)
+	{
+		ZResourceType resType = res->GetResourceType();
+		if (resType == ZResourceType::Room || resType == ZResourceType::Scene ||
+		    resType == ZResourceType::AltHeader)
+		{
+			hasZRoom = true;
+			break;
+		}
+	}
+
+	if (hasZRoom)
+	{
+		sourceOutput += GetZRoomHeaderInclude();
+	}
+
 	GeneratePlaceholderDeclarations();
 
 	// Generate Code
 	for (size_t i = 0; i < resources.size(); i++)
 	{
 		ZResource* res = resources.at(i);
-		std::string resSrc = res->GetSourceOutputCode(name);
-
-		if (res->IsExternalResource())
-		{
-			std::string path = Path::GetFileNameWithoutExtension(res->GetName()).c_str();
-
-			std::string assetOutDir =
-				(outputDir / Path::GetFileNameWithoutExtension(res->GetOutName())).string();
-			std::string declType = res->GetSourceTypeName();
-
-			std::string incStr = StringHelper::Sprintf("%s.%s.inc", assetOutDir.c_str(),
-			                                           res->GetExternalExtension().c_str());
-
-			if (res->GetResourceType() == ZResourceType::Texture)
-			{
-				ZTexture* tex = static_cast<ZTexture*>(res);
-
-				if (!Globals::Instance->cfg.texturePool.empty())
-				{
-					tex->CalcHash();
-
-					// TEXTURE POOL CHECK
-					if (Globals::Instance->cfg.texturePool.find(tex->hash) !=
-					    Globals::Instance->cfg.texturePool.end())
-					{
-						incStr = Globals::Instance->cfg.texturePool[tex->hash].path.string() + "." +
-								 res->GetExternalExtension() + ".inc";
-					}
-				}
-
-				incStr += ".c";
-			}
-			else if (res->GetResourceType() == ZResourceType::Blob ||
-			         res->GetResourceType() == ZResourceType::Background)
-			{
-				incStr += ".c";
-			}
-
-			AddDeclarationIncludeArray(res->GetRawDataIndex(), incStr, res->GetRawDataSize(),
-			                           declType, res->GetName(), 0);
-		}
-		else
-		{
-			sourceOutput += resSrc;
-		}
-
-		if (resSrc != "" && !res->IsExternalResource())
-			sourceOutput += "\n";
+		res->GetSourceOutputCode(name);
 	}
 
 	sourceOutput += ProcessDeclarations();
@@ -710,10 +680,22 @@ void ZFile::GenerateSourceHeaderFiles()
 	File::WriteAllText(headerFilename, formatter.GetOutput());
 }
 
-std::string ZFile::GetHeaderInclude()
+std::string ZFile::GetHeaderInclude() const
 {
-	return StringHelper::Sprintf("#include \"%s\"\n\n",
-	                             (outName.parent_path() / outName.stem().concat(".h")).c_str());
+	std::string headers = StringHelper::Sprintf("#include \"%s.h\"\n",
+	                                            (outName.parent_path() / outName.stem()).c_str());
+
+	return headers;
+}
+
+std::string ZFile::GetZRoomHeaderInclude() const
+{
+	std::string headers;
+	headers += "#include \"segment_symbols.h\"\n";
+	headers += "#include \"command_macros_base.h\"\n";
+	headers += "#include \"z64cutscene_commands.h\"\n";
+	headers += "#include \"variables.h\"\n";
+	return headers;
 }
 
 void ZFile::GeneratePlaceholderDeclarations()
@@ -834,26 +816,13 @@ std::string ZFile::ProcessDeclarations()
 		{
 			if (item.second->alignment == DeclarationAlignment::Align16)
 			{
-				// int32_t lastAddrSizeTest = declarations[lastAddr]->size;
 				int32_t curPtr = lastAddr + declarations[lastAddr]->size;
 
 				while (curPtr % 4 != 0)
 				{
 					declarations[lastAddr]->size++;
-					// item.second->size++;
 					curPtr++;
 				}
-
-				/*while (curPtr % 16 != 0)
-				{
-				    char buffer[2048];
-
-				    sprintf(buffer, "static u32 align%02X = 0;\n", curPtr);
-				    item.second->text = buffer + item.second->text;
-
-				    declarations[lastAddr]->size += 4;
-				    curPtr += 4;
-				}*/
 			}
 			else if (item.second->alignment == DeclarationAlignment::Align8)
 			{
@@ -862,7 +831,6 @@ std::string ZFile::ProcessDeclarations()
 				while (curPtr % 4 != 0)
 				{
 					declarations[lastAddr]->size++;
-					// item.second->size++;
 					curPtr++;
 				}
 
@@ -874,7 +842,6 @@ std::string ZFile::ProcessDeclarations()
 					item.second->preText = buffer + item.second->preText;
 
 					declarations[lastAddr]->size += 4;
-					// item.second->size += 4;
 					curPtr += 4;
 				}
 			}

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -682,6 +682,7 @@ void ZFile::GenerateSourceFiles()
 	sourceOutput += "#include \"z64.h\"\n";
 	sourceOutput += "#include \"macros.h\"\n";
 	sourceOutput += GetHeaderInclude();
+	sourceOutput += GetExternalFileHeaderInclude();
 
 	bool hasZRoom = false;
 	for (const auto& res : resources)

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -682,7 +682,6 @@ void ZFile::GenerateSourceFiles()
 	sourceOutput += "#include \"z64.h\"\n";
 	sourceOutput += "#include \"macros.h\"\n";
 	sourceOutput += GetHeaderInclude();
-	sourceOutput += GetExternalFileHeaderInclude();
 
 	bool hasZRoom = false;
 	for (const auto& res : resources)
@@ -700,6 +699,8 @@ void ZFile::GenerateSourceFiles()
 	{
 		sourceOutput += GetZRoomHeaderInclude();
 	}
+
+	sourceOutput += GetExternalFileHeaderInclude();
 
 	GeneratePlaceholderDeclarations();
 

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -726,7 +726,8 @@ void ZFile::GeneratePlaceholderDeclarations()
 			continue;
 		}
 
-		Declaration* decl = AddDeclarationPlaceholder(res->GetRawDataIndex(), res->GetName());
+		Declaration* decl = res->DeclareVar(GetName(), "");
+		decl->staticConf = res->GetStaticConf();
 		if (res->GetResourceType() == ZResourceType::Symbol)
 		{
 			decl->staticConf = StaticConfig::Off;

--- a/ZAPD/ZFile.h
+++ b/ZAPD/ZFile.h
@@ -73,7 +73,10 @@ public:
 	Declaration* GetDeclarationRanged(uint32_t address) const;
 	uint32_t GetDeclarationRangedAddress(uint32_t address) const;
 	bool HasDeclaration(uint32_t address);
-	std::string GetHeaderInclude();
+
+	std::string GetHeaderInclude() const;
+	std::string GetZRoomHeaderInclude() const;
+
 	void GeneratePlaceholderDeclarations();
 
 	void AddTextureResource(uint32_t offset, ZTexture* tex);
@@ -100,7 +103,7 @@ protected:
 	void ParseXML(ZFileMode mode, tinyxml2::XMLElement* reader, const std::string& filename,
 	              bool placeholderMode);
 	void DeclareResourceSubReferences();
-	void GenerateSourceFiles(fs::path outputDir);
+	void GenerateSourceFiles();
 	void GenerateSourceHeaderFiles();
 	void AddDeclarationDebugChecks(uint32_t address);
 	std::string ProcessDeclarations();

--- a/ZAPD/ZResource.cpp
+++ b/ZAPD/ZResource.cpp
@@ -39,6 +39,7 @@ void ZResource::ExtractFromXML(tinyxml2::XMLElement* reader, offset_t nRawDataIn
 		Declaration* decl = DeclareVar(parent->GetName(), "");
 		assert(decl != nullptr);
 		decl->declaredInXml = true;
+		decl->staticConf = staticConf;
 	}
 }
 
@@ -219,6 +220,11 @@ DeclarationAlignment ZResource::GetDeclarationAlignment() const
 bool ZResource::WasDeclaredInXml() const
 {
 	return declaredInXml;
+}
+
+StaticConfig ZResource::GetStaticConf() const
+{
+	return staticConf;
 }
 
 offset_t ZResource::GetRawDataIndex() const

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -163,6 +163,7 @@ public:
 	 * `false` otherwise (for example, a Vtx extracted indirectly by a DList)
 	 */
 	[[nodiscard]] bool WasDeclaredInXml() const;
+	[[nodiscard]] StaticConfig GetStaticConf() const;
 
 protected:
 	std::string name;

--- a/ZAPD/ZRoom/Commands/SetActorCutsceneList.cpp
+++ b/ZAPD/ZRoom/Commands/SetActorCutsceneList.cpp
@@ -47,7 +47,7 @@ void SetActorCutsceneList::DeclareReferences(const std::string& prefix)
 		parent->AddDeclarationArray(
 			segmentOffset, DeclarationAlignment::Align4, cutscenes.size() * 16, typeName,
 			StringHelper::Sprintf("%s%sList_%06X", prefix.c_str(), typeName.c_str(), segmentOffset),
-			0, declaration);
+			cutscenes.size(), declaration);
 	}
 }
 

--- a/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
+++ b/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
@@ -51,8 +51,8 @@ void SetAlternateHeaders::DeclareReferencesLate(const std::string& prefix)
 
 		parent->AddDeclarationArray(
 			segmentOffset, DeclarationAlignment::Align4, headers.size() * 4, "SceneCmd*",
-			StringHelper::Sprintf("%sAltHeader_%06X", prefix.c_str(), segmentOffset), headers.size(),
-			declaration);
+			StringHelper::Sprintf("%sAltHeader_%06X", prefix.c_str(), segmentOffset),
+			headers.size(), declaration);
 	}
 }
 

--- a/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
+++ b/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
@@ -51,7 +51,7 @@ void SetAlternateHeaders::DeclareReferencesLate(const std::string& prefix)
 
 		parent->AddDeclarationArray(
 			segmentOffset, DeclarationAlignment::Align4, headers.size() * 4, "SceneCmd*",
-			StringHelper::Sprintf("%sAltHeader_%06X", prefix.c_str(), segmentOffset), 0,
+			StringHelper::Sprintf("%sAltHeader_%06X", prefix.c_str(), segmentOffset), headers.size(),
 			declaration);
 	}
 }

--- a/ZAPD/ZRoom/Commands/SetRoomList.cpp
+++ b/ZAPD/ZRoom/Commands/SetRoomList.cpp
@@ -85,7 +85,7 @@ Declaration* RomFile::DeclareVar(const std::string& prefix, const std::string& b
 
 	return parent->AddDeclarationArray(rawDataIndex, DeclarationAlignment::Align4,
 	                                   rooms.size() * rooms.at(0).GetRawDataSize(),
-	                                   GetSourceTypeName(), auxName, 0, body);
+	                                   GetSourceTypeName(), auxName, rooms.size(), body);
 }
 
 std::string RomFile::GetBodySourceCode() const

--- a/ZAPD/ZRoom/Commands/SetStartPositionList.cpp
+++ b/ZAPD/ZRoom/Commands/SetStartPositionList.cpp
@@ -43,8 +43,8 @@ void SetStartPositionList::DeclareReferences(const std::string& prefix)
 
 		parent->AddDeclarationArray(
 			segmentOffset, DeclarationAlignment::Align4, actors.size() * 16, "ActorEntry",
-			StringHelper::Sprintf("%sStartPositionList0x%06X", prefix.c_str(), segmentOffset), actors.size(),
-			declaration);
+			StringHelper::Sprintf("%sStartPositionList0x%06X", prefix.c_str(), segmentOffset),
+			actors.size(), declaration);
 	}
 }
 

--- a/ZAPD/ZRoom/Commands/SetStartPositionList.cpp
+++ b/ZAPD/ZRoom/Commands/SetStartPositionList.cpp
@@ -43,7 +43,7 @@ void SetStartPositionList::DeclareReferences(const std::string& prefix)
 
 		parent->AddDeclarationArray(
 			segmentOffset, DeclarationAlignment::Align4, actors.size() * 16, "ActorEntry",
-			StringHelper::Sprintf("%sStartPositionList0x%06X", prefix.c_str(), segmentOffset), 0,
+			StringHelper::Sprintf("%sStartPositionList0x%06X", prefix.c_str(), segmentOffset), actors.size(),
 			declaration);
 	}
 }

--- a/ZAPD/ZRoom/Commands/SetTransitionActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetTransitionActorList.cpp
@@ -45,7 +45,7 @@ void SetTransitionActorList::DeclareReferences(const std::string& prefix)
 	parent->AddDeclarationArray(
 		segmentOffset, DeclarationAlignment::Align4, transitionActors.size() * 16,
 		"TransitionActorEntry",
-		StringHelper::Sprintf("%sTransitionActorList_%06X", prefix.c_str(), segmentOffset), 0,
+		StringHelper::Sprintf("%sTransitionActorList_%06X", prefix.c_str(), segmentOffset), transitionActors.size(),
 		declaration);
 }
 

--- a/ZAPD/ZRoom/Commands/SetTransitionActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetTransitionActorList.cpp
@@ -45,8 +45,8 @@ void SetTransitionActorList::DeclareReferences(const std::string& prefix)
 	parent->AddDeclarationArray(
 		segmentOffset, DeclarationAlignment::Align4, transitionActors.size() * 16,
 		"TransitionActorEntry",
-		StringHelper::Sprintf("%sTransitionActorList_%06X", prefix.c_str(), segmentOffset), transitionActors.size(),
-		declaration);
+		StringHelper::Sprintf("%sTransitionActorList_%06X", prefix.c_str(), segmentOffset),
+		transitionActors.size(), declaration);
 }
 
 std::string SetTransitionActorList::GetBodySourceCode() const

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -404,11 +404,6 @@ std::string ZRoom::GetSourceOutputCode([[maybe_unused]] const std::string& prefi
 
 	if (zroomType == ZResourceType::Scene || zroomType == ZResourceType::Room)
 	{
-		sourceOutput += "#include \"segment_symbols.h\"\n";
-		sourceOutput += "#include \"command_macros_base.h\"\n";
-		sourceOutput += "#include \"z64cutscene_commands.h\"\n";
-		sourceOutput += "#include \"variables.h\"\n";
-
 		if (Globals::Instance->lastScene != nullptr)
 			sourceOutput += Globals::Instance->lastScene->parent->GetHeaderInclude();
 	}

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -302,7 +302,7 @@ Declaration* ZRoom::DeclareVar(const std::string& prefix, const std::string& bod
 
 	Declaration* decl =
 		parent->AddDeclarationArray(rawDataIndex, GetDeclarationAlignment(), GetRawDataSize(),
-	                                GetSourceTypeName(), auxName, 0, body);
+	                                GetSourceTypeName(), auxName, commands.size(), body);
 	decl->staticConf = staticConf;
 	return decl;
 }

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -335,7 +335,7 @@ void ZTexture::DeclareReferences([[maybe_unused]] const std::string& prefix)
 			tlut->ExtractFromBinary(tlutOffset, tlutDim, tlutDim, TextureType::RGBA16bpp, true);
 			parent->AddTextureResource(tlutOffset, tlut);
 			parent->AddDeclarationIncludeArray(tlutOffset, incStr, tlut->GetRawDataSize(),
-			                                   tlut->GetSourceTypeName(), tlut->GetName(), 0);
+			                                   tlut->GetSourceTypeName(), tlut->GetName(), GetRawDataSize()/8);
 		}
 		else
 		{
@@ -748,7 +748,7 @@ Declaration* ZTexture::DeclareVar(const std::string& prefix,
 		StringHelper::Sprintf("%s.%s.inc.c", filepath.c_str(), GetExternalExtension().c_str());
 
 	Declaration* decl = parent->AddDeclarationIncludeArray(rawDataIndex, incStr, GetRawDataSize(),
-	                                                       GetSourceTypeName(), auxName, 0);
+	                                                       GetSourceTypeName(), auxName, GetRawDataSize()/8);
 	decl->staticConf = staticConf;
 	return decl;
 }

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -754,12 +754,13 @@ Declaration* ZTexture::DeclareVar(const std::string& prefix,
 		const auto& poolEntry = Globals::Instance->cfg.texturePool.find(hash);
 		if (poolEntry != Globals::Instance->cfg.texturePool.end())
 		{
-			incStr = StringHelper::Sprintf("%s.%s.inc.c", poolEntry->second.path.c_str(), GetExternalExtension().c_str());
+			incStr = StringHelper::Sprintf("%s.%s.inc.c", poolEntry->second.path.c_str(),
+			                               GetExternalExtension().c_str());
 		}
 	}
 
-	Declaration* decl = parent->AddDeclarationIncludeArray(rawDataIndex, incStr, GetRawDataSize(),
-	                                                       GetSourceTypeName(), auxName, GetRawDataSize()/8);
+	Declaration* decl = parent->AddDeclarationIncludeArray(
+		rawDataIndex, incStr, GetRawDataSize(), GetSourceTypeName(), auxName, GetRawDataSize() / 8);
 	decl->staticConf = staticConf;
 	return decl;
 }

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -327,15 +327,10 @@ void ZTexture::DeclareReferences([[maybe_unused]] const std::string& prefix)
 			if (format == TextureType::Palette4bpp)
 				tlutDim = 4;
 
-			auto filepath = Globals::Instance->outputPath / fs::path(name).stem();
-			std::string incStr = StringHelper::Sprintf("%s.%s.inc.c", filepath.c_str(),
-			                                           GetExternalExtension().c_str());
-
 			tlut = new ZTexture(parent);
 			tlut->ExtractFromBinary(tlutOffset, tlutDim, tlutDim, TextureType::RGBA16bpp, true);
 			parent->AddTextureResource(tlutOffset, tlut);
-			parent->AddDeclarationIncludeArray(tlutOffset, incStr, tlut->GetRawDataSize(),
-			                                   tlut->GetSourceTypeName(), tlut->GetName(), GetRawDataSize()/8);
+			tlut->DeclareVar(prefix, "");
 		}
 		else
 		{
@@ -738,14 +733,30 @@ Declaration* ZTexture::DeclareVar(const std::string& prefix,
                                   [[maybe_unused]] const std::string& bodyStr)
 {
 	std::string auxName = name;
+	std::string auxOutName = outName;
 
-	if (name == "")
+	if (auxName == "")
 		auxName = GetDefaultName(prefix);
 
-	auto filepath = Globals::Instance->outputPath / fs::path(auxName).stem();
+	if (auxOutName == "")
+		auxOutName = GetDefaultName(prefix);
+
+	auto filepath = Globals::Instance->outputPath / fs::path(auxOutName).stem();
 
 	std::string incStr =
 		StringHelper::Sprintf("%s.%s.inc.c", filepath.c_str(), GetExternalExtension().c_str());
+
+	if (!Globals::Instance->cfg.texturePool.empty())
+	{
+		CalcHash();
+
+		// TEXTURE POOL CHECK
+		const auto& poolEntry = Globals::Instance->cfg.texturePool.find(hash);
+		if (poolEntry != Globals::Instance->cfg.texturePool.end())
+		{
+			incStr = StringHelper::Sprintf("%s.%s.inc.c", poolEntry->second.path.c_str(), GetExternalExtension().c_str());
+		}
+	}
 
 	Declaration* decl = parent->AddDeclarationIncludeArray(rawDataIndex, incStr, GetRawDataSize(),
 	                                                       GetSourceTypeName(), auxName, GetRawDataSize()/8);


### PR DESCRIPTION
Currently, some extracted overlay data fails to build if the extracted XML is marked as static. One example is `ovl_En_Clear_Tag`.
This happens because a static array variable can't be forward declared if its size is not used explicitly.
Because of this, this PR changes every array to use a fixed size at extraction.