### PR TITLE
Only use array lengths on static variables

### DIFF
--- a/ZAPD/Declaration.cpp
+++ b/ZAPD/Declaration.cpp
@@ -146,9 +146,11 @@ std::string Declaration::GetExternalDeclarationStr() const
 	}
 
 	if (arrayItemCntStr != "" && (IsStatic() || forceArrayCnt))
-		output += StringHelper::Sprintf("%s %s[%s] = ", varType.c_str(), varName.c_str(), arrayItemCntStr.c_str());
+		output += StringHelper::Sprintf("%s %s[%s] = ", varType.c_str(), varName.c_str(),
+		                                arrayItemCntStr.c_str());
 	else if (arrayItemCnt != 0 && (IsStatic() || forceArrayCnt))
-		output += StringHelper::Sprintf("%s %s[%i] = ", varType.c_str(), varName.c_str(), arrayItemCnt);
+		output +=
+			StringHelper::Sprintf("%s %s[%i] = ", varType.c_str(), varName.c_str(), arrayItemCnt);
 	else
 		output += StringHelper::Sprintf("%s %s[] = ", varType.c_str(), varName.c_str());
 

--- a/ZAPD/Declaration.cpp
+++ b/ZAPD/Declaration.cpp
@@ -97,14 +97,14 @@ std::string Declaration::GetNormalDeclarationStr() const
 			output += StringHelper::Sprintf("%s %s[%s];\n", varType.c_str(), varName.c_str(),
 			                                arrayItemCntStr.c_str());
 		}
-		else if (arrayItemCnt == 0)
-		{
-			output += StringHelper::Sprintf("%s %s[] = {\n", varType.c_str(), varName.c_str());
-		}
-		else
+		else if (arrayItemCnt != 0 && IsStatic())
 		{
 			output += StringHelper::Sprintf("%s %s[%i] = {\n", varType.c_str(), varName.c_str(),
 			                                arrayItemCnt);
+		}
+		else
+		{
+			output += StringHelper::Sprintf("%s %s[] = {\n", varType.c_str(), varName.c_str());
 		}
 
 		output += text + "\n";
@@ -146,15 +146,13 @@ std::string Declaration::GetExternalDeclarationStr() const
 	}
 
 	if (arrayItemCntStr != "")
-		output +=
-			StringHelper::Sprintf("%s %s[%s] = {\n#include \"%s\"\n};", varType.c_str(),
-		                          varName.c_str(), arrayItemCntStr.c_str(), includePath.c_str());
-	else if (arrayItemCnt != 0)
-		output += StringHelper::Sprintf("%s %s[%i] = {\n#include \"%s\"\n};", varType.c_str(),
-		                                varName.c_str(), arrayItemCnt, includePath.c_str());
+		output += StringHelper::Sprintf("%s %s[%s] = ", varType.c_str(), varName.c_str(), arrayItemCntStr.c_str());
+	else if (arrayItemCnt != 0 && IsStatic())
+		output += StringHelper::Sprintf("%s %s[%i] = ", varType.c_str(), varName.c_str(), arrayItemCnt);
 	else
-		output += StringHelper::Sprintf("%s %s[] = {\n#include \"%s\"\n};", varType.c_str(),
-		                                varName.c_str(), includePath.c_str());
+		output += StringHelper::Sprintf("%s %s[] = ", varType.c_str(), varName.c_str());
+
+	output += StringHelper::Sprintf("{\n#include \"%s\"\n};", includePath.c_str());
 
 	if (rightText != "")
 		output += " " + rightText + "";
@@ -183,9 +181,11 @@ std::string Declaration::GetExternStr() const
 			return StringHelper::Sprintf("extern %s %s[%s];\n", varType.c_str(), varName.c_str(),
 			                             arrayItemCntStr.c_str());
 		}
-		else if (arrayItemCnt != 0)
-			return StringHelper::Sprintf("extern %s %s[%i];\n", varType.c_str(), varName.c_str(),
-			                             arrayItemCnt);
+		//else if (arrayItemCnt != 0)
+		//{
+		//	return StringHelper::Sprintf("extern %s %s[%i];\n", varType.c_str(), varName.c_str(),
+		//	                             arrayItemCnt);
+		//}
 		else
 			return StringHelper::Sprintf("extern %s %s[];\n", varType.c_str(), varName.c_str());
 	}

