### PR TITLE
Remove cast for scene file lists

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                             sh 'cp ../ZAPD.out tools/ZAPD/'
                             sh 'python3 tools/fixbaserom.py'
                             sh 'python3 tools/extract_baserom.py'
-                            sh 'python3 extract_assets.py -t$(nproc)'
+                            sh 'python3 extract_assets.py -j$(nproc)'
                         }
                     }
                 }

--- a/ZAPD/ZRoom/Commands/SetRoomList.cpp
+++ b/ZAPD/ZRoom/Commands/SetRoomList.cpp
@@ -105,7 +105,7 @@ std::string RomFile::GetBodySourceCode() const
 					declaration += "\n";
 
 				declaration +=
-					StringHelper::Sprintf("\t{ (u32)_%sSegmentRomStart, (u32)_%sSegmentRomEnd },",
+					StringHelper::Sprintf("\t{ (uintptr_t)_%sSegmentRomStart, (uintptr_t)_%sSegmentRomEnd },",
 				                          roomName.c_str(), roomName.c_str());
 				isFirst = false;
 			}

--- a/ZAPD/ZRoom/Commands/SetRoomList.cpp
+++ b/ZAPD/ZRoom/Commands/SetRoomList.cpp
@@ -105,7 +105,7 @@ std::string RomFile::GetBodySourceCode() const
 					declaration += "\n";
 
 				declaration +=
-					StringHelper::Sprintf("\t{ (uintptr_t)_%sSegmentRomStart, (uintptr_t)_%sSegmentRomEnd },",
+					StringHelper::Sprintf("\t{ _%sSegmentRomStart, _%sSegmentRomEnd },",
 				                          roomName.c_str(), roomName.c_str());
 				isFirst = false;
 			}


### PR DESCRIPTION
This will obviously fail on OOT until it starts using `uintptr_t`. zeldaret/oot#1089