### PR TITLE
Cleanups

### DIFF
--- a/ExporterTest/CollisionExporter.cpp
+++ b/ExporterTest/CollisionExporter.cpp
@@ -58,7 +58,7 @@ void ExporterExample_Collision::Save(ZResource* res, [[maybe_unused]] fs::path o
 
 	writer->Seek(col->polyTypeDefSegmentOffset, SeekOffsetType::Start);
 
-	for (const auto poly : col->polygonTypes)
+	for (const auto& poly : col->polygonTypes)
 	{
 		writer->Write(poly.data[0]);
 		writer->Write(poly.data[1]);

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ else
   CXX := g++
 endif
 
-INC := -I ZAPD -I lib/elfio -I lib/libgfxd -I lib/tinyxml2 -I ZAPDUtils
+INC := -I ZAPD -I lib/libgfxd -I lib/tinyxml2 -I ZAPDUtils
 CXXFLAGS := -fpic -std=c++17 -Wall -Wextra -fno-omit-frame-pointer
 OPTFLAGS :=
 


### PR DESCRIPTION
Fix warning in CollisionExporter.
Remove include for unused elfio lib.