### PR TITLE
Fix out-of-bounds reading when converting textures to C

### DIFF
--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -51,7 +51,7 @@ void ZNormalAnimation::ParseRawData()
 {
 	ZAnimation::ParseRawData();
 
-	const uint8_t* data = parent->GetRawData().data();
+	auto& data = parent->GetRawData();
 
 	rotationValuesSeg = BitConverter::ToInt32BE(data, rawDataIndex + 4);
 	rotationIndicesSeg = BitConverter::ToInt32BE(data, rawDataIndex + 8);

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -256,32 +256,28 @@ size_t ZCollisionHeader::GetRawDataSize() const
 
 PolygonEntry::PolygonEntry(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	const uint8_t* data = rawData.data();
-
-	type = BitConverter::ToUInt16BE(data, rawDataIndex + 0);
-	vtxA = BitConverter::ToUInt16BE(data, rawDataIndex + 2);
-	vtxB = BitConverter::ToUInt16BE(data, rawDataIndex + 4);
-	vtxC = BitConverter::ToUInt16BE(data, rawDataIndex + 6);
-	a = BitConverter::ToUInt16BE(data, rawDataIndex + 8);
-	b = BitConverter::ToUInt16BE(data, rawDataIndex + 10);
-	c = BitConverter::ToUInt16BE(data, rawDataIndex + 12);
-	d = BitConverter::ToUInt16BE(data, rawDataIndex + 14);
+	type = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	vtxA = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	vtxB = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
+	vtxC = BitConverter::ToUInt16BE(rawData, rawDataIndex + 6);
+	a = BitConverter::ToUInt16BE(rawData, rawDataIndex + 8);
+	b = BitConverter::ToUInt16BE(rawData, rawDataIndex + 10);
+	c = BitConverter::ToUInt16BE(rawData, rawDataIndex + 12);
+	d = BitConverter::ToUInt16BE(rawData, rawDataIndex + 14);
 }
 
 WaterBoxHeader::WaterBoxHeader(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	const uint8_t* data = rawData.data();
-
-	xMin = BitConverter::ToInt16BE(data, rawDataIndex + 0);
-	ySurface = BitConverter::ToInt16BE(data, rawDataIndex + 2);
-	zMin = BitConverter::ToInt16BE(data, rawDataIndex + 4);
-	xLength = BitConverter::ToInt16BE(data, rawDataIndex + 6);
-	zLength = BitConverter::ToInt16BE(data, rawDataIndex + 8);
+	xMin = BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
+	ySurface = BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
+	zMin = BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
+	xLength = BitConverter::ToInt16BE(rawData, rawDataIndex + 6);
+	zLength = BitConverter::ToInt16BE(rawData, rawDataIndex + 8);
 
 	if (Globals::Instance->game == ZGame::OOT_SW97)
-		properties = BitConverter::ToInt16BE(data, rawDataIndex + 10);
+		properties = BitConverter::ToInt16BE(rawData, rawDataIndex + 10);
 	else
-		properties = BitConverter::ToInt32BE(data, rawDataIndex + 12);
+		properties = BitConverter::ToInt32BE(rawData, rawDataIndex + 12);
 }
 
 std::string WaterBoxHeader::GetBodySourceCode() const

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -1122,8 +1122,6 @@ size_t CutsceneCommandEnd::GetCommandSize()
 
 SpecialActionEntry::SpecialActionEntry(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	const uint8_t* data = rawData.data();
-
 	base = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
 	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
 	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -445,30 +445,26 @@ size_t CutsceneCommand::GetCommandSize()
 
 CutsceneCameraPoint::CutsceneCameraPoint(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	const uint8_t* data = rawData.data();
+	continueFlag = rawData.at(rawDataIndex + 0);
+	cameraRoll = rawData.at(rawDataIndex + 1);
+	nextPointFrame = BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
+	viewAngle = BitConverter::ToFloatBE(rawData, rawDataIndex + 4);
 
-	continueFlag = data[rawDataIndex + 0];
-	cameraRoll = data[rawDataIndex + 1];
-	nextPointFrame = BitConverter::ToInt16BE(data, rawDataIndex + 2);
-	viewAngle = BitConverter::ToFloatBE(data, rawDataIndex + 4);
+	posX = BitConverter::ToInt16BE(rawData, rawDataIndex + 8);
+	posY = BitConverter::ToInt16BE(rawData, rawDataIndex + 10);
+	posZ = BitConverter::ToInt16BE(rawData, rawDataIndex + 12);
 
-	posX = BitConverter::ToInt16BE(data, rawDataIndex + 8);
-	posY = BitConverter::ToInt16BE(data, rawDataIndex + 10);
-	posZ = BitConverter::ToInt16BE(data, rawDataIndex + 12);
-
-	unused = BitConverter::ToInt16BE(data, rawDataIndex + 14);
+	unused = BitConverter::ToInt16BE(rawData, rawDataIndex + 14);
 }
 
 CutsceneCommandSetCameraPos::CutsceneCommandSetCameraPos(const std::vector<uint8_t>& rawData,
                                                          uint32_t rawDataIndex)
 	: CutsceneCommand(rawData, rawDataIndex)
 {
-	const uint8_t* data = rawData.data();
-
-	base = BitConverter::ToUInt16BE(data, rawDataIndex + 0);
-	startFrame = BitConverter::ToUInt16BE(data, rawDataIndex + 2);
-	endFrame = BitConverter::ToUInt16BE(data, rawDataIndex + 4);
-	unused = BitConverter::ToUInt16BE(data, rawDataIndex + 6);
+	base = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
+	unused = BitConverter::ToUInt16BE(rawData, rawDataIndex + 6);
 
 	entries = std::vector<CutsceneCameraPoint*>();
 
@@ -994,23 +990,21 @@ size_t CutsceneCommandTextbox::GetCommandSize()
 
 ActorAction::ActorAction(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	const uint8_t* data = rawData.data();
-
-	action = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 0);
-	startFrame = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 2);
-	endFrame = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 4);
-	rotX = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 6);
-	rotY = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 8);
-	rotZ = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 10);
-	startPosX = BitConverter::ToInt32BE(data, rawDataIndex + 12);
-	startPosY = BitConverter::ToInt32BE(data, rawDataIndex + 16);
-	startPosZ = BitConverter::ToInt32BE(data, rawDataIndex + 20);
-	endPosX = BitConverter::ToInt32BE(data, rawDataIndex + 24);
-	endPosY = BitConverter::ToInt32BE(data, rawDataIndex + 28);
-	endPosZ = BitConverter::ToInt32BE(data, rawDataIndex + 32);
-	normalX = BitConverter::ToFloatBE(data, rawDataIndex + 36);
-	normalY = BitConverter::ToFloatBE(data, rawDataIndex + 40);
-	normalZ = BitConverter::ToFloatBE(data, rawDataIndex + 44);
+	action = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
+	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
+	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
+	rotX = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 6);
+	rotY = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 8);
+	rotZ = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 10);
+	startPosX = BitConverter::ToInt32BE(rawData, rawDataIndex + 12);
+	startPosY = BitConverter::ToInt32BE(rawData, rawDataIndex + 16);
+	startPosZ = BitConverter::ToInt32BE(rawData, rawDataIndex + 20);
+	endPosX = BitConverter::ToInt32BE(rawData, rawDataIndex + 24);
+	endPosY = BitConverter::ToInt32BE(rawData, rawDataIndex + 28);
+	endPosZ = BitConverter::ToInt32BE(rawData, rawDataIndex + 32);
+	normalX = BitConverter::ToFloatBE(rawData, rawDataIndex + 36);
+	normalY = BitConverter::ToFloatBE(rawData, rawDataIndex + 40);
+	normalZ = BitConverter::ToFloatBE(rawData, rawDataIndex + 44);
 }
 
 CutsceneCommandActorAction::CutsceneCommandActorAction(const std::vector<uint8_t>& rawData,
@@ -1130,20 +1124,20 @@ SpecialActionEntry::SpecialActionEntry(const std::vector<uint8_t>& rawData, uint
 {
 	const uint8_t* data = rawData.data();
 
-	base = BitConverter::ToUInt16BE(data, rawDataIndex + 0);
-	startFrame = BitConverter::ToUInt16BE(data, rawDataIndex + 2);
-	endFrame = BitConverter::ToUInt16BE(data, rawDataIndex + 4);
-	unused0 = BitConverter::ToUInt16BE(data, rawDataIndex + 6);
-	unused1 = BitConverter::ToUInt32BE(data, rawDataIndex + 8);
-	unused2 = BitConverter::ToUInt32BE(data, rawDataIndex + 12);
-	unused3 = BitConverter::ToUInt32BE(data, rawDataIndex + 16);
-	unused4 = BitConverter::ToUInt32BE(data, rawDataIndex + 20);
-	unused5 = BitConverter::ToUInt32BE(data, rawDataIndex + 24);
-	unused6 = BitConverter::ToUInt32BE(data, rawDataIndex + 28);
-	unused7 = BitConverter::ToUInt32BE(data, rawDataIndex + 32);
-	unused8 = BitConverter::ToUInt32BE(data, rawDataIndex + 36);
-	unused9 = BitConverter::ToUInt32BE(data, rawDataIndex + 40);
-	unused10 = BitConverter::ToUInt32BE(data, rawDataIndex + 44);
+	base = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
+	unused0 = BitConverter::ToUInt16BE(rawData, rawDataIndex + 6);
+	unused1 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 8);
+	unused2 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 12);
+	unused3 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 16);
+	unused4 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 20);
+	unused5 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 24);
+	unused6 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 28);
+	unused7 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 32);
+	unused8 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 36);
+	unused9 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 40);
+	unused10 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 44);
 }
 
 CutsceneCommandSpecialAction::CutsceneCommandSpecialAction(const std::vector<uint8_t>& rawData,

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -393,7 +393,7 @@ void ZTexture::PrepareRawDataRGBA16(const fs::path& rgbaPath)
 	height = textureData.GetHeight();
 
 	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
+	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -423,7 +423,7 @@ void ZTexture::PrepareRawDataRGBA32(const fs::path& rgbaPath)
 	height = textureData.GetHeight();
 
 	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
+	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -447,7 +447,7 @@ void ZTexture::PrepareRawDataGrayscale4(const fs::path& grayPath)
 	height = textureData.GetHeight();
 
 	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
+	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x += 2)
@@ -469,7 +469,7 @@ void ZTexture::PrepareRawDataGrayscale8(const fs::path& grayPath)
 	height = textureData.GetHeight();
 
 	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
