### PR TITLE
Pre reserve vector elements when possible

### DIFF
--- a/ZAPD/OtherStructs/CutsceneMM_Commands.cpp
+++ b/ZAPD/OtherStructs/CutsceneMM_Commands.cpp
@@ -54,6 +54,7 @@ CutsceneMMCommand_GenericCmd::CutsceneMMCommand_GenericCmd(const std::vector<uin
 
 	commandID = static_cast<uint32_t>(cmdId);
 
+	entries.reserve(numEntries);
 	for (size_t i = 0; i < numEntries; i++)
 	{
 		auto* entry = new CutsceneSubCommandEntry_GenericMMCmd(rawData, rawDataIndex, cmdId);
@@ -96,6 +97,7 @@ CutsceneMMCommand_Camera::CutsceneMMCommand_Camera(const std::vector<uint8_t>& r
 {
 	rawDataIndex += 4;
 
+	entries.reserve(numEntries);
 	for (size_t i = 0; i < numEntries / 4; i++)
 	{
 		auto* entry = new CutsceneSubCommandEntry_Camera(rawData, rawDataIndex);
@@ -138,6 +140,7 @@ CutsceneMMCommand_FadeScreen::CutsceneMMCommand_FadeScreen(const std::vector<uin
 {
 	rawDataIndex += 4;
 
+	entries.reserve(numEntries);
 	for (size_t i = 0; i < numEntries; i++)
 	{
 		auto* entry = new CutsceneSubCommandEntry_FadeScreen(rawData, rawDataIndex);
@@ -174,6 +177,7 @@ CutsceneMMCommand_FadeSeq::CutsceneMMCommand_FadeSeq(const std::vector<uint8_t>&
 {
 	rawDataIndex += 4;
 
+	entries.reserve(numEntries);
 	for (size_t i = 0; i < numEntries; i++)
 	{
 		auto* entry = new CutsceneSubCommandEntry_FadeSeq(rawData, rawDataIndex);
@@ -199,6 +203,7 @@ CutsceneMMCommand_NonImplemented::CutsceneMMCommand_NonImplemented(
 {
 	rawDataIndex += 4;
 
+	entries.reserve(numEntries);
 	for (size_t i = 0; i < numEntries; i++)
 	{
 		auto* entry = new CutsceneSubCommandEntry_NonImplemented(rawData, rawDataIndex);

--- a/ZAPD/OtherStructs/Cutscene_Commands.cpp
+++ b/ZAPD/OtherStructs/Cutscene_Commands.cpp
@@ -154,6 +154,7 @@ CutsceneCommand_GenericCmd::CutsceneCommand_GenericCmd(const std::vector<uint8_t
 	rawDataIndex += 4;
 
 	commandID = static_cast<uint32_t>(cmdId);
+	entries.reserve(numEntries);
 
 	for (size_t i = 0; i < numEntries; i++)
 	{
@@ -320,6 +321,7 @@ CutsceneCommand_Rumble::CutsceneCommand_Rumble(const std::vector<uint8_t>& rawDa
 {
 	rawDataIndex += 4;
 
+	entries.reserve(numEntries);
 	for (size_t i = 0; i < numEntries; i++)
 	{
 		auto* entry = new CutsceneSubCommandEntry_Rumble(rawData, rawDataIndex);
@@ -363,6 +365,7 @@ CutsceneCommand_SetTime::CutsceneCommand_SetTime(const std::vector<uint8_t>& raw
 {
 	rawDataIndex += 4;
 
+	entries.reserve(numEntries);
 	for (size_t i = 0; i < numEntries; i++)
 	{
 		auto* entry = new CutsceneSubCommandEntry_SetTime(rawData, rawDataIndex);
@@ -438,6 +441,7 @@ CutsceneCommand_TextBox::CutsceneCommand_TextBox(const std::vector<uint8_t>& raw
 {
 	rawDataIndex += 4;
 
+	entries.reserve(numEntries);
 	for (size_t i = 0; i < numEntries; i++)
 	{
 		auto* entry = new CutsceneSubCommandEntry_TextBox(rawData, rawDataIndex);
@@ -516,6 +520,7 @@ CutsceneCommand_ActorAction::CutsceneCommand_ActorAction(const std::vector<uint8
 {
 	rawDataIndex += 4;
 
+	entries.reserve(numEntries);
 	for (size_t i = 0; i < numEntries; i++)
 	{
 		auto* entry = new CutsceneSubCommandEntry_ActorAction(rawData, rawDataIndex);

--- a/ZAPD/OtherStructs/SkinLimbStructs.cpp
+++ b/ZAPD/OtherStructs/SkinLimbStructs.cpp
@@ -104,6 +104,8 @@ void Struct_800A598C::ParseRawData()
 	if (unk_8 != 0 && GETSEGNUM(unk_8) == parent->segment)
 	{
 		uint32_t unk_8_Offset = Seg2Filespace(unk_8, parent->baseAddress);
+
+		unk_8_arr.reserve(unk_0);
 		for (size_t i = 0; i < unk_0; i++)
 		{
 			Struct_800A57C0 unk8_data(parent);
@@ -117,6 +119,8 @@ void Struct_800A598C::ParseRawData()
 	if (unk_C != 0 && GETSEGNUM(unk_8) == parent->segment)
 	{
 		uint32_t unk_C_Offset = Seg2Filespace(unk_C, parent->baseAddress);
+
+		unk_C_arr.reserve(unk_2);
 		for (size_t i = 0; i < unk_2; i++)
 		{
 			Struct_800A598C_2 unkC_data(parent);
@@ -244,6 +248,8 @@ void Struct_800A5E28::ParseRawData()
 	if (unk_4 != 0 && GETSEGNUM(unk_4) == parent->segment)
 	{
 		uint32_t unk_4_Offset = Seg2Filespace(unk_4, parent->baseAddress);
+
+		unk_4_arr.reserve(unk_2);
 		for (size_t i = 0; i < unk_2; i++)
 		{
 			Struct_800A598C unk_4_data(parent);

--- a/ZAPD/ZArray.cpp
+++ b/ZAPD/ZArray.cpp
@@ -43,6 +43,7 @@ void ZArray::ParseXML(tinyxml2::XMLElement* reader)
 
 	auto nodeMap = ZFile::GetNodeMap();
 	size_t childIndex = rawDataIndex;
+	resList.reserve(arrayCnt);
 	for (size_t i = 0; i < arrayCnt; i++)
 	{
 		ZResource* res = nodeMap->at(childName)(parent);

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -76,7 +76,7 @@ void ZCutscene::ParseRawData()
 
 	endFrame = BitConverter::ToInt32BE(rawData, rawDataIndex + 4);
 	offset_t currentPtr = rawDataIndex + 8;
-
+	commands.reserve(numCommands);
 	for (int32_t i = 0; i < numCommands; i++)
 	{
 		uint32_t id = BitConverter::ToUInt32BE(rawData, currentPtr);

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -94,6 +94,7 @@ void ZDisplayList::ParseRawData()
 	instructions.reserve(numInstructions);
 	uint32_t ptr = rawDataIndex;
 
+	instructions.reserve(numInstructions);
 	for (size_t i = 0; i < numInstructions; i++)
 	{
 		instructions.push_back(BitConverter::ToUInt64BE(rawData, ptr));
@@ -1839,7 +1840,7 @@ void ZDisplayList::DeclareReferences(const std::string& prefix)
 
 		// Generate Vertex Declarations
 		std::vector<int32_t> vtxKeys;
-
+		vtxKeys.reserve(vertices.size());
 		for (auto& item : vertices)
 			vtxKeys.push_back(item.first);
 

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -420,7 +420,8 @@ ZResource* ZFile::FindResource(offset_t rawDataIndex)
 std::vector<ZResource*> ZFile::GetResourcesOfType(ZResourceType resType)
 {
 	std::vector<ZResource*> resList;
-
+	resList.reserve(resources.size());
+	
 	for (ZResource* res : resources)
 	{
 		if (res->GetResourceType() == resType)
@@ -1169,6 +1170,7 @@ void ZFile::HandleUnaccountedData()
 	uint32_t lastSize = 0;
 	std::vector<offset_t> declsAddresses;
 
+	declsAddresses.reserve(declarations.size());
 	for (const auto& item : declarations)
 	{
 		declsAddresses.push_back(item.first);

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -35,6 +35,7 @@ void ZPath::ParseRawData()
 
 	uint32_t currentPtr = rawDataIndex;
 
+	pathways.reserve(numPaths);
 	for (size_t pathIndex = 0; pathIndex < numPaths; pathIndex++)
 	{
 		PathwayEntry path(parent);
@@ -125,6 +126,7 @@ void PathwayEntry::ParseRawData()
 
 	uint32_t currentPtr = GETSEGOFFSET(listSegmentAddress);
 
+	points.reserve(numPoints);
 	for (int32_t i = 0; i < numPoints; i++)
 	{
 		ZVector vec(parent);

--- a/ZAPD/ZRoom/Commands/SetActorCutsceneList.cpp
+++ b/ZAPD/ZRoom/Commands/SetActorCutsceneList.cpp
@@ -14,8 +14,9 @@ void SetActorCutsceneList::ParseRawData()
 {
 	ZRoomCommand::ParseRawData();
 	int numCutscenes = cmdArg1;
-	int32_t currentPtr = segmentOffset;
+	offset_t currentPtr = segmentOffset;
 
+	cutscenes.reserve(numCutscenes);
 	for (int32_t i = 0; i < numCutscenes; i++)
 	{
 		ActorCutsceneEntry entry(parent->GetRawData(), currentPtr);

--- a/ZAPD/ZRoom/Commands/SetActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetActorList.cpp
@@ -34,6 +34,7 @@ void SetActorList::ParseRawDataLate()
 
 	uint32_t currentPtr = segmentOffset;
 
+	actors.reserve(actorsAmount);
 	for (size_t i = 0; i < actorsAmount; i++)
 	{
 		ActorSpawnEntry entry(parent->GetRawData(), currentPtr);

--- a/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
+++ b/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
@@ -21,9 +21,10 @@ void SetAlternateHeaders::DeclareReferences([[maybe_unused]] const std::string& 
 
 void SetAlternateHeaders::ParseRawDataLate()
 {
-	int numHeaders = zRoom->GetDeclarationSizeFromNeighbor(segmentOffset) / 4;
+	size_t numHeaders = zRoom->GetDeclarationSizeFromNeighbor(segmentOffset) / 4;
 
-	for (int32_t i = 0; i < numHeaders; i++)
+	headers.reserve(numHeaders);
+	for (uint32_t i = 0; i < numHeaders; i++)
 	{
 		int32_t address = BitConverter::ToInt32BE(parent->GetRawData(), segmentOffset + (i * 4));
 		headers.push_back(address);

--- a/ZAPD/ZRoom/Commands/SetCsCamera.cpp
+++ b/ZAPD/ZRoom/Commands/SetCsCamera.cpp
@@ -18,6 +18,7 @@ void SetCsCamera::ParseRawData()
 	uint32_t currentPtr = segmentOffset;
 	int32_t numPoints = 0;
 
+	cameras.reserve(numCameras);
 	for (int32_t i = 0; i < numCameras; i++)
 	{
 		CsCameraEntry entry(parent->GetRawData(), currentPtr);
@@ -31,6 +32,7 @@ void SetCsCamera::ParseRawData()
 	{
 		uint32_t currentPtr = cameras.at(0).GetSegmentOffset();
 
+		points.reserve(numPoints);
 		for (int32_t i = 0; i < numPoints; i++)
 		{
 			ZVector vec(parent);

--- a/ZAPD/ZRoom/Commands/SetCutscenes.cpp
+++ b/ZAPD/ZRoom/Commands/SetCutscenes.cpp
@@ -20,6 +20,7 @@ void SetCutscenes::ParseRawData()
 	{
 		int32_t currentPtr = segmentOffset;
 
+		cutsceneEntries.reserve(numCutscenes);
 		for (uint8_t i = 0; i < numCutscenes; i++)
 		{
 			CutsceneEntry entry(parent->GetRawData(), currentPtr);

--- a/ZAPD/ZRoom/Commands/SetEntranceList.cpp
+++ b/ZAPD/ZRoom/Commands/SetEntranceList.cpp
@@ -24,10 +24,11 @@ void SetEntranceList::DeclareReferences([[maybe_unused]] const std::string& pref
 void SetEntranceList::ParseRawDataLate()
 {
 	// Parse Entrances and Generate Declaration
-	int numEntrances = zRoom->GetDeclarationSizeFromNeighbor(segmentOffset) / 2;
+	uint32_t numEntrances = zRoom->GetDeclarationSizeFromNeighbor(segmentOffset) / 2;
 	uint32_t currentPtr = segmentOffset;
 
-	for (int32_t i = 0; i < numEntrances; i++)
+	entrances.reserve(numEntrances);
+	for (uint32_t i = 0; i < numEntrances; i++)
 	{
 		EntranceEntry entry(parent->GetRawData(), currentPtr);
 		entrances.push_back(entry);

--- a/ZAPD/ZRoom/Commands/SetExitList.cpp
+++ b/ZAPD/ZRoom/Commands/SetExitList.cpp
@@ -23,10 +23,11 @@ void SetExitList::DeclareReferences([[maybe_unused]] const std::string& prefix)
 void SetExitList::ParseRawDataLate()
 {
 	// Parse Entrances and Generate Declaration
-	int numEntrances = zRoom->GetDeclarationSizeFromNeighbor(segmentOffset) / 2;
+	uint32_t numEntrances = zRoom->GetDeclarationSizeFromNeighbor(segmentOffset) / 2;
 	uint32_t currentPtr = segmentOffset;
 
-	for (int32_t i = 0; i < numEntrances; i++)
+	exits.reserve(numEntrances);
+	for (uint32_t i = 0; i < numEntrances; i++)
 	{
 		uint16_t exit = BitConverter::ToUInt16BE(parent->GetRawData(), currentPtr);
 		exits.push_back(exit);

--- a/ZAPD/ZRoom/Commands/SetLightList.cpp
+++ b/ZAPD/ZRoom/Commands/SetLightList.cpp
@@ -15,6 +15,8 @@ void SetLightList::ParseRawData()
 
 	numLights = cmdArg1;
 	int32_t currentPtr = segmentOffset;
+
+	lights.reserve(this->numLights);
 	for (int i = 0; i < this->numLights; i++)
 	{
 		LightInfo light(parent->GetRawData(), currentPtr);

--- a/ZAPD/ZRoom/Commands/SetLightingSettings.cpp
+++ b/ZAPD/ZRoom/Commands/SetLightingSettings.cpp
@@ -15,6 +15,7 @@ void SetLightingSettings::ParseRawData()
 	ZRoomCommand::ParseRawData();
 	uint8_t numLights = cmdArg1;
 
+	settings.reserve(numLights);
 	for (int i = 0; i < numLights; i++)
 		settings.push_back(LightingSettings(parent->GetRawData(), segmentOffset + (i * 22)));
 }

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -442,6 +442,8 @@ void PolygonType1::DeclareReferences(const std::string& prefix)
 		{
 			listAddress = Seg2Filespace(list, parent->baseAddress);
 			uint32_t auxPtr = listAddress;
+
+			multiList.reserve(count);
 			for (size_t i = 0; i < count; ++i)
 			{
 				BgImage bg(false, prefix, auxPtr, parent);
@@ -545,6 +547,8 @@ void PolygonType2::ParseRawData()
 	end = BitConverter::ToUInt32BE(rawData, rawDataIndex + 0x08);
 
 	uint32_t currentPtr = GETSEGOFFSET(start);
+
+	polyDLists.reserve(num);
 	for (size_t i = 0; i < num; i++)
 	{
 		PolygonDlist entry(parent);

--- a/ZAPD/ZRoom/Commands/SetMinimapChests.cpp
+++ b/ZAPD/ZRoom/Commands/SetMinimapChests.cpp
@@ -15,8 +15,9 @@ void SetMinimapChests::ParseRawData()
 	ZRoomCommand::ParseRawData();
 	int numChests = cmdArg1;
 
-	int32_t currentPtr = segmentOffset;
+	offset_t currentPtr = segmentOffset;
 
+	chests.reserve(numChests);
 	for (int32_t i = 0; i < numChests; i++)
 	{
 		MinimapChest chest(parent->GetRawData(), currentPtr);

--- a/ZAPD/ZRoom/Commands/SetMinimapList.cpp
+++ b/ZAPD/ZRoom/Commands/SetMinimapList.cpp
@@ -17,8 +17,9 @@ void SetMinimapList::ParseRawData()
 	listSegmentOffset = GETSEGOFFSET(listSegmentAddr);
 	unk4 = BitConverter::ToInt32BE(parent->GetRawData(), segmentOffset + 4);
 
-	int32_t currentPtr = listSegmentOffset;
+	uint32_t currentPtr = listSegmentOffset;
 
+	minimaps.reserve(zRoom->roomCount);
 	for (int32_t i = 0; i < zRoom->roomCount; i++)
 	{
 		MinimapEntry entry(parent->GetRawData(), currentPtr);

--- a/ZAPD/ZRoom/Commands/SetObjectList.cpp
+++ b/ZAPD/ZRoom/Commands/SetObjectList.cpp
@@ -17,6 +17,7 @@ void SetObjectList::ParseRawData()
 	uint8_t objectCnt = parent->GetRawData().at(rawDataIndex + 1);
 	uint32_t currentPtr = segmentOffset;
 
+	objects.reserve(objectCnt);
 	for (uint8_t i = 0; i < objectCnt; i++)
 	{
 		uint16_t objectIndex = BitConverter::ToInt16BE(parent->GetRawData(), currentPtr);

--- a/ZAPD/ZRoom/Commands/SetRoomList.cpp
+++ b/ZAPD/ZRoom/Commands/SetRoomList.cpp
@@ -69,6 +69,7 @@ void RomFile::ParseRawData()
 
 	uint32_t currentPtr = rawDataIndex;
 
+	rooms.reserve(numRooms);
 	for (int32_t i = 0; i < numRooms; i++)
 	{
 		RoomEntry entry(parent->GetRawData(), currentPtr);

--- a/ZAPD/ZRoom/Commands/SetStartPositionList.cpp
+++ b/ZAPD/ZRoom/Commands/SetStartPositionList.cpp
@@ -16,9 +16,10 @@ void SetStartPositionList::ParseRawData()
 	ZRoomCommand::ParseRawData();
 	uint8_t numActors = cmdArg1;
 
-	uint32_t currentPtr = segmentOffset;
+	offset_t currentPtr = segmentOffset;
 
-	for (int32_t i = 0; i < numActors; i++)
+	actors.reserve(numActors);
+	for (uint32_t i = 0; i < numActors; i++)
 	{
 		actors.push_back(ActorSpawnEntry(parent->GetRawData(), currentPtr));
 		currentPtr += 16;

--- a/ZAPD/ZRoom/Commands/SetTransitionActorList.cpp
+++ b/ZAPD/ZRoom/Commands/SetTransitionActorList.cpp
@@ -17,6 +17,7 @@ void SetTransitionActorList::ParseRawData()
 	int numActors = cmdArg1;
 	uint32_t currentPtr = segmentOffset;
 
+	transitionActors.reserve(numActors);
 	for (int32_t i = 0; i < numActors; i++)
 	{
 		TransitionActorEntry entry(parent->GetRawData(), currentPtr);

--- a/ZAPD/ZSkeleton.cpp
+++ b/ZAPD/ZSkeleton.cpp
@@ -287,6 +287,8 @@ void ZLimbTable::ParseRawData()
 
 	const auto& rawData = parent->GetRawData();
 	uint32_t ptr = rawDataIndex;
+
+	limbsAddresses.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		limbsAddresses.push_back(BitConverter::ToUInt32BE(rawData, ptr));
@@ -301,7 +303,7 @@ void ZLimbTable::DeclareReferences(const std::string& prefix)
 		varPrefix = prefix;
 
 	ZResource::DeclareReferences(varPrefix);
-
+	limbsReferences.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		segptr_t limbAddress = limbsAddresses[i];

--- a/ZAPD/ZVector.cpp
+++ b/ZAPD/ZVector.cpp
@@ -48,7 +48,7 @@ void ZVector::ParseRawData()
 	int32_t currentRawDataIndex = rawDataIndex;
 	// TODO: this shouldn't be necessary.
 	scalars.clear();
-
+	scalars.reserve(dimensions);
 	for (uint32_t i = 0; i < dimensions; i++)
 	{
 		ZScalar scalar(parent);


### PR DESCRIPTION
Save memory allocations and moves by pre allocating vector elements. 
Before
|File| Allocs |Total Bytes  |
|--|--|--|
|Spirit Temple|1,433,235|319,231,738|
|Gameplay Keep|164,617|231,334,006|
|Object Tw|140,241|73,792,431|

After

|File| Allocs |Total Bytes  |
|--|--|--|
|Spirit Temple|1,359,918|307,492,602|
|Gameplay Keep|161,135|230,773,518|
|Object Tw|140,089|73,787,139|

I left out the collision system since that has a PR and texture animations cause it has a pointer math system I didn't feel like messing with this time.