### PR TITLE
Added alias for ZPath called "PathList".

### DIFF
--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -6,7 +6,8 @@
 #include "WarningHandler.h"
 #include "ZFile.h"
 
-REGISTER_ZFILENODE(Path, ZPath);
+REGISTER_ZFILENODE(Path, ZPath); // Old name that is being kept for backwards compatability
+REGISTER_ZFILENODE(PathList, ZPath); // New name that may be used in future XMLs
 
 ZPath::ZPath(ZFile* nParent) : ZResource(nParent)
 {


### PR DESCRIPTION
This PR intends to address the problems presented in #241. The issue mentions that `numPaths` in a `Path` node is ignored. This seems to have been fixed at some point.

This PR adds an alternate XML node called `PathList` which does the same as `Path`. The latter is being kept for backwards compatibility with existing XMLs.