--- a/ZAPD/Declaration.cpp
+++ b/ZAPD/Declaration.cpp
@@ -92,12 +92,12 @@ std::string Declaration::GetNormalDeclarationStr() const
 
 	if (isArray)
 	{
-		if (arrayItemCntStr != "")
+		if (arrayItemCntStr != "" && (IsStatic() || forceArrayCnt))
 		{
 			output += StringHelper::Sprintf("%s %s[%s];\n", varType.c_str(), varName.c_str(),
 			                                arrayItemCntStr.c_str());
 		}
-		else if (arrayItemCnt != 0 && IsStatic())
+		else if (arrayItemCnt != 0 && (IsStatic() || forceArrayCnt))
 		{
 			output += StringHelper::Sprintf("%s %s[%i] = {\n", varType.c_str(), varName.c_str(),
 			                                arrayItemCnt);
@@ -145,9 +145,9 @@ std::string Declaration::GetExternalDeclarationStr() const
 		output += "static ";
 	}
 
-	if (arrayItemCntStr != "")
+	if (arrayItemCntStr != "" && (IsStatic() || forceArrayCnt))
 		output += StringHelper::Sprintf("%s %s[%s] = ", varType.c_str(), varName.c_str(), arrayItemCntStr.c_str());
-	else if (arrayItemCnt != 0 && IsStatic())
+	else if (arrayItemCnt != 0 && (IsStatic() || forceArrayCnt))
 		output += StringHelper::Sprintf("%s %s[%i] = ", varType.c_str(), varName.c_str(), arrayItemCnt);
 	else
 		output += StringHelper::Sprintf("%s %s[] = ", varType.c_str(), varName.c_str());
@@ -176,16 +176,16 @@ std::string Declaration::GetExternStr() const
 
 	if (isArray)
 	{
-		if (arrayItemCntStr != "")
+		if (arrayItemCntStr != "" && (IsStatic() || forceArrayCnt))
 		{
 			return StringHelper::Sprintf("extern %s %s[%s];\n", varType.c_str(), varName.c_str(),
 			                             arrayItemCntStr.c_str());
 		}
-		//else if (arrayItemCnt != 0)
-		//{
-		//	return StringHelper::Sprintf("extern %s %s[%i];\n", varType.c_str(), varName.c_str(),
-		//	                             arrayItemCnt);
-		//}
+		else if (arrayItemCnt != 0 && (IsStatic() || forceArrayCnt))
+		{
+			return StringHelper::Sprintf("extern %s %s[%i];\n", varType.c_str(), varName.c_str(),
+			                             arrayItemCnt);
+		}
 		else
 			return StringHelper::Sprintf("extern %s %s[];\n", varType.c_str(), varName.c_str());
 	}

--- a/ZAPD/Declaration.h
+++ b/ZAPD/Declaration.h
@@ -38,8 +38,10 @@ public:
 	std::string varType;
 	std::string varName;
 	std::string includePath;
+
 	bool isExternal = false;
 	bool isArray = false;
+	bool forceArrayCnt = false;
 	size_t arrayItemCnt = 0;
 	std::string arrayItemCntStr;
 	std::vector<segptr_t> references;

--- a/ZAPD/ZBackground.cpp
+++ b/ZAPD/ZBackground.cpp
@@ -138,6 +138,7 @@ Declaration* ZBackground::DeclareVar(const std::string& prefix,
 	Declaration* decl = parent->AddDeclarationIncludeArray(rawDataIndex, incStr, GetRawDataSize(),
 	                                                       GetSourceTypeName(), auxName, 0);
 	decl->arrayItemCntStr = "SCREEN_WIDTH * SCREEN_HEIGHT / 4";
+	decl->forceArrayCnt = true;
 	decl->staticConf = staticConf;
 	return decl;
 }

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -1070,8 +1070,6 @@ std::string ZFile::ProcessDeclarations()
 		}
 	}
 
-	output += "\n";
-
 	return output;
 }
 

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -582,9 +582,10 @@ void PolygonType2::DeclareReferences(const std::string& prefix)
 		polyDListName = StringHelper::Sprintf("%s%s_%06X", prefix.c_str(), polyDlistType.c_str(),
 		                                      GETSEGOFFSET(start));
 
-		Declaration* decl = parent->AddDeclarationArray(GETSEGOFFSET(start), DeclarationAlignment::Align4,
-		                            polyDLists.size() * polyDLists.at(0).GetRawDataSize(),
-		                            polyDlistType, polyDListName, polyDLists.size(), declaration);
+		Declaration* decl = parent->AddDeclarationArray(
+			GETSEGOFFSET(start), DeclarationAlignment::Align4,
+			polyDLists.size() * polyDLists.at(0).GetRawDataSize(), polyDlistType, polyDListName,
+			polyDLists.size(), declaration);
 		decl->forceArrayCnt = true;
 	}
 

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -582,9 +582,10 @@ void PolygonType2::DeclareReferences(const std::string& prefix)
 		polyDListName = StringHelper::Sprintf("%s%s_%06X", prefix.c_str(), polyDlistType.c_str(),
 		                                      GETSEGOFFSET(start));
 
-		parent->AddDeclarationArray(GETSEGOFFSET(start), DeclarationAlignment::Align4,
+		Declaration* decl = parent->AddDeclarationArray(GETSEGOFFSET(start), DeclarationAlignment::Align4,
 		                            polyDLists.size() * polyDLists.at(0).GetRawDataSize(),
 		                            polyDlistType, polyDListName, polyDLists.size(), declaration);
+		decl->forceArrayCnt = true;
 	}
 
 	parent->AddDeclaration(GETSEGOFFSET(end), DeclarationAlignment::Align4, 4, "s32",


### PR DESCRIPTION
As requested array lengths are not used wherever is possible to avoid them.
Those will be still enabled for static declaration because those are needed for their corresponding forward declarations.