### PR TITLE
MM Jenkins Update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
                     steps {
                         dir('mm') {
                             sh 'make -j disasm'
-                            sh 'make -j all'
+                            sh 'make -j'
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,8 +70,10 @@ pipeline {
 
         // INSTALL PYTHON DEPENDENCIES, currently MM only
         stage('Install Python dependencies') {
-            dir('mm') {
-                sh 'python3 -m pip install -r requirements.txt'
+            steps {
+                dir('mm') {
+                    sh 'python3 -m pip install -r requirements.txt'
+                }
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,6 +68,13 @@ pipeline {
             }
         }
 
+        // INSTALL PYTHON DEPENDENCIES, currently MM only
+        stage('Install Python dependencies') {
+            dir('mm') {
+                sh 'python3 -m pip install -r requirements.txt'
+            }
+        }
+
         // BUILD THE REPOS
         stage('Build repos') {
             parallel {


### PR DESCRIPTION
https://discordapp.com/channels/688807550715560050/688852030403379277/994958671631102033 It was discussed since MM's disassembler might be updated every now and again that would require a new imagine, it would be better to just add a step to the Jenkinsfile to install the required python dependencies, instead of making people update the image (though that is still a possibility). I feel like it would be best to keep this out of the parallel steps, to make sure python doesn't step on itself between OoT and MM, though if desired I could move it to a parallel step, probably MM's setup stage.