### PR TITLE
Fix `CollisionHeader` extraction

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                             sh 'cp ../ZAPD.out tools/ZAPD/'
                             sh 'python3 tools/fixbaserom.py'
                             sh 'python3 tools/extract_baserom.py'
-                            sh 'python3 extract_assets.py -t$(nproc)'
+                            sh 'python3 extract_assets.py -j $(nproc)'
                         }
                     }
                 }

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -77,29 +77,34 @@ void ZCollisionHeader::ParseRawData()
 		polygonTypes.push_back(
 			BitConverter::ToUInt64BE(rawData, polyTypeDefSegmentOffset + (i * 8)));
 
-	if (camDataAddress != 0) {
+	if (camDataAddress != 0)
+	{
 		// Try to guess how many elements the CamDataList array has.
-		// The "guessing algorithm" is basically a "best effort" one and it 
+		// The "guessing algorithm" is basically a "best effort" one and it
 		// is error-prone.
 		// This is based mostly on observation of how CollisionHeader data is
 		// usually ordered. If for some reason the data was in some other funny
 		// order, this would probably break.
 		offset_t upperCameraBoundary = polyTypeDefSegmentOffset;
-		if (upperCameraBoundary == SEGMENTED_NULL) {
+		if (upperCameraBoundary == SEGMENTED_NULL)
+		{
 			upperCameraBoundary = polySegmentOffset;
 		}
-		if (upperCameraBoundary == SEGMENTED_NULL) {
+		if (upperCameraBoundary == SEGMENTED_NULL)
+		{
 			upperCameraBoundary = vtxSegmentOffset;
 		}
-		if (upperCameraBoundary == SEGMENTED_NULL) {
+		if (upperCameraBoundary == SEGMENTED_NULL)
+		{
 			upperCameraBoundary = waterBoxSegmentOffset;
 		}
-		if (upperCameraBoundary == SEGMENTED_NULL) {
+		if (upperCameraBoundary == SEGMENTED_NULL)
+		{
 			upperCameraBoundary = rawDataIndex;
 		}
 
-		camData = new CameraDataList(parent, name, rawData, camDataSegmentOffset,
-		                             upperCameraBoundary);
+		camData =
+			new CameraDataList(parent, name, rawData, camDataSegmentOffset, upperCameraBoundary);
 	}
 
 	for (uint16_t i = 0; i < numWaterBoxes; i++)
@@ -128,8 +133,7 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 
 		parent->AddDeclarationArray(
 			waterBoxSegmentOffset, DeclarationAlignment::Align4, 16 * waterBoxes.size(), "WaterBox",
-			StringHelper::Sprintf("%sWaterBoxes", auxName.c_str()),
-			waterBoxes.size(), declaration);
+			StringHelper::Sprintf("%sWaterBoxes", auxName.c_str()), waterBoxes.size(), declaration);
 	}
 
 	if (polygons.size() > 0)
@@ -148,8 +152,7 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 
 		parent->AddDeclarationArray(
 			polySegmentOffset, DeclarationAlignment::Align4, polygons.size() * 16, "CollisionPoly",
-			StringHelper::Sprintf("%sPolygons", auxName.c_str()),
-			polygons.size(), declaration);
+			StringHelper::Sprintf("%sPolygons", auxName.c_str()), polygons.size(), declaration);
 	}
 
 	declaration.clear();
@@ -163,11 +166,10 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 	}
 
 	if (polyTypeDefAddress != 0)
-		parent->AddDeclarationArray(
-			polyTypeDefSegmentOffset, DeclarationAlignment::Align4, polygonTypes.size() * 8,
-			"SurfaceType",
-			StringHelper::Sprintf("%sSurfaceType", auxName.c_str()),
-			polygonTypes.size(), declaration);
+		parent->AddDeclarationArray(polyTypeDefSegmentOffset, DeclarationAlignment::Align4,
+		                            polygonTypes.size() * 8, "SurfaceType",
+		                            StringHelper::Sprintf("%sSurfaceType", auxName.c_str()),
+		                            polygonTypes.size(), declaration);
 
 	declaration.clear();
 
@@ -189,8 +191,7 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 			parent->AddDeclarationArray(
 				vtxSegmentOffset, first.GetDeclarationAlignment(),
 				vertices.size() * first.GetRawDataSize(), first.GetSourceTypeName(),
-				StringHelper::Sprintf("%sVertices", auxName.c_str()),
-				vertices.size(), declaration);
+				StringHelper::Sprintf("%sVertices", auxName.c_str()), vertices.size(), declaration);
 	}
 }
 
