### PR TITLE
Added setting for ZBackground Array Size

### DIFF
--- a/ZAPD/Declaration.h
+++ b/ZAPD/Declaration.h
@@ -42,7 +42,7 @@ public:
 	bool isArray = false;
 	bool forceArrayCnt = false;
 	size_t arrayItemCnt = 0;
-	std::string arrayItemCntStr = "";
+	std::string arrayItemCntStr = ""; // Can be used to put a specific string inside an array declaration's brackets
 	std::vector<segptr_t> references;
 	bool isUnaccounted = false;
 	bool isPlaceholder = false;

--- a/ZAPD/GameConfig.cpp
+++ b/ZAPD/GameConfig.cpp
@@ -124,6 +124,7 @@ void GameConfig::ConfigFunc_BGConfig(const tinyxml2::XMLElement& element)
 {
 	bgScreenWidth = element.IntAttribute("ScreenWidth", 320);
 	bgScreenHeight = element.IntAttribute("ScreenHeight", 240);
+	useScreenWidthHeightConstants = element.BoolAttribute("UseScreenWidthHeightConstants", true);
 }
 
 void GameConfig::ConfigFunc_ExternalXMLFolder(const tinyxml2::XMLElement& element)

--- a/ZAPD/GameConfig.h
+++ b/ZAPD/GameConfig.h
@@ -37,6 +37,7 @@ public:
 
 	// ZBackground
 	uint32_t bgScreenWidth = 320, bgScreenHeight = 240;
+	bool useScreenWidthHeightConstants = true; // If true, ZBackground's will be declared with SCREEN_WIDTH * SCREEN_HEIGHT in the C file
 
 	// ExternalFile
 	fs::path externalXmlFolder;

--- a/ZAPD/ZBackground.cpp
+++ b/ZAPD/ZBackground.cpp
@@ -132,8 +132,13 @@ Declaration* ZBackground::DeclareVar(const std::string& prefix,
 
 	Declaration* decl = parent->AddDeclarationIncludeArray(rawDataIndex, incStr, GetRawDataSize(),
 	                                                       GetSourceTypeName(), auxName, 0);
-	decl->arrayItemCntStr = "SCREEN_WIDTH * SCREEN_HEIGHT / 4";
-	decl->forceArrayCnt = true;
+
+	if (Globals::Instance->cfg.useScreenWidthHeightConstants)
+	{
+		decl->arrayItemCntStr = "SCREEN_WIDTH * SCREEN_HEIGHT / 4";
+		decl->forceArrayCnt = true;
+	}
+
 	decl->staticConf = staticConf;
 	return decl;
 }


### PR DESCRIPTION
Normally when a ZBackground (JPEG) is converted to C, it is declared as an array with size `SCREEN_WIDTH * SCREEN_HEIGHT`. Some have expressed concern that the size of the background should not be tied to the resolution of the game (see issue #272).
This PR addresses this issue by adding a new setting for Config.xml. By adding the following:
`<BGConfig UseScreenWidthHeightConstants="false"/>`
The array is simply declared without a size.
Without this setting in the config file, `SCREEN_WIDTH * SCREEN_HEIGHT` will be used like before.