### PR TITLE
Remove `-Werror` enabled by default and remove `-march`/`-mtune`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
         // Non-parallel ZAPD stage
         stage('Build ZAPD') {
             steps {
-                sh 'make -j'
+                sh 'make -j WERROR=1'
             }
         }
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DEPRECATION_ON ?= 1
 DEBUG ?= 0
 COPYCHECK_ARGS ?=
 LLD ?= 0
+WERROR ?= 0
 
 # Use clang++ if available, else use g++
 ifeq ($(shell command -v clang++ >/dev/null 2>&1; echo $$?),0)
@@ -23,7 +24,9 @@ ifneq ($(DEBUG),0)
   CXXFLAGS += -g3 -DDEVELOPMENT -D_DEBUG
   COPYCHECK_ARGS += --devel
   DEPRECATION_ON = 0
-else
+endif
+
+ifneq ($(WERROR),0)
   CXXFLAGS += -Werror
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 ifeq ($(OPTIMIZATION_ON),0)
   OPTFLAGS := -O0
 else
-  OPTFLAGS := -O2 -march=native -mtune=native
+  OPTFLAGS := -O2
 endif
 
 ifneq ($(ASAN),0)


### PR DESCRIPTION
Since we can't really check that we are warning-free in every possible compiler anybody would try to build ZAPD with, I decided to disable the use of `-Werror` by default.

I added a `WERROR` variable to the Makefile, passing any non-zero value will pass `-Werror` to the compiler.
Jenkins will pass this variable to the Makefile too, so warnings will still be checked automatically.

I also removed the `-march` and `-mtune` flags because people were having problem with more modern machines.