### PR TITLE
Don't generate extern declarations for unaccounted variables

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                             sh 'cp ../ZAPD.out tools/ZAPD/'
                             sh 'python3 tools/fixbaserom.py'
                             sh 'python3 tools/extract_baserom.py'
-                            sh 'python3 extract_assets.py -t$(nproc)'
+                            sh 'python3 extract_assets.py -j $(nproc)'
                         }
                     }
                 }

--- a/ZAPD/Declaration.cpp
+++ b/ZAPD/Declaration.cpp
@@ -171,7 +171,7 @@ std::string Declaration::GetExternalDeclarationStr() const
 
 std::string Declaration::GetExternStr() const
 {
-	if (IsStatic() || varType == "")
+	if (IsStatic() || varType == "" || isUnaccounted)
 	{
 		return "";
 	}

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -776,9 +776,8 @@ Declaration* ZTexture::DeclareVar(const std::string& prefix,
 				incStr = StringHelper::Sprintf("%s.%s.inc.c", poolEntry->second.path.c_str(),
 				                               GetExternalExtension().c_str());
 			else
-				incStr =
-					StringHelper::Sprintf("%s.u32.%s.inc.c", poolEntry->second.path.c_str(),
-				                          GetExternalExtension().c_str());
+				incStr = StringHelper::Sprintf("%s.u32.%s.inc.c", poolEntry->second.path.c_str(),
+				                               GetExternalExtension().c_str());
 		}
 	}
 	size_t texSizeDivisor = (dWordAligned) ? 8 : 4;


### PR DESCRIPTION
Prevents the generation of externs in a header for unaccounted variables