### PR TITLE
Warn hardcoded pointers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
                             sh 'cp ../ZAPD.out tools/ZAPD/'
                             sh 'python3 tools/fixbaserom.py'
                             sh 'python3 tools/extract_baserom.py'
-                            sh 'python3 extract_assets.py -t$(nproc)'
+                            sh 'python3 extract_assets.py -j $(nproc)'
                         }
                     }
                 }

--- a/README.md
+++ b/README.md
@@ -144,22 +144,23 @@ Each warning type uses one of these by default, but can be modified with flags, 
 
 All warning types currently implemented, with their default levels:
 
-| Warning type                | Default level | Description                                                              |
-| --------------------------- | ------------- | ------------------------------------------------------------------------ |
-| `-Wdeprecated`              | Warn          | Deprecated features                                                      |
-| `-Whardcoded-pointer`       | Warn          | ZAPD lacks the info to make a symbol, so must output a hardcoded pointer |
-| `-Wintersection`            | Warn          | Two assets intersect                                                     |
-| `-Winvalid-attribute-value` | Err           | Attribute declared in XML is wrong                                       |
-| `-Winvalid-extracted-data`  | Err           | Extracted data does not have correct form                                |
-| `-Winvalid-jpeg`            | Err           | JPEG file does not conform to the game's format requirements             |
-| `-Winvalid-png`             | Err           | Issues arising when processing PNG data                                  |
-| `-Winvalid-xml`             | Err           | XML has syntax errors                                                    |
-| `-Wmissing-attribute`       | Warn          | Required attribute missing in XML tag                                    |
-| `-Wmissing-offsets`         | Warn          | Offset attribute missing in XML tag                                      |
-| `-Wmissing-segment`         | Warn          | Segment not given in File tag in XML                                     |
-| `-Wnot-implemented`         | Warn          | ZAPD does not currently support this feature                             |
-| `-Wunaccounted`             | Off           | Large blocks of unaccounted                                              |
-| `-Wunknown-attribute`       | Warn          | Unknown attribute in XML entry tag                                       |
+| Warning type                  | Default level | Description                                                              |
+| ----------------------------- | ------------- | ------------------------------------------------------------------------ |
+| `-Wdeprecated`                | Warn          | Deprecated features                                                      |
+| `-Whardcoded-generic-pointer` | Off           | A generic segmented pointer must be produced                             |
+| `-Whardcoded-pointer`         | Warn          | ZAPD lacks the info to make a symbol, so must output a hardcoded pointer |
+| `-Wintersection`              | Warn          | Two assets intersect                                                     |
+| `-Winvalid-attribute-value`   | Err           | Attribute declared in XML is wrong                                       |
+| `-Winvalid-extracted-data`    | Err           | Extracted data does not have correct form                                |
+| `-Winvalid-jpeg`              | Err           | JPEG file does not conform to the game's format requirements             |
+| `-Winvalid-png`               | Err           | Issues arising when processing PNG data                                  |
+| `-Winvalid-xml`               | Err           | XML has syntax errors                                                    |
+| `-Wmissing-attribute`         | Warn          | Required attribute missing in XML tag                                    |
+| `-Wmissing-offsets`           | Warn          | Offset attribute missing in XML tag                                      |
+| `-Wmissing-segment`           | Warn          | Segment not given in File tag in XML                                     |
+| `-Wnot-implemented`           | Warn          | ZAPD does not currently support this feature                             |
+| `-Wunaccounted`               | Off           | Large blocks of unaccounted                                              |
+| `-Wunknown-attribute`         | Warn          | Unknown attribute in XML entry tag                                       |
 
 There are also errors that do not have a type, and cannot be disabled.
 

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -83,9 +83,9 @@ ExporterSet* Globals::GetExporterSet()
 }
 
 bool Globals::GetSegmentedPtrName(segptr_t segAddress, ZFile* currentFile,
-                                  const std::string& expectedType, std::string& declName)
+                                  const std::string& expectedType, std::string& declName, bool warnIfNotFound)
 {
-	if (segAddress == 0)
+	if (segAddress == SEGMENTED_NULL)
 	{
 		declName = "NULL";
 		return true;
@@ -160,7 +160,7 @@ bool Globals::GetSegmentedPtrName(segptr_t segAddress, ZFile* currentFile,
 	}
 
 	declName = StringHelper::Sprintf("0x%08X", segAddress);
-	if (segment <= 6 || segment == 0x80) {
+	if (warnIfNotFound && ((segment >= 2 && segment <= 6) || segment == 0x80)) {
 		std::string errorHeader = "A hardcoded pointer was found";
 		std::string errorBody = StringHelper::Sprintf("Pointer: 0x%08X", segAddress);
 
@@ -171,9 +171,9 @@ bool Globals::GetSegmentedPtrName(segptr_t segAddress, ZFile* currentFile,
 
 bool Globals::GetSegmentedArrayIndexedName(segptr_t segAddress, size_t elementSize,
                                            ZFile* currentFile, const std::string& expectedType,
-                                           std::string& declName)
+                                           std::string& declName, bool warnIfNotFound)
 {
-	if (segAddress == 0)
+	if (segAddress == SEGMENTED_NULL)
 	{
 		declName = "NULL";
 		return true;
@@ -203,7 +203,7 @@ bool Globals::GetSegmentedArrayIndexedName(segptr_t segAddress, size_t elementSi
 	}
 
 	declName = StringHelper::Sprintf("0x%08X", segAddress);
-	if (segment <= 6 || segment == 0x80) {
+	if (warnIfNotFound && ((segment >= 2 && segment <= 6) || segment == 0x80)) {
 		std::string errorHeader = "A hardcoded pointer was found";
 		std::string errorBody = StringHelper::Sprintf("Pointer: 0x%08X", segAddress);
 

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -160,6 +160,12 @@ bool Globals::GetSegmentedPtrName(segptr_t segAddress, ZFile* currentFile,
 	}
 
 	declName = StringHelper::Sprintf("0x%08X", segAddress);
+	if (segment <= 6 || segment == 0x80) {
+		std::string errorHeader = "A hardcoded pointer was found";
+		std::string errorBody = StringHelper::Sprintf("Pointer: 0x%08X", segAddress);
+
+		HANDLE_WARNING_RESOURCE(WarningType::HardcodedPointer, currentFile, nullptr, -1, errorHeader, errorBody);
+	}
 	return false;
 }
 
@@ -197,6 +203,12 @@ bool Globals::GetSegmentedArrayIndexedName(segptr_t segAddress, size_t elementSi
 	}
 
 	declName = StringHelper::Sprintf("0x%08X", segAddress);
+	if (segment <= 6 || segment == 0x80) {
+		std::string errorHeader = "A hardcoded pointer was found";
+		std::string errorBody = StringHelper::Sprintf("Pointer: 0x%08X", segAddress);
+
+		HANDLE_WARNING_RESOURCE(WarningType::HardcodedPointer, currentFile, nullptr, -1, errorHeader, errorBody);
+	}
 	return false;
 }
 

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -216,6 +216,12 @@ void Globals::WarnHardcodedPointer(segptr_t segAddress, ZFile* currentFile, ZRes
 
 		HANDLE_WARNING_RESOURCE(WarningType::HardcodedPointer, currentFile, res, currentOffset, errorHeader, errorBody);
 	}
+	else {
+		std::string errorHeader = "A general purpose hardcoded pointer was found";
+		std::string errorBody = StringHelper::Sprintf("Pointer: 0x%08X", segAddress);
+
+		HANDLE_WARNING_RESOURCE(WarningType::HardcodedGenericPointer, currentFile, res, currentOffset, errorHeader, errorBody);
+	}
 }
 
 ExternalFile::ExternalFile(fs::path nXmlPath, fs::path nOutPath)

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -83,7 +83,8 @@ ExporterSet* Globals::GetExporterSet()
 }
 
 bool Globals::GetSegmentedPtrName(segptr_t segAddress, ZFile* currentFile,
-                                  const std::string& expectedType, std::string& declName, bool warnIfNotFound)
+                                  const std::string& expectedType, std::string& declName,
+                                  bool warnIfNotFound)
 {
 	if (segAddress == SEGMENTED_NULL)
 	{
@@ -160,7 +161,8 @@ bool Globals::GetSegmentedPtrName(segptr_t segAddress, ZFile* currentFile,
 	}
 
 	declName = StringHelper::Sprintf("0x%08X", segAddress);
-	if (warnIfNotFound) {
+	if (warnIfNotFound)
+	{
 		WarnHardcodedPointer(segAddress, currentFile, nullptr, -1);
 	}
 	return false;
@@ -200,27 +202,33 @@ bool Globals::GetSegmentedArrayIndexedName(segptr_t segAddress, size_t elementSi
 	}
 
 	declName = StringHelper::Sprintf("0x%08X", segAddress);
-	if (warnIfNotFound) {
+	if (warnIfNotFound)
+	{
 		WarnHardcodedPointer(segAddress, currentFile, nullptr, -1);
 	}
 	return false;
 }
 
-void Globals::WarnHardcodedPointer(segptr_t segAddress, ZFile* currentFile, ZResource* res, offset_t currentOffset)
+void Globals::WarnHardcodedPointer(segptr_t segAddress, ZFile* currentFile, ZResource* res,
+                                   offset_t currentOffset)
 {
 	uint8_t segment = GETSEGNUM(segAddress);
 
-	if ((segment >= 2 && segment <= 6) || segment == 0x80) {
+	if ((segment >= 2 && segment <= 6) || segment == 0x80)
+	{
 		std::string errorHeader = "A hardcoded pointer was found";
 		std::string errorBody = StringHelper::Sprintf("Pointer: 0x%08X", segAddress);
 
-		HANDLE_WARNING_RESOURCE(WarningType::HardcodedPointer, currentFile, res, currentOffset, errorHeader, errorBody);
+		HANDLE_WARNING_RESOURCE(WarningType::HardcodedPointer, currentFile, res, currentOffset,
+		                        errorHeader, errorBody);
 	}
-	else {
+	else
+	{
 		std::string errorHeader = "A general purpose hardcoded pointer was found";
 		std::string errorBody = StringHelper::Sprintf("Pointer: 0x%08X", segAddress);
 
-		HANDLE_WARNING_RESOURCE(WarningType::HardcodedGenericPointer, currentFile, res, currentOffset, errorHeader, errorBody);
+		HANDLE_WARNING_RESOURCE(WarningType::HardcodedGenericPointer, currentFile, res,
+		                        currentOffset, errorHeader, errorBody);
 	}
 }
 

--- a/ZAPD/Globals.cpp
+++ b/ZAPD/Globals.cpp
@@ -160,11 +160,8 @@ bool Globals::GetSegmentedPtrName(segptr_t segAddress, ZFile* currentFile,
 	}
 
 	declName = StringHelper::Sprintf("0x%08X", segAddress);
-	if (warnIfNotFound && ((segment >= 2 && segment <= 6) || segment == 0x80)) {
-		std::string errorHeader = "A hardcoded pointer was found";
-		std::string errorBody = StringHelper::Sprintf("Pointer: 0x%08X", segAddress);
-
-		HANDLE_WARNING_RESOURCE(WarningType::HardcodedPointer, currentFile, nullptr, -1, errorHeader, errorBody);
+	if (warnIfNotFound) {
+		WarnHardcodedPointer(segAddress, currentFile, nullptr, -1);
 	}
 	return false;
 }
@@ -203,13 +200,22 @@ bool Globals::GetSegmentedArrayIndexedName(segptr_t segAddress, size_t elementSi
 	}
 
 	declName = StringHelper::Sprintf("0x%08X", segAddress);
-	if (warnIfNotFound && ((segment >= 2 && segment <= 6) || segment == 0x80)) {
+	if (warnIfNotFound) {
+		WarnHardcodedPointer(segAddress, currentFile, nullptr, -1);
+	}
+	return false;
+}
+
+void Globals::WarnHardcodedPointer(segptr_t segAddress, ZFile* currentFile, ZResource* res, offset_t currentOffset)
+{
+	uint8_t segment = GETSEGNUM(segAddress);
+
+	if ((segment >= 2 && segment <= 6) || segment == 0x80) {
 		std::string errorHeader = "A hardcoded pointer was found";
 		std::string errorBody = StringHelper::Sprintf("Pointer: 0x%08X", segAddress);
 
-		HANDLE_WARNING_RESOURCE(WarningType::HardcodedPointer, currentFile, nullptr, -1, errorHeader, errorBody);
+		HANDLE_WARNING_RESOURCE(WarningType::HardcodedPointer, currentFile, res, currentOffset, errorHeader, errorBody);
 	}
-	return false;
 }
 
 ExternalFile::ExternalFile(fs::path nXmlPath, fs::path nOutPath)

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -86,11 +86,14 @@ public:
 	 * in which case `declName` will be set to the address formatted as a pointer.
 	 */
 	bool GetSegmentedPtrName(segptr_t segAddress, ZFile* currentFile,
-	                         const std::string& expectedType, std::string& declName, bool warnIfNotFound=true);
+	                         const std::string& expectedType, std::string& declName,
+	                         bool warnIfNotFound = true);
 
 	bool GetSegmentedArrayIndexedName(segptr_t segAddress, size_t elementSize, ZFile* currentFile,
-	                                  const std::string& expectedType, std::string& declName, bool warnIfNotFound=true);
+	                                  const std::string& expectedType, std::string& declName,
+	                                  bool warnIfNotFound = true);
 
 	// TODO: consider moving to another place
-	void WarnHardcodedPointer(segptr_t segAddress, ZFile* currentFile, ZResource* res, offset_t currentOffset);
+	void WarnHardcodedPointer(segptr_t segAddress, ZFile* currentFile, ZResource* res,
+	                          offset_t currentOffset);
 };

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -86,8 +86,8 @@ public:
 	 * in which case `declName` will be set to the address formatted as a pointer.
 	 */
 	bool GetSegmentedPtrName(segptr_t segAddress, ZFile* currentFile,
-	                         const std::string& expectedType, std::string& declName);
+	                         const std::string& expectedType, std::string& declName, bool warnIfNotFound=true);
 
 	bool GetSegmentedArrayIndexedName(segptr_t segAddress, size_t elementSize, ZFile* currentFile,
-	                                  const std::string& expectedType, std::string& declName);
+	                                  const std::string& expectedType, std::string& declName, bool warnIfNotFound=true);
 };

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -90,4 +90,7 @@ public:
 
 	bool GetSegmentedArrayIndexedName(segptr_t segAddress, size_t elementSize, ZFile* currentFile,
 	                                  const std::string& expectedType, std::string& declName, bool warnIfNotFound=true);
+
+	// TODO: consider moving to another place
+	void WarnHardcodedPointer(segptr_t segAddress, ZFile* currentFile, ZResource* res, offset_t currentOffset);
 };

--- a/ZAPD/WarningHandler.cpp
+++ b/ZAPD/WarningHandler.cpp
@@ -221,7 +221,10 @@ void WarningHandler::ExtractedFilePreamble(const ZFile *parent, const ZResource*
     if (res != nullptr) {
         fprintf(stderr, "resource '%s' at ", res->GetName().c_str());
     }
-    fprintf(stderr, "offset 0x%06X: \n\t", offset); 
+    if (offset != static_cast<uint32_t>(-1)) {
+        fprintf(stderr, "offset 0x%06X:", offset);
+    }
+    fprintf(stderr, "\n\t");
 }
 
 /**

--- a/ZAPD/WarningHandler.cpp
+++ b/ZAPD/WarningHandler.cpp
@@ -84,26 +84,27 @@ typedef struct
  */
 // clang-format off
 static const std::unordered_map<std::string, WarningInfoInit> warningStringToInitMap = {
-    {"deprecated",              {WarningType::Deprecated,
+    {"deprecated",                  {WarningType::Deprecated,
 #ifdef DEPRECATION_ON
     WarningLevel::Warn,
 #else
     WarningLevel::Off,
 #endif
     "Deprecated features"}},
-    {"unaccounted",             {WarningType::Unaccounted,           WarningLevel::Off,  "Large blocks of unaccounted"}},
-    {"missing-offsets",         {WarningType::MissingOffsets,        WarningLevel::Warn, "Offset attribute missing in XML tag"}},
-    {"intersection",            {WarningType::Intersection,          WarningLevel::Warn, "Two assets intersect"}},
-    {"missing-attribute",       {WarningType::MissingAttribute,      WarningLevel::Warn, "Required attribute missing in XML tag"}},
-    {"invalid-attribute-value", {WarningType::InvalidAttributeValue, WarningLevel::Err,  "Attribute declared in XML is wrong"}},
-    {"unknown-attribute",       {WarningType::UnknownAttribute,      WarningLevel::Warn, "Unknown attribute in XML entry tag"}},
-    {"invalid-xml",             {WarningType::InvalidXML,            WarningLevel::Err,  "XML has syntax errors"}},
-    {"invalid-jpeg",            {WarningType::InvalidJPEG,           WarningLevel::Err,  "JPEG file does not conform to the game's format requirements"}},
-    {"invalid-png",             {WarningType::InvalidPNG,            WarningLevel::Err,  "Issues arising when processing PNG data"}},
-    {"invalid-extracted-data",  {WarningType::InvalidExtractedData,  WarningLevel::Err,  "Extracted data does not have correct form"}},
-    {"missing-segment",         {WarningType::MissingSegment,        WarningLevel::Warn, "Segment not given in File tag in XML"}},
-    {"hardcoded-pointer",       {WarningType::HardcodedPointer,      WarningLevel::Warn, "ZAPD lacks the info to make a symbol, so must output a hardcoded pointer"}},
-    {"not-implemented",         {WarningType::NotImplemented,        WarningLevel::Warn, "ZAPD does not currently support this feature"}},
+    {"unaccounted",                 {WarningType::Unaccounted,              WarningLevel::Off,  "Large blocks of unaccounted"}},
+    {"missing-offsets",             {WarningType::MissingOffsets,           WarningLevel::Warn, "Offset attribute missing in XML tag"}},
+    {"intersection",                {WarningType::Intersection,             WarningLevel::Warn, "Two assets intersect"}},
+    {"missing-attribute",           {WarningType::MissingAttribute,         WarningLevel::Warn, "Required attribute missing in XML tag"}},
+    {"invalid-attribute-value",     {WarningType::InvalidAttributeValue,    WarningLevel::Err,  "Attribute declared in XML is wrong"}},
+    {"unknown-attribute",           {WarningType::UnknownAttribute,         WarningLevel::Warn, "Unknown attribute in XML entry tag"}},
+    {"invalid-xml",                 {WarningType::InvalidXML,               WarningLevel::Err,  "XML has syntax errors"}},
+    {"invalid-jpeg",                {WarningType::InvalidJPEG,              WarningLevel::Err,  "JPEG file does not conform to the game's format requirements"}},
+    {"invalid-png",                 {WarningType::InvalidPNG,               WarningLevel::Err,  "Issues arising when processing PNG data"}},
+    {"invalid-extracted-data",      {WarningType::InvalidExtractedData,     WarningLevel::Err,  "Extracted data does not have correct form"}},
+    {"missing-segment",             {WarningType::MissingSegment,           WarningLevel::Warn, "Segment not given in File tag in XML"}},
+    {"hardcoded-generic-pointer",   {WarningType::HardcodedGenericPointer,  WarningLevel::Off,  "A generic segmented pointer must be produced"}},
+    {"hardcoded-pointer",           {WarningType::HardcodedPointer,         WarningLevel::Warn, "ZAPD lacks the info to make a symbol, so must output a hardcoded pointer"}},
+    {"not-implemented",             {WarningType::NotImplemented,           WarningLevel::Warn, "ZAPD does not currently support this feature"}},
 };
 
 /**

--- a/ZAPD/WarningHandler.h
+++ b/ZAPD/WarningHandler.h
@@ -81,6 +81,7 @@ enum class WarningType
 	InvalidExtractedData,
 	MissingSegment,
 	HardcodedPointer,
+	HardcodedGenericPointer,
 	NotImplemented,
 	Max,
 };

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -1707,7 +1707,8 @@ static int32_t GfxdCallback_DisplayList(uint32_t seg)
 	uint32_t dListSegNum = GETSEGNUM(seg);
 
 	std::string dListName = "";
-	bool addressFound = Globals::Instance->GetSegmentedPtrName(seg, self->parent, "Gfx", dListName, false);
+	bool addressFound =
+		Globals::Instance->GetSegmentedPtrName(seg, self->parent, "Gfx", dListName, false);
 
 	if (!addressFound)
 	{
@@ -1723,7 +1724,8 @@ static int32_t GfxdCallback_DisplayList(uint32_t seg)
 		}
 		else
 		{
-			Globals::Instance->WarnHardcodedPointer(seg, self->parent, self, self->GetRawDataIndex());
+			Globals::Instance->WarnHardcodedPointer(seg, self->parent, self,
+			                                        self->GetRawDataIndex());
 		}
 	}
 
@@ -1737,7 +1739,8 @@ static int32_t GfxdCallback_Matrix(uint32_t seg)
 	std::string mtxName;
 	ZDisplayList* self = static_cast<ZDisplayList*>(gfxd_udata_get());
 
-	bool addressFound = Globals::Instance->GetSegmentedPtrName(seg, self->parent, "Mtx", mtxName, false);
+	bool addressFound =
+		Globals::Instance->GetSegmentedPtrName(seg, self->parent, "Mtx", mtxName, false);
 
 	if (!addressFound)
 	{
@@ -1759,7 +1762,8 @@ static int32_t GfxdCallback_Matrix(uint32_t seg)
 		}
 		else
 		{
-			Globals::Instance->WarnHardcodedPointer(seg, self->parent, self, self->GetRawDataIndex());
+			Globals::Instance->WarnHardcodedPointer(seg, self->parent, self,
+			                                        self->GetRawDataIndex());
 		}
 	}
 

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -1707,7 +1707,7 @@ static int32_t GfxdCallback_DisplayList(uint32_t seg)
 	uint32_t dListSegNum = GETSEGNUM(seg);
 
 	std::string dListName = "";
-	bool addressFound = Globals::Instance->GetSegmentedPtrName(seg, self->parent, "Gfx", dListName);
+	bool addressFound = Globals::Instance->GetSegmentedPtrName(seg, self->parent, "Gfx", dListName, false);
 
 	if (!addressFound && self->parent->segment == dListSegNum)
 	{
@@ -1730,7 +1730,7 @@ static int32_t GfxdCallback_Matrix(uint32_t seg)
 	std::string mtxName;
 	ZDisplayList* self = static_cast<ZDisplayList*>(gfxd_udata_get());
 
-	bool addressFound = Globals::Instance->GetSegmentedPtrName(seg, self->parent, "Mtx", mtxName);
+	bool addressFound = Globals::Instance->GetSegmentedPtrName(seg, self->parent, "Mtx", mtxName, false);
 	if (!addressFound && GETSEGNUM(seg) == self->parent->segment)
 	{
 		Declaration* decl =

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -1709,15 +1709,22 @@ static int32_t GfxdCallback_DisplayList(uint32_t seg)
 	std::string dListName = "";
 	bool addressFound = Globals::Instance->GetSegmentedPtrName(seg, self->parent, "Gfx", dListName, false);
 
-	if (!addressFound && self->parent->segment == dListSegNum)
+	if (!addressFound)
 	{
-		ZDisplayList* newDList = new ZDisplayList(self->parent);
-		newDList->ExtractFromBinary(
-			dListOffset,
-			self->GetDListLength(self->parent->GetRawData(), dListOffset, self->dListType));
-		newDList->SetName(newDList->GetDefaultName(self->parent->GetName()));
-		self->otherDLists.push_back(newDList);
-		dListName = newDList->GetName();
+		if (self->parent->segment == dListSegNum)
+		{
+			ZDisplayList* newDList = new ZDisplayList(self->parent);
+			newDList->ExtractFromBinary(
+				dListOffset,
+				self->GetDListLength(self->parent->GetRawData(), dListOffset, self->dListType));
+			newDList->SetName(newDList->GetDefaultName(self->parent->GetName()));
+			self->otherDLists.push_back(newDList);
+			dListName = newDList->GetName();
+		}
+		else
+		{
+			Globals::Instance->WarnHardcodedPointer(seg, self->parent, self, self->GetRawDataIndex());
+		}
 	}
 
 	gfxd_puts(dListName.c_str());
@@ -1731,20 +1738,28 @@ static int32_t GfxdCallback_Matrix(uint32_t seg)
 	ZDisplayList* self = static_cast<ZDisplayList*>(gfxd_udata_get());
 
 	bool addressFound = Globals::Instance->GetSegmentedPtrName(seg, self->parent, "Mtx", mtxName, false);
-	if (!addressFound && GETSEGNUM(seg) == self->parent->segment)
-	{
-		Declaration* decl =
-			self->parent->GetDeclaration(Seg2Filespace(seg, self->parent->baseAddress));
-		if (decl == nullptr)
-		{
-			ZMtx mtx(self->parent);
-			mtx.SetName(mtx.GetDefaultName(self->GetName()));
-			mtx.ExtractFromFile(Seg2Filespace(seg, self->parent->baseAddress));
-			mtx.DeclareVar(self->GetName(), "");
 
-			mtx.GetSourceOutputCode(self->GetName());
-			self->mtxList.push_back(mtx);
-			mtxName = "&" + mtx.GetName();
+	if (!addressFound)
+	{
+		if (GETSEGNUM(seg) == self->parent->segment)
+		{
+			Declaration* decl =
+				self->parent->GetDeclaration(Seg2Filespace(seg, self->parent->baseAddress));
+			if (decl == nullptr)
+			{
+				ZMtx mtx(self->parent);
+				mtx.SetName(mtx.GetDefaultName(self->GetName()));
+				mtx.ExtractFromFile(Seg2Filespace(seg, self->parent->baseAddress));
+				mtx.DeclareVar(self->GetName(), "");
+
+				mtx.GetSourceOutputCode(self->GetName());
+				self->mtxList.push_back(mtx);
+				mtxName = "&" + mtx.GetName();
+			}
+		}
+		else
+		{
+			Globals::Instance->WarnHardcodedPointer(seg, self->parent, self, self->GetRawDataIndex());
 		}
 	}
 

--- a/ZAPD/ZLimb.cpp
+++ b/ZAPD/ZLimb.cpp
@@ -367,7 +367,7 @@ void ZLimb::DeclareDList(segptr_t dListSegmentedPtr, const std::string& prefix,
 
 	std::string dlistName;
 	bool declFound = Globals::Instance->GetSegmentedArrayIndexedName(dListSegmentedPtr, 8, parent,
-	                                                                 "Gfx", dlistName);
+	                                                                 "Gfx", dlistName, false);
 	if (declFound)
 		return;
 

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -143,7 +143,7 @@ void PathwayEntry::DeclareReferences(const std::string& prefix)
 
 	std::string pointsName;
 	bool addressFound =
-		Globals::Instance->GetSegmentedPtrName(listSegmentAddress, parent, "Vec3s", pointsName);
+		Globals::Instance->GetSegmentedPtrName(listSegmentAddress, parent, "Vec3s", pointsName, false);
 	if (addressFound)
 		return;
 

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -142,8 +142,8 @@ void PathwayEntry::DeclareReferences(const std::string& prefix)
 		return;
 
 	std::string pointsName;
-	bool addressFound =
-		Globals::Instance->GetSegmentedPtrName(listSegmentAddress, parent, "Vec3s", pointsName, false);
+	bool addressFound = Globals::Instance->GetSegmentedPtrName(listSegmentAddress, parent, "Vec3s",
+	                                                           pointsName, false);
 	if (addressFound)
 		return;
 

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -776,9 +776,8 @@ Declaration* ZTexture::DeclareVar(const std::string& prefix,
 				incStr = StringHelper::Sprintf("%s.%s.inc.c", poolEntry->second.path.c_str(),
 				                               GetExternalExtension().c_str());
 			else
-				incStr =
-					StringHelper::Sprintf("%s.u32.%s.inc.c", poolEntry->second.path.c_str(),
-				                          GetExternalExtension().c_str());
+				incStr = StringHelper::Sprintf("%s.u32.%s.inc.c", poolEntry->second.path.c_str(),
+				                               GetExternalExtension().c_str());
 		}
 	}
 	size_t texSizeDivisor = (dWordAligned) ? 8 : 4;


### PR DESCRIPTION
Extends the functionality of  `-Whardcoded-pointer` to every pointer ZAPD has to process, so it will now warn for every raw pointer it will use which has segments 2, 3, 4, 5, or 6, or a VRAM address (0x80XXXXXX).

For other generic / general purposes pointers of other segments that are not catched by that warning, a new warning was introduced: `-Whardcoded-generic-pointer`. It is off by default because how noisy it is.