@@ -361,10 +362,9 @@ CameraDataList::CameraDataList(ZFile* parent, const std::string& prefix,
 
 		int32_t cameraPosDataIndex = GETSEGOFFSET(cameraPosDataSeg);
 		uint32_t entrySize = numDataTotal * 0x6;
-		parent->AddDeclarationArray(
-			cameraPosDataIndex, DeclarationAlignment::Align4, entrySize, "Vec3s",
-			StringHelper::Sprintf("%sCamPosData", prefix.c_str()),
-			numDataTotal, declaration);
+		parent->AddDeclarationArray(cameraPosDataIndex, DeclarationAlignment::Align4, entrySize,
+		                            "Vec3s", StringHelper::Sprintf("%sCamPosData", prefix.c_str()),
+		                            numDataTotal, declaration);
 	}
 }
 

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -123,7 +123,7 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 
 		parent->AddDeclarationArray(
 			waterBoxSegmentOffset, DeclarationAlignment::Align4, 16 * waterBoxes.size(), "WaterBox",
-			StringHelper::Sprintf("%s_waterBoxes_%06X", auxName.c_str(), waterBoxSegmentOffset),
+			StringHelper::Sprintf("%sWaterBoxes", auxName.c_str()),
 			waterBoxes.size(), declaration);
 	}
 
@@ -143,7 +143,7 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 
 		parent->AddDeclarationArray(
 			polySegmentOffset, DeclarationAlignment::Align4, polygons.size() * 16, "CollisionPoly",
-			StringHelper::Sprintf("%s_polygons_%08X", auxName.c_str(), polySegmentOffset),
+			StringHelper::Sprintf("%sPolygons", auxName.c_str()),
 			polygons.size(), declaration);
 	}
 
@@ -161,7 +161,7 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 		parent->AddDeclarationArray(
 			polyTypeDefSegmentOffset, DeclarationAlignment::Align4, polygonTypes.size() * 8,
 			"SurfaceType",
-			StringHelper::Sprintf("%s_surfaceType_%08X", auxName.c_str(), polyTypeDefSegmentOffset),
+			StringHelper::Sprintf("%sSurfaceType", auxName.c_str()),
 			polygonTypes.size(), declaration);
 
 	declaration.clear();
@@ -184,7 +184,7 @@ void ZCollisionHeader::DeclareReferences(const std::string& prefix)
 			parent->AddDeclarationArray(
 				vtxSegmentOffset, first.GetDeclarationAlignment(),
 				vertices.size() * first.GetRawDataSize(), first.GetSourceTypeName(),
-				StringHelper::Sprintf("%s_vtx_%08X", auxName.c_str(), vtxSegmentOffset),
+				StringHelper::Sprintf("%sVertices", auxName.c_str()),
 				vertices.size(), declaration);
 	}
 }
@@ -320,8 +320,7 @@ CameraDataList::CameraDataList(ZFile* parent, const std::string& prefix,
 		{
 			int32_t index =
 				((entries[i]->cameraPosDataSeg & 0x00FFFFFF) - cameraPosDataOffset) / 0x6;
-			sprintf(camSegLine, "&%s_camPosData_%08X[%i]", prefix.c_str(), cameraPosDataOffset,
-			        index);
+			sprintf(camSegLine, "&%sCamPosData[%i]", prefix.c_str(), index);
 		}
 		else
 			sprintf(camSegLine, "NULL");
@@ -336,7 +335,7 @@ CameraDataList::CameraDataList(ZFile* parent, const std::string& prefix,
 
 	parent->AddDeclarationArray(
 		rawDataIndex, DeclarationAlignment::Align4, entries.size() * 8, "CamData",
-		StringHelper::Sprintf("%s_camDataList_%08X", prefix.c_str(), rawDataIndex), entries.size(),
+		StringHelper::Sprintf("%sCamDataList", prefix.c_str(), rawDataIndex), entries.size(),
 		declaration);
 
 	uint32_t numDataTotal = (rawDataIndex - cameraPosDataOffset) / 0x6;
@@ -359,7 +358,7 @@ CameraDataList::CameraDataList(ZFile* parent, const std::string& prefix,
 		uint32_t entrySize = numDataTotal * 0x6;
 		parent->AddDeclarationArray(
 			cameraPosDataIndex, DeclarationAlignment::Align4, entrySize, "Vec3s",
-			StringHelper::Sprintf("%s_camPosData_%08X", prefix.c_str(), cameraPosDataIndex),
+			StringHelper::Sprintf("%sCamPosData", prefix.c_str()),
 			numDataTotal, declaration);
 	}
 }

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -85,6 +85,12 @@ void ZCollisionHeader::ParseRawData()
 		// This is based mostly on observation of how CollisionHeader data is
 		// usually ordered. If for some reason the data was in some other funny
 		// order, this would probably break.
+		// The most common ordering is:
+		// - *CamData*
+		// - SurfaceType
+		// - CollisionPoly
+		// - Vertices
+		// - WaterBoxes
 		offset_t upperCameraBoundary = polyTypeDefSegmentOffset;
 		if (upperCameraBoundary == 0)
 		{

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -77,7 +77,7 @@ void ZCollisionHeader::ParseRawData()
 		polygonTypes.push_back(
 			BitConverter::ToUInt64BE(rawData, polyTypeDefSegmentOffset + (i * 8)));
 
-	if (camDataAddress != 0)
+	if (camDataAddress != SEGMENTED_NULL)
 	{
 		// Try to guess how many elements the CamDataList array has.
 		// The "guessing algorithm" is basically a "best effort" one and it
@@ -86,19 +86,19 @@ void ZCollisionHeader::ParseRawData()
 		// usually ordered. If for some reason the data was in some other funny
 		// order, this would probably break.
 		offset_t upperCameraBoundary = polyTypeDefSegmentOffset;
-		if (upperCameraBoundary == SEGMENTED_NULL)
+		if (upperCameraBoundary == 0)
 		{
 			upperCameraBoundary = polySegmentOffset;
 		}
-		if (upperCameraBoundary == SEGMENTED_NULL)
+		if (upperCameraBoundary == 0)
 		{
 			upperCameraBoundary = vtxSegmentOffset;
 		}
-		if (upperCameraBoundary == SEGMENTED_NULL)
+		if (upperCameraBoundary == 0)
 		{
 			upperCameraBoundary = waterBoxSegmentOffset;
 		}
-		if (upperCameraBoundary == SEGMENTED_NULL)
+		if (upperCameraBoundary == 0)
 		{
 			upperCameraBoundary = rawDataIndex;
 		}

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -91,6 +91,7 @@ void ZCollisionHeader::ParseRawData()
 		// - CollisionPoly
 		// - Vertices
 		// - WaterBoxes
+		// - CollisionHeader
 		offset_t upperCameraBoundary = polyTypeDefSegmentOffset;
 		if (upperCameraBoundary == 0)
 		{

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -78,7 +78,12 @@ void ZCollisionHeader::ParseRawData()
 			BitConverter::ToUInt64BE(rawData, polyTypeDefSegmentOffset + (i * 8)));
 
 	if (camDataAddress != 0) {
-		// Try to guess how many elements the CamDataList array has
+		// Try to guess how many elements the CamDataList array has.
+		// The "guessing algorithm" is basically a "best effort" one and it 
+		// is error-prone.
+		// This is based mostly on observation of how CollisionHeader data is
+		// usually ordered. If for some reason the data was in some other funny
+		// order, this would probably break.
 		offset_t upperCameraBoundary = polyTypeDefSegmentOffset;
 		if (upperCameraBoundary == SEGMENTED_NULL) {
 			upperCameraBoundary = polySegmentOffset;

--- a/ZAPD/ZCollision.h
+++ b/ZAPD/ZCollision.h
@@ -55,8 +55,7 @@ public:
 	std::vector<CameraPositionData*> cameraPositionData;
 
 	CameraDataList(ZFile* parent, const std::string& prefix, const std::vector<uint8_t>& rawData,
-	               uint32_t rawDataIndex, uint32_t polyTypeDefSegmentOffset,
-	               uint32_t polygonTypesCnt);
+	               offset_t rawDataIndex, offset_t upperCameraBoundary);
 	~CameraDataList();
 };
 

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -776,9 +776,8 @@ Declaration* ZTexture::DeclareVar(const std::string& prefix,
 				incStr = StringHelper::Sprintf("%s.%s.inc.c", poolEntry->second.path.c_str(),
 				                               GetExternalExtension().c_str());
 			else
-				incStr =
-					StringHelper::Sprintf("%s.u32.%s.inc.c", poolEntry->second.path.c_str(),
-				                          GetExternalExtension().c_str());
+				incStr = StringHelper::Sprintf("%s.u32.%s.inc.c", poolEntry->second.path.c_str(),
+				                               GetExternalExtension().c_str());
 		}
 	}
 	size_t texSizeDivisor = (dWordAligned) ? 8 : 4;


### PR DESCRIPTION
Fixes a bug when trying to extract a `CollisionHeader` which has `CamData` but no `surfaceTypeList`.

To replicate the current bug, use this collision node in the `object_oyu`  XML of MM:

```xml
        <Collision Name="object_oyu_Colheader_000988" Offset="0x988" />
```

Also improved the names of autogenerated variables used by the extracted collision header