### PR TITLE
Plug some large leaks, deprecate `Segment="128"`

### DIFF
--- a/ExporterTest/Main.cpp
+++ b/ExporterTest/Main.cpp
@@ -76,4 +76,4 @@ static void ImportExporters()
 
 // When ZAPD starts up, it will automatically call the below function, which in turn sets up our
 // exporters.
-REGISTER_EXPORTER(ImportExporters)
+REGISTER_EXPORTER(ImportExporters);

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -23,6 +23,15 @@ Globals::Globals()
 	outputPath = Directory::GetCurrentDirectory();
 }
 
+Globals::~Globals()
+{
+	auto& exporters = GetExporterMap();
+
+	for (auto& it: exporters) {
+		delete it.second;
+	}
+}
+
 void Globals::AddSegment(int32_t segment, ZFile* file)
 {
 	if (std::find(segments.begin(), segments.end(), segment) == segments.end())
@@ -38,21 +47,21 @@ bool Globals::HasSegment(int32_t segment)
 	return std::find(segments.begin(), segments.end(), segment) != segments.end();
 }
 
-std::map<std::string, ExporterSet*>* Globals::GetExporterMap()
+std::map<std::string, ExporterSet*>& Globals::GetExporterMap()
 {
 	static std::map<std::string, ExporterSet*> exporters;
-	return &exporters;
+	return exporters;
 }
 
 void Globals::AddExporter(std::string exporterName, ExporterSet* exporterSet)
 {
-	auto exporters = GetExporterMap();
-	(*exporters)[exporterName] = exporterSet;
+	auto& exporters = GetExporterMap();
+	exporters[exporterName] = exporterSet;
 }
 
 ZResourceExporter* Globals::GetExporter(ZResourceType resType)
 {
-	auto exporters = *GetExporterMap();
+	auto& exporters = GetExporterMap();
 
 	if (currentExporter != "" && exporters[currentExporter]->exporters.find(resType) !=
 	                                 exporters[currentExporter]->exporters.end())
@@ -63,7 +72,7 @@ ZResourceExporter* Globals::GetExporter(ZResourceType resType)
 
 ExporterSet* Globals::GetExporterSet()
 {
-	auto exporters = *GetExporterMap();
+	auto& exporters = GetExporterMap();
 
 	if (currentExporter != "")
 		return exporters[currentExporter];
@@ -192,4 +201,11 @@ bool Globals::GetSegmentedArrayIndexedName(segptr_t segAddress, size_t elementSi
 ExternalFile::ExternalFile(fs::path nXmlPath, fs::path nOutPath)
 	: xmlPath{nXmlPath}, outPath{nOutPath}
 {
+}
+
+ExporterSet::~ExporterSet()
+{
+	for(auto& it: exporters){
+		delete it.second;
+	}
 }

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -27,7 +27,8 @@ Globals::~Globals()
 {
 	auto& exporters = GetExporterMap();
 
-	for (auto& it: exporters) {
+	for (auto& it : exporters)
+	{
 		delete it.second;
 	}
 }
@@ -205,7 +206,8 @@ ExternalFile::ExternalFile(fs::path nXmlPath, fs::path nOutPath)
 
 ExporterSet::~ExporterSet()
 {
-	for(auto& it: exporters){
+	for (auto& it : exporters)
+	{
 		delete it.second;
 	}
 }

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -24,6 +24,8 @@ typedef void (*ExporterSetFuncVoid3)();
 class ExporterSet
 {
 public:
+	~ExporterSet();
+
 	std::map<ZResourceType, ZResourceExporter*> exporters;
 	ExporterSetFuncVoid parseArgsFunc = nullptr;
 	ExporterSetFuncVoid2 parseFileModeFunc = nullptr;
@@ -64,10 +66,11 @@ public:
 	std::map<uint32_t, std::string> symbolMap;
 
 	std::string currentExporter;
-	static std::map<std::string, ExporterSet*>* GetExporterMap();
+	static std::map<std::string, ExporterSet*>& GetExporterMap();
 	static void AddExporter(std::string exporterName, ExporterSet* exporterSet);
 
 	Globals();
+	~Globals();
 
 	void AddSegment(int32_t segment, ZFile* file);
 	bool HasSegment(int32_t segment);

--- a/ZAPD/ZCollision.h
+++ b/ZAPD/ZCollision.h
@@ -82,7 +82,7 @@ public:
 	std::vector<PolygonEntry> polygons;
 	std::vector<uint64_t> polygonTypes;
 	std::vector<WaterBoxHeader> waterBoxes;
-	CameraDataList* camData;
+	CameraDataList* camData = nullptr;
 
 	ZCollisionHeader(ZFile* nParent);
 	~ZCollisionHeader();

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -938,6 +938,7 @@ std::string ZFile::ProcessDeclarations()
 							lastItem.second->text += "\n" + curItem.second->text;
 							declarations.erase(curItem.first);
 							declarationKeys.erase(declarationKeys.begin() + i);
+							delete curItem.second;
 							i--;
 							continue;
 						}

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -133,30 +133,30 @@ void ZFile::ParseXML(tinyxml2::XMLElement* reader, const std::string& filename)
 	const char* segmentXml = reader->Attribute("Segment");
 	if (segmentXml != nullptr)
 	{
-		if (StringHelper::HasOnlyDigits(segmentXml))
-		{
-			segment = StringHelper::StrToL(segmentXml, 10);
-			if (segment > 15)
-			{
-				if (segment == 128)
-				{
-					fprintf(stderr, "warning: segment 128 is deprecated.\n\tRemove "
-					                "'Segment=\"128\"' from the xml to use virtual addresses\n");
-				}
-				else
-				{
-					throw std::runtime_error(StringHelper::Sprintf(
-						"error: invalid segment value '%s': must be a decimal "
-						"number between 0 and 15 inclusive",
-						segmentXml));
-				}
-			}
-		}
-		else
+		if (!StringHelper::HasOnlyDigits(segmentXml))
 		{
 			throw std::runtime_error(StringHelper::Sprintf(
 				"error: Invalid segment value '%s': must be a decimal between 0 and 15 inclusive",
 				segmentXml));
+		}
+
+		segment = StringHelper::StrToL(segmentXml, 10);
+		if (segment > 15)
+		{
+			if (segment == 128)
+			{
+#ifdef DEPRECATION_ON
+				fprintf(stderr, "warning: segment 128 is deprecated.\n\tRemove "
+				                "'Segment=\"128\"' from the xml to use virtual addresses\n");
+#endif
+			}
+			else
+			{
+				throw std::runtime_error(
+					StringHelper::Sprintf("error: invalid segment value '%s': must be a decimal "
+				                          "number between 0 and 15 inclusive",
+				                          segmentXml));
+			}
 		}
 	}
 	Globals::Instance->AddSegment(segment, this);

--- a/ZAPD/ZFile.h
+++ b/ZAPD/ZFile.h
@@ -34,7 +34,7 @@ public:
 	std::map<offset_t, Declaration*> declarations;
 	std::string defines;
 	std::vector<ZResource*> resources;
-	uint32_t segment;
+	int32_t segment = -1;
 	uint32_t baseAddress, rangeStart, rangeEnd;
 	bool isExternalFile = false;
 

--- a/ZAPD/ZFile.h
+++ b/ZAPD/ZFile.h
@@ -34,7 +34,9 @@ public:
 	std::map<offset_t, Declaration*> declarations;
 	std::string defines;
 	std::vector<ZResource*> resources;
-	int32_t segment = -1;
+
+	// Default to using virtual addresses
+	uint32_t segment = 0x80;
 	uint32_t baseAddress, rangeStart, rangeEnd;
 	bool isExternalFile = false;
 

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -209,6 +209,7 @@ class ZResourceExporter
 {
 public:
 	ZResourceExporter() = default;
+	virtual ~ZResourceExporter() = default;
 
 	virtual void Save(ZResource* res, fs::path outPath, BinaryWriter* writer) = 0;
 };
@@ -239,4 +240,4 @@ typedef ZResource*(ZResourceFactoryFunc)(ZFile* nParent);
 	public:                                                                                        \
 		ZResExp_##expFunc() { expFunc(); }                                                         \
 	};                                                                                             \
-	static ZResExp_##expFunc inst_ZResExp_##expFunc;
+	static ZResExp_##expFunc inst_ZResExp_##expFunc

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -208,6 +208,7 @@ ZDisplayList* PolygonDlist::MakeDlist(segptr_t ptr, [[maybe_unused]] const std::
 		parent->GetRawData(), dlistAddress,
 		Globals::Instance->game == ZGame::OOT_SW97 ? DListType::F3DEX : DListType::F3DZEX);
 	ZDisplayList* dlist = new ZDisplayList(parent);
+	parent->AddResource(dlist);
 	dlist->ExtractFromBinary(dlistAddress, dlistLength);
 	dlist->SetName(dlist->GetDefaultName(prefix));
 	GenDListDeclarations(zRoom, parent, dlist);

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -49,7 +49,11 @@ void ZSkeleton::ParseRawData()
 	const auto& rawData = parent->GetRawData();
 	limbsArrayAddress = BitConverter::ToUInt32BE(rawData, rawDataIndex);
 	limbCount = BitConverter::ToUInt8BE(rawData, rawDataIndex + 4);
-	dListCount = BitConverter::ToUInt8BE(rawData, rawDataIndex + 8);
+	
+	if (type == ZSkeletonType::Flex)
+	{
+		dListCount = BitConverter::ToUInt8BE(rawData, rawDataIndex + 8);
+	}
 
 	if (limbsArrayAddress != 0 && GETSEGNUM(limbsArrayAddress) == parent->segment)
 	{

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -49,7 +49,7 @@ void ZSkeleton::ParseRawData()
 	const auto& rawData = parent->GetRawData();
 	limbsArrayAddress = BitConverter::ToUInt32BE(rawData, rawDataIndex);
 	limbCount = BitConverter::ToUInt8BE(rawData, rawDataIndex + 4);
-	
+
 	if (type == ZSkeletonType::Flex)
 	{
 		dListCount = BitConverter::ToUInt8BE(rawData, rawDataIndex + 8);

--- a/docs/zapd_extraction_xml_reference.md
+++ b/docs/zapd_extraction_xml_reference.md
@@ -112,6 +112,8 @@ Allows ZAPD to map segmented addresses to variables declared in other files by u
 
 It is useful for objects that use variables from `gameplay_keep`, `gameplay_dangeon_keep`, `gameplay_field_keep`, etc.
 
+This tag can be used in the global `config.xml` file.
+
 - Example of this tag:
 
 ```xml

--- a/docs/zapd_extraction_xml_reference.md
+++ b/docs/zapd_extraction_xml_reference.md
@@ -98,7 +98,7 @@ This table summarizes if the asset will be marked `static` (✅) or not (❌)
 
   - `Name`: Required. The name of the file in `baserom/` which will be extracted.
   - `OutName`: Optional. The output name of the generated C source file. Defaults to the value passed to `Name`.
-  - `Segment`: Required. This is the segment number of the current file. Expects a decimal number, usually 6 if it is an object, or 128 for overlays (It's kinda a whacky hack to get around of the `0x80` addresses).
+  - `Segment`: Optional. This is the segment number of the current file. Expects a decimal number between 0 and 15 inclusive, usually 6 if it is an object. If not specified, the file will use VRAM instead of segmented addresses.
   - `BaseAddress`: Optional. RAM address of the file. Expects a hex number (with `0x` prefix). Default value: `0`.
   - `RangeStart`: Optional. File offset where the extraction will begin. Hex. Default value: `0x000000000`.
   - `RangeEnd`: Optional. File offset where the extraction will end. Hex. Default value: `0xFFFFFFFF`.

--- a/docs/zapd_extraction_xml_reference.md
+++ b/docs/zapd_extraction_xml_reference.md
@@ -106,6 +106,25 @@ This table summarizes if the asset will be marked `static` (✅) or not (❌)
 
 -------------------------
 
+### ExternalFile
+
+Allows ZAPD to map segmented addresses to variables declared in other files by using its XML.
+
+It is useful for objects that use variables from `gameplay_keep`, `gameplay_dangeon_keep`, `gameplay_field_keep`, etc.
+
+- Example of this tag:
+
+```xml
+<ExternalFile XmlPath="objects/gameplay_keep.xml" OutPath="objects/gameplay_keep/"/>
+```
+
+- Attributes:
+
+  - `XmlPath`: Required. The path of the XML, relative to the value set by `ExternalXMLFolder` in the configuration file.
+  - `OutPath`: Required. The path were the header for the corresponding external file is. It is used to `#include` it in the generated `.c` file.
+
+-------------------------
+
 ### Texture
 
 Textures are extracted as `.png` files.


### PR DESCRIPTION
- Fixed some significant memory leaks in ZCollision, Exporters, ZFile, ZSetMesh.
- Correct ZSkeleton reading out-of-bounds for non-flex skeletons.
- The ZFile leak was caused by non-segmented files not being freed correctly, so I changed ZAPD to assign a default segment (which is the same as the address being VRAM), wrote some more robust checking when reading on the `Segment` attribute, and deprecated `128` as a user input: from now on not declaring the segment will use the default (i.e. VRAM).

This removes 273,662,867 bytes of leaks when extracting OoT; ASan reports no more problems.

Joint work with @AngheloAlf . This should resolve #52 , with the possible exception of the last point.