### PR TITLE
Fixed improperly extracted vertices.

### DIFF
--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -367,6 +367,9 @@ public:
 	std::string ProcessLegacy(const std::string& prefix);
 	std::string ProcessGfxDis(const std::string& prefix);
 
+	// Combines vertex lists from the vertices map which touch or intersect
+	void MergeConnectingVertexLists();
+
 	bool IsExternalResource() const override;
 	std::string GetExternalExtension() const override;
 	std::string GetSourceTypeName() const override;


### PR DESCRIPTION
Addresses issue #253. With certain display lists vertex lists were being overridden with smaller versions of the same data when they should not have been. This would cause vertex data to be flagged as "unaccounted" despite being used by a display list. Some optimizations were also made to the way vertices are merged - though this only applies to vertex lists inside display lists currently.