+	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -489,7 +489,7 @@ void ZTexture::PrepareRawDataGrayscaleAlpha4(const fs::path& grayAlphaPath)
 	height = textureData.GetHeight();
 
 	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
+	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x += 2)
@@ -522,7 +522,7 @@ void ZTexture::PrepareRawDataGrayscaleAlpha8(const fs::path& grayAlphaPath)
 	height = textureData.GetHeight();
 
 	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
+	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -546,7 +546,7 @@ void ZTexture::PrepareRawDataGrayscaleAlpha16(const fs::path& grayAlphaPath)
 	height = textureData.GetHeight();
 
 	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
+	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -571,7 +571,7 @@ void ZTexture::PrepareRawDataPalette4(const fs::path& palPath)
 	height = textureData.GetHeight();
 
 	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
+	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x += 2)
@@ -594,7 +594,7 @@ void ZTexture::PrepareRawDataPalette8(const fs::path& palPath)
 	height = textureData.GetHeight();
 
 	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
+	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -352,6 +352,9 @@ void ZTexture::PrepareRawDataFromFile(const fs::path& pngFilePath)
 {
 	textureData.ReadPng(pngFilePath);
 
+	width = textureData.GetWidth();
+	height = textureData.GetHeight();
+
 	textureDataRaw.clear();
 	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 
@@ -392,9 +395,6 @@ void ZTexture::PrepareRawDataFromFile(const fs::path& pngFilePath)
 
 void ZTexture::PrepareRawDataRGBA16()
 {
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -418,9 +418,6 @@ void ZTexture::PrepareRawDataRGBA16()
 
 void ZTexture::PrepareRawDataRGBA32()
 {
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -438,9 +435,6 @@ void ZTexture::PrepareRawDataRGBA32()
 
 void ZTexture::PrepareRawDataGrayscale4()
 {
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x += 2)
@@ -456,9 +450,6 @@ void ZTexture::PrepareRawDataGrayscale4()
 
 void ZTexture::PrepareRawDataGrayscale8()
 {
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -472,9 +463,6 @@ void ZTexture::PrepareRawDataGrayscale8()
 
 void ZTexture::PrepareRawDataGrayscaleAlpha4()
 {
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x += 2)
@@ -501,9 +489,6 @@ void ZTexture::PrepareRawDataGrayscaleAlpha4()
 
 void ZTexture::PrepareRawDataGrayscaleAlpha8()
 {
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -521,9 +506,6 @@ void ZTexture::PrepareRawDataGrayscaleAlpha8()
 
 void ZTexture::PrepareRawDataGrayscaleAlpha16()
 {
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -542,9 +524,6 @@ void ZTexture::PrepareRawDataGrayscaleAlpha16()
 
 void ZTexture::PrepareRawDataPalette4()
 {
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x += 2)
@@ -561,9 +540,6 @@ void ZTexture::PrepareRawDataPalette4()
 
 void ZTexture::PrepareRawDataPalette8()
 {
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -350,37 +350,39 @@ void ZTexture::DeclareReferences([[maybe_unused]] const std::string& prefix)
 
 void ZTexture::PrepareRawDataFromFile(const fs::path& pngFilePath)
 {
+	textureData.ReadPng(pngFilePath);
+
 	textureDataRaw.clear();
 	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 
 	switch (format)
 	{
 	case TextureType::RGBA16bpp:
-		PrepareRawDataRGBA16(pngFilePath);
+		PrepareRawDataRGBA16();
 		break;
 	case TextureType::RGBA32bpp:
-		PrepareRawDataRGBA32(pngFilePath);
+		PrepareRawDataRGBA32();
 		break;
 	case TextureType::Grayscale4bpp:
-		PrepareRawDataGrayscale4(pngFilePath);
+		PrepareRawDataGrayscale4();
 		break;
 	case TextureType::Grayscale8bpp:
-		PrepareRawDataGrayscale8(pngFilePath);
+		PrepareRawDataGrayscale8();
 		break;
 	case TextureType::GrayscaleAlpha4bpp:
-		PrepareRawDataGrayscaleAlpha4(pngFilePath);
+		PrepareRawDataGrayscaleAlpha4();
 		break;
 	case TextureType::GrayscaleAlpha8bpp:
-		PrepareRawDataGrayscaleAlpha8(pngFilePath);
+		PrepareRawDataGrayscaleAlpha8();
 		break;
 	case TextureType::GrayscaleAlpha16bpp:
-		PrepareRawDataGrayscaleAlpha16(pngFilePath);
+		PrepareRawDataGrayscaleAlpha16();
 		break;
 	case TextureType::Palette4bpp:
-		PrepareRawDataPalette4(pngFilePath);
+		PrepareRawDataPalette4();
 		break;
 	case TextureType::Palette8bpp:
-		PrepareRawDataPalette8(pngFilePath);
+		PrepareRawDataPalette8();
 		break;
 	case TextureType::Error:
 		HANDLE_ERROR_PROCESS(WarningType::InvalidPNG, "Input PNG file has invalid format type", "");
@@ -388,10 +390,8 @@ void ZTexture::PrepareRawDataFromFile(const fs::path& pngFilePath)
 	}
 }
 
-void ZTexture::PrepareRawDataRGBA16(const fs::path& rgbaPath)
+void ZTexture::PrepareRawDataRGBA16()
 {
-	textureData.ReadPng(rgbaPath);
-
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
@@ -416,10 +416,8 @@ void ZTexture::PrepareRawDataRGBA16(const fs::path& rgbaPath)
 	}
 }
 
-void ZTexture::PrepareRawDataRGBA32(const fs::path& rgbaPath)
+void ZTexture::PrepareRawDataRGBA32()
 {
-	textureData.ReadPng(rgbaPath);
-
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
@@ -438,10 +436,8 @@ void ZTexture::PrepareRawDataRGBA32(const fs::path& rgbaPath)
 	}
 }
 
-void ZTexture::PrepareRawDataGrayscale4(const fs::path& grayPath)
+void ZTexture::PrepareRawDataGrayscale4()
 {
-	textureData.ReadPng(grayPath);
-
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
@@ -458,10 +454,8 @@ void ZTexture::PrepareRawDataGrayscale4(const fs::path& grayPath)
 	}
 }
 
-void ZTexture::PrepareRawDataGrayscale8(const fs::path& grayPath)
+void ZTexture::PrepareRawDataGrayscale8()
 {
-	textureData.ReadPng(grayPath);
-
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
@@ -476,10 +470,8 @@ void ZTexture::PrepareRawDataGrayscale8(const fs::path& grayPath)
 	}
 }
 
-void ZTexture::PrepareRawDataGrayscaleAlpha4(const fs::path& grayAlphaPath)
+void ZTexture::PrepareRawDataGrayscaleAlpha4()
 {
-	textureData.ReadPng(grayAlphaPath);
-
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
@@ -507,10 +499,8 @@ void ZTexture::PrepareRawDataGrayscaleAlpha4(const fs::path& grayAlphaPath)
 	}
 }
 
-void ZTexture::PrepareRawDataGrayscaleAlpha8(const fs::path& grayAlphaPath)
+void ZTexture::PrepareRawDataGrayscaleAlpha8()
 {
-	textureData.ReadPng(grayAlphaPath);
-
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
@@ -529,10 +519,8 @@ void ZTexture::PrepareRawDataGrayscaleAlpha8(const fs::path& grayAlphaPath)
 	}
 }
 
-void ZTexture::PrepareRawDataGrayscaleAlpha16(const fs::path& grayAlphaPath)
+void ZTexture::PrepareRawDataGrayscaleAlpha16()
 {
-	textureData.ReadPng(grayAlphaPath);
-
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
@@ -552,10 +540,8 @@ void ZTexture::PrepareRawDataGrayscaleAlpha16(const fs::path& grayAlphaPath)
 	}
 }
 
-void ZTexture::PrepareRawDataPalette4(const fs::path& palPath)
+void ZTexture::PrepareRawDataPalette4()
 {
-	textureData.ReadPng(palPath);
-
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
@@ -573,10 +559,8 @@ void ZTexture::PrepareRawDataPalette4(const fs::path& palPath)
 	}
 }
 
-void ZTexture::PrepareRawDataPalette8(const fs::path& palPath)
+void ZTexture::PrepareRawDataPalette8()
 {
-	textureData.ReadPng(palPath);
-
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 

--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -350,6 +350,9 @@ void ZTexture::DeclareReferences([[maybe_unused]] const std::string& prefix)
 
 void ZTexture::PrepareRawDataFromFile(const fs::path& pngFilePath)
 {
+	textureDataRaw.clear();
+	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
+
 	switch (format)
 	{
 	case TextureType::RGBA16bpp:
@@ -392,8 +395,6 @@ void ZTexture::PrepareRawDataRGBA16(const fs::path& rgbaPath)
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
-	textureDataRaw.clear();
-	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -422,8 +423,6 @@ void ZTexture::PrepareRawDataRGBA32(const fs::path& rgbaPath)
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
-	textureDataRaw.clear();
-	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -446,8 +445,6 @@ void ZTexture::PrepareRawDataGrayscale4(const fs::path& grayPath)
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
-	textureDataRaw.clear();
-	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x += 2)
@@ -468,8 +465,6 @@ void ZTexture::PrepareRawDataGrayscale8(const fs::path& grayPath)
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
-	textureDataRaw.clear();
-	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -488,8 +483,6 @@ void ZTexture::PrepareRawDataGrayscaleAlpha4(const fs::path& grayAlphaPath)
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
-	textureDataRaw.clear();
-	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x += 2)
@@ -521,8 +514,6 @@ void ZTexture::PrepareRawDataGrayscaleAlpha8(const fs::path& grayAlphaPath)
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
-	textureDataRaw.clear();
-	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -545,8 +536,6 @@ void ZTexture::PrepareRawDataGrayscaleAlpha16(const fs::path& grayAlphaPath)
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
-	textureDataRaw.clear();
-	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -570,8 +559,6 @@ void ZTexture::PrepareRawDataPalette4(const fs::path& palPath)
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
-	textureDataRaw.clear();
-	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x += 2)
@@ -593,8 +580,6 @@ void ZTexture::PrepareRawDataPalette8(const fs::path& palPath)
 	width = textureData.GetWidth();
 	height = textureData.GetHeight();
 
-	textureDataRaw.clear();
-	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)

--- a/ZAPD/ZTexture.h
+++ b/ZAPD/ZTexture.h
@@ -40,15 +40,15 @@ protected:
 	void PrepareBitmapPalette8();
 
 	void PrepareRawDataFromFile(const fs::path& inFolder);
-	void PrepareRawDataRGBA16(const fs::path& rgbaPath);
-	void PrepareRawDataRGBA32(const fs::path& rgbaPath);
-	void PrepareRawDataGrayscale4(const fs::path& grayPath);
-	void PrepareRawDataGrayscale8(const fs::path& grayPath);
-	void PrepareRawDataGrayscaleAlpha4(const fs::path& grayAlphaPath);
-	void PrepareRawDataGrayscaleAlpha8(const fs::path& grayAlphaPath);
-	void PrepareRawDataGrayscaleAlpha16(const fs::path& grayAlphaPath);
-	void PrepareRawDataPalette4(const fs::path& palPath);
-	void PrepareRawDataPalette8(const fs::path& palPath);
+	void PrepareRawDataRGBA16();
+	void PrepareRawDataRGBA32();
+	void PrepareRawDataGrayscale4();
+	void PrepareRawDataGrayscale8();
+	void PrepareRawDataGrayscaleAlpha4();
+	void PrepareRawDataGrayscaleAlpha8();
+	void PrepareRawDataGrayscaleAlpha16();
+	void PrepareRawDataPalette4();
+	void PrepareRawDataPalette8();
 
 public:
 	ZTexture(ZFile* nParent);

--- a/ZAPDUtils/Utils/BitConverter.h
+++ b/ZAPDUtils/Utils/BitConverter.h
@@ -4,6 +4,10 @@
 #include <limits>
 #include <vector>
 
+#define ALIGN8(val) (((val) + 7) & ~7)
+#define ALIGN16(val) (((val) + 0xF) & ~0xF)
+#define ALIGN64(val) (((val) + 0x3F) & ~0x3F)
+
 class BitConverter
 {
 public:

--- a/ZAPDUtils/Utils/BitConverter.h
+++ b/ZAPDUtils/Utils/BitConverter.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <cinttypes>
 #include <cstdint>
 #include <cstdio>
-#include <cinttypes>
 #include <limits>
 #include <vector>
 
@@ -15,7 +15,8 @@ class BitConverter
 public:
 	static inline int8_t ToInt8BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		if (offset + 0 > data.size()) {
+		if (offset + 0 > data.size())
+		{
 			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
 			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
 			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
@@ -26,7 +27,8 @@ public:
 
 	static inline uint8_t ToUInt8BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		if (offset + 0 > data.size()) {
+		if (offset + 0 > data.size())
+		{
 			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
 			fprintf(stderr, "Error: Trying an out-of-bounds reading from a data buffer\n");
 			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
@@ -37,7 +39,8 @@ public:
 
 	static inline int16_t ToInt16BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		if (offset + 1 > data.size()) {
+		if (offset + 1 > data.size())
+		{
 			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
 			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
 			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
@@ -48,7 +51,8 @@ public:
 
 	static inline uint16_t ToUInt16BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		if (offset + 1 > data.size()) {
+		if (offset + 1 > data.size())
+		{
 			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
 			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
 			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
@@ -59,7 +63,8 @@ public:
 
 	static inline int32_t ToInt32BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		if (offset + 3 > data.size()) {
+		if (offset + 3 > data.size())
+		{
 			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
 			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
 			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
@@ -71,7 +76,8 @@ public:
 
 	static inline uint32_t ToUInt32BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		if (offset + 3 > data.size()) {
+		if (offset + 3 > data.size())
+		{
 			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
 			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
 			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
@@ -83,7 +89,8 @@ public:
 
 	static inline int64_t ToInt64BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		if (offset + 7 > data.size()) {
+		if (offset + 7 > data.size())
+		{
 			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
 			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
 			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
@@ -97,7 +104,8 @@ public:
 
 	static inline uint64_t ToUInt64BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		if (offset + 7 > data.size()) {
+		if (offset + 7 > data.size())
+		{
 			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
 			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
 			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
@@ -111,7 +119,8 @@ public:
 
 	static inline float ToFloatBE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		if (offset + 3 > data.size()) {
+		if (offset + 3 > data.size())
+		{
 			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
 			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
 			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
@@ -128,7 +137,8 @@ public:
 
 	static inline double ToDoubleBE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		if (offset + 7 > data.size()) {
+		if (offset + 7 > data.size())
+		{
 			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
 			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
 			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());

--- a/ZAPDUtils/Utils/BitConverter.h
+++ b/ZAPDUtils/Utils/BitConverter.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdio>
+#include <cinttypes>
 #include <limits>
 #include <vector>
 
@@ -11,56 +13,110 @@
 class BitConverter
 {
 public:
-	static inline int8_t ToInt8BE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline int8_t ToInt8BE(const std::vector<uint8_t>& data, size_t offset)
 	{
+		if (offset + 0 > data.size()) {
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
 		return (int8_t)data.at(offset + 0);
 	}
 
-	static inline uint8_t ToUInt8BE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline uint8_t ToUInt8BE(const std::vector<uint8_t>& data, size_t offset)
 	{
+		if (offset + 0 > data.size()) {
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying an out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
 		return (uint8_t)data.at(offset + 0);
 	}
 
-	static inline int16_t ToInt16BE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline int16_t ToInt16BE(const std::vector<uint8_t>& data, size_t offset)
 	{
+		if (offset + 1 > data.size()) {
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
 		return ((uint16_t)data.at(offset + 0) << 8) + (uint16_t)data.at(offset + 1);
 	}
 
-	static inline uint16_t ToUInt16BE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline uint16_t ToUInt16BE(const std::vector<uint8_t>& data, size_t offset)
 	{
+		if (offset + 1 > data.size()) {
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
 		return ((uint16_t)data.at(offset + 0) << 8) + (uint16_t)data.at(offset + 1);
 	}
 
-	static inline int32_t ToInt32BE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline int32_t ToInt32BE(const std::vector<uint8_t>& data, size_t offset)
 	{
+		if (offset + 3 > data.size()) {
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
 		return ((uint32_t)data.at(offset + 0) << 24) + ((uint32_t)data.at(offset + 1) << 16) +
 			   ((uint32_t)data.at(offset + 2) << 8) + (uint32_t)data.at(offset + 3);
 	}
 
-	static inline uint32_t ToUInt32BE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline uint32_t ToUInt32BE(const std::vector<uint8_t>& data, size_t offset)
 	{
+		if (offset + 3 > data.size()) {
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
 		return ((uint32_t)data.at(offset + 0) << 24) + ((uint32_t)data.at(offset + 1) << 16) +
 			   ((uint32_t)data.at(offset + 2) << 8) + (uint32_t)data.at(offset + 3);
 	}
 
-	static inline int64_t ToInt64BE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline int64_t ToInt64BE(const std::vector<uint8_t>& data, size_t offset)
 	{
+		if (offset + 7 > data.size()) {
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
 		return ((uint64_t)data.at(offset + 0) << 56) + ((uint64_t)data.at(offset + 1) << 48) +
 			   ((uint64_t)data.at(offset + 2) << 40) + ((uint64_t)data.at(offset + 3) << 32) +
 			   ((uint64_t)data.at(offset + 4) << 24) + ((uint64_t)data.at(offset + 5) << 16) +
 			   ((uint64_t)data.at(offset + 6) << 8) + ((uint64_t)data.at(offset + 7));
 	}
 
-	static inline uint64_t ToUInt64BE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline uint64_t ToUInt64BE(const std::vector<uint8_t>& data, size_t offset)
 	{
+		if (offset + 7 > data.size()) {
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
 		return ((uint64_t)data.at(offset + 0) << 56) + ((uint64_t)data.at(offset + 1) << 48) +
 			   ((uint64_t)data.at(offset + 2) << 40) + ((uint64_t)data.at(offset + 3) << 32) +
 			   ((uint64_t)data.at(offset + 4) << 24) + ((uint64_t)data.at(offset + 5) << 16) +
 			   ((uint64_t)data.at(offset + 6) << 8) + ((uint64_t)data.at(offset + 7));
 	}
 
-	static inline float ToFloatBE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline float ToFloatBE(const std::vector<uint8_t>& data, size_t offset)
 	{
+		if (offset + 3 > data.size()) {
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
 		float value;
 		uint32_t floatData = ((uint32_t)data.at(offset + 0) << 24) +
 							 ((uint32_t)data.at(offset + 1) << 16) +
@@ -70,8 +126,14 @@ public:
 		return value;
 	}
 
-	static inline double ToDoubleBE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline double ToDoubleBE(const std::vector<uint8_t>& data, size_t offset)
 	{
+		if (offset + 7 > data.size()) {
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
 		double value;
 		uint64_t floatData =
 			((uint64_t)data.at(offset + 0) << 56) + ((uint64_t)data.at(offset + 1) << 48) +

--- a/ZAPDUtils/Utils/BitConverter.h
+++ b/ZAPDUtils/Utils/BitConverter.h
@@ -11,137 +11,61 @@
 class BitConverter
 {
 public:
-	static inline int8_t ToInt8BE(const uint8_t* data, int32_t offset)
-	{
-		return (uint8_t)data[offset + 0];
-	}
-
 	static inline int8_t ToInt8BE(const std::vector<uint8_t>& data, int32_t offset)
 	{
-		return (uint8_t)data[offset + 0];
-	}
-
-	static inline uint8_t ToUInt8BE(const uint8_t* data, int32_t offset)
-	{
-		return (uint8_t)data[offset + 0];
+		return (int8_t)data.at(offset + 0);
 	}
 
 	static inline uint8_t ToUInt8BE(const std::vector<uint8_t>& data, int32_t offset)
 	{
-		return (uint8_t)data[offset + 0];
-	}
-
-	static inline int16_t ToInt16BE(const uint8_t* data, int32_t offset)
-	{
-		return ((uint16_t)data[offset + 0] << 8) + (uint16_t)data[offset + 1];
+		return (uint8_t)data.at(offset + 0);
 	}
 
 	static inline int16_t ToInt16BE(const std::vector<uint8_t>& data, int32_t offset)
 	{
-		return ((uint16_t)data[offset + 0] << 8) + (uint16_t)data[offset + 1];
-	}
-
-	static inline uint16_t ToUInt16BE(const uint8_t* data, int32_t offset)
-	{
-		return ((uint16_t)data[offset + 0] << 8) + (uint16_t)data[offset + 1];
+		return ((uint16_t)data.at(offset + 0) << 8) + (uint16_t)data.at(offset + 1);
 	}
 
 	static inline uint16_t ToUInt16BE(const std::vector<uint8_t>& data, int32_t offset)
 	{
-		return ((uint16_t)data[offset + 0] << 8) + (uint16_t)data[offset + 1];
-	}
-
-	static inline int32_t ToInt32BE(const uint8_t* data, int32_t offset)
-	{
-		return ((uint32_t)data[offset + 0] << 24) + ((uint32_t)data[offset + 1] << 16) +
-			   ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
+		return ((uint16_t)data.at(offset + 0) << 8) + (uint16_t)data.at(offset + 1);
 	}
 
 	static inline int32_t ToInt32BE(const std::vector<uint8_t>& data, int32_t offset)
 	{
-		return ((uint32_t)data[offset + 0] << 24) + ((uint32_t)data[offset + 1] << 16) +
-			   ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
-	}
-
-	static inline uint32_t ToUInt32BE(const uint8_t* data, int32_t offset)
-	{
-		return ((uint32_t)data[offset + 0] << 24) + ((uint32_t)data[offset + 1] << 16) +
-			   ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
+		return ((uint32_t)data.at(offset + 0) << 24) + ((uint32_t)data.at(offset + 1) << 16) +
+			   ((uint32_t)data.at(offset + 2) << 8) + (uint32_t)data.at(offset + 3);
 	}
 
 	static inline uint32_t ToUInt32BE(const std::vector<uint8_t>& data, int32_t offset)
 	{
-		return ((uint32_t)data[offset + 0] << 24) + ((uint32_t)data[offset + 1] << 16) +
-			   ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
-	}
-
-	static inline int64_t ToInt64BE(const uint8_t* data, int32_t offset)
-	{
-		return ((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) +
-			   ((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) +
-			   ((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) +
-			   ((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
+		return ((uint32_t)data.at(offset + 0) << 24) + ((uint32_t)data.at(offset + 1) << 16) +
+			   ((uint32_t)data.at(offset + 2) << 8) + (uint32_t)data.at(offset + 3);
 	}
 
 	static inline int64_t ToInt64BE(const std::vector<uint8_t>& data, int32_t offset)
 	{
-		return ((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) +
-			   ((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) +
-			   ((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) +
-			   ((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
-	}
-
-	static inline uint64_t ToUInt64BE(const uint8_t* data, int32_t offset)
-	{
-		return ((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) +
-			   ((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) +
-			   ((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) +
-			   ((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
+		return ((uint64_t)data.at(offset + 0) << 56) + ((uint64_t)data.at(offset + 1) << 48) +
+			   ((uint64_t)data.at(offset + 2) << 40) + ((uint64_t)data.at(offset + 3) << 32) +
+			   ((uint64_t)data.at(offset + 4) << 24) + ((uint64_t)data.at(offset + 5) << 16) +
+			   ((uint64_t)data.at(offset + 6) << 8) + ((uint64_t)data.at(offset + 7));
 	}
 
 	static inline uint64_t ToUInt64BE(const std::vector<uint8_t>& data, int32_t offset)
 	{
-		return ((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) +
-			   ((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) +
-			   ((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) +
-			   ((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
-	}
-
-	static inline float ToFloatBE(const uint8_t* data, int32_t offset)
-	{
-		float value;
-		uint32_t floatData = ((uint32_t)data[offset + 0] << 24) +
-							 ((uint32_t)data[offset + 1] << 16) +
-							 ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
-		static_assert(sizeof(uint32_t) == sizeof(float), "expected 32-bit float");
-		std::memcpy(&value, &floatData, sizeof(value));
-		return value;
+		return ((uint64_t)data.at(offset + 0) << 56) + ((uint64_t)data.at(offset + 1) << 48) +
+			   ((uint64_t)data.at(offset + 2) << 40) + ((uint64_t)data.at(offset + 3) << 32) +
+			   ((uint64_t)data.at(offset + 4) << 24) + ((uint64_t)data.at(offset + 5) << 16) +
+			   ((uint64_t)data.at(offset + 6) << 8) + ((uint64_t)data.at(offset + 7));
 	}
 
 	static inline float ToFloatBE(const std::vector<uint8_t>& data, int32_t offset)
 	{
 		float value;
-		uint32_t floatData = ((uint32_t)data[offset + 0] << 24) +
-							 ((uint32_t)data[offset + 1] << 16) +
-							 ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
+		uint32_t floatData = ((uint32_t)data.at(offset + 0) << 24) +
+							 ((uint32_t)data.at(offset + 1) << 16) +
+							 ((uint32_t)data.at(offset + 2) << 8) + (uint32_t)data.at(offset + 3);
 		static_assert(sizeof(uint32_t) == sizeof(float), "expected 32-bit float");
-		std::memcpy(&value, &floatData, sizeof(value));
-		return value;
-	}
-
-	static inline double ToDoubleBE(const uint8_t* data, int32_t offset)
-	{
-		double value;
-		uint64_t floatData =
-			((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) +
-			((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) +
-			((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) +
-			((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
-		static_assert(sizeof(uint64_t) == sizeof(double), "expected 64-bit double");
-		// Checks if the float format on the platform the ZAPD binary is running on supports the
-		// same float format as the object file.
-		static_assert(std::numeric_limits<float>::is_iec559,
-		              "expected IEC559 floats on host machine");
 		std::memcpy(&value, &floatData, sizeof(value));
 		return value;
 	}
@@ -150,10 +74,10 @@ public:
 	{
 		double value;
 		uint64_t floatData =
-			((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) +
-			((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) +
-			((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) +
-			((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
+			((uint64_t)data.at(offset + 0) << 56) + ((uint64_t)data.at(offset + 1) << 48) +
+			((uint64_t)data.at(offset + 2) << 40) + ((uint64_t)data.at(offset + 3) << 32) +
+			((uint64_t)data.at(offset + 4) << 24) + ((uint64_t)data.at(offset + 5) << 16) +
+			((uint64_t)data.at(offset + 6) << 8) + ((uint64_t)data.at(offset + 7));
 		static_assert(sizeof(uint64_t) == sizeof(double), "expected 64-bit double");
 		// Checks if the float format on the platform the ZAPD binary is running on supports the
 		// same float format as the object file.


### PR DESCRIPTION
Fixes an issue that happens when ZAPD tries to convert a PNG texture that is not a multiple of 8 bytes to a C file.

In most cases an oob operation like this resulted on reading zeroes after the end of the buffer, but in some cases this can be just garbage data.

The fix consists of just filling the buffer to a multiple of 8 bytes.

To prevent these kind of problems in the future:
- I added boundary checks to every function in BitConverter.
- Added a complementary warning to the boundary check so this problem can become easier to track.
- Removed the overloaded methods that took a char array instead of a proper vector of bytes (vectors contains the size of the buffer, while the raw pointers don't.).