### PR TITLE
Use ARRAY_COUNT where possible.

### DIFF
--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -219,11 +219,11 @@ std::string ZCollisionHeader::GetBodySourceCode() const
 
 	std::string vtxName;
 	Globals::Instance->GetSegmentedPtrName(vtxAddress, parent, "Vec3s", vtxName);
-	declaration += StringHelper::Sprintf("\t%i, %s,\n", numVerts, vtxName.c_str());
+	declaration += StringHelper::Sprintf("\tARRAY_COUNT(%s), %s,\n", vtxName.c_str(), vtxName.c_str());
 
 	std::string polyName;
 	Globals::Instance->GetSegmentedPtrName(polyAddress, parent, "CollisionPoly", polyName);
-	declaration += StringHelper::Sprintf("\t%i, %s,\n", numPolygons, polyName.c_str());
+	declaration += StringHelper::Sprintf("\tARRAY_COUNT(%s), %s,\n", polyName.c_str(), polyName.c_str());
 
 	std::string surfaceName;
 	Globals::Instance->GetSegmentedPtrName(polyTypeDefAddress, parent, "SurfaceType", surfaceName);
@@ -235,7 +235,11 @@ std::string ZCollisionHeader::GetBodySourceCode() const
 
 	std::string waterBoxName;
 	Globals::Instance->GetSegmentedPtrName(waterBoxAddress, parent, "WaterBox", waterBoxName);
-	declaration += StringHelper::Sprintf("\t%i, %s\n", numWaterBoxes, waterBoxName.c_str());
+
+	if (numWaterBoxes > 0)
+		declaration += StringHelper::Sprintf("\tARRAY_COUNT(%s), %s\n", waterBoxName.c_str(), waterBoxName.c_str());
+	else
+		declaration += StringHelper::Sprintf("\t%i, %s\n", numWaterBoxes, waterBoxName.c_str());
 
 	return declaration;
 }

--- a/ZAPD/ZCollision.cpp
+++ b/ZAPD/ZCollision.cpp
@@ -219,11 +219,19 @@ std::string ZCollisionHeader::GetBodySourceCode() const
 
 	std::string vtxName;
 	Globals::Instance->GetSegmentedPtrName(vtxAddress, parent, "Vec3s", vtxName);
-	declaration += StringHelper::Sprintf("\tARRAY_COUNT(%s), %s,\n", vtxName.c_str(), vtxName.c_str());
+
+	if (numVerts > 0)
+		declaration += StringHelper::Sprintf("\tARRAY_COUNT(%s), %s,\n", vtxName.c_str(), vtxName.c_str());
+	else
+		declaration += StringHelper::Sprintf("\t%i, %s,\n", numVerts, vtxName.c_str());
 
 	std::string polyName;
 	Globals::Instance->GetSegmentedPtrName(polyAddress, parent, "CollisionPoly", polyName);
-	declaration += StringHelper::Sprintf("\tARRAY_COUNT(%s), %s,\n", polyName.c_str(), polyName.c_str());
+
+	if (numPolygons > 0)
+		declaration += StringHelper::Sprintf("\tARRAY_COUNT(%s), %s,\n", polyName.c_str(), polyName.c_str());
+	else
+		declaration += StringHelper::Sprintf("\t%i, %s,\n", numPolygons, polyName.c_str());
 
 	std::string surfaceName;
 	Globals::Instance->GetSegmentedPtrName(polyTypeDefAddress, parent, "SurfaceType", surfaceName);

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -186,7 +186,7 @@ std::string PathwayEntry::GetBodySourceCode() const
 		declaration +=
 			StringHelper::Sprintf("%i, %i, %i, %s", numPoints, unk1, unk2, listName.c_str());
 	else
-		declaration += StringHelper::Sprintf("%i, %s", numPoints, listName.c_str());
+		declaration += StringHelper::Sprintf("ARRAY_COUNT(%s), %s", listName.c_str(), listName.c_str());
 
 	return declaration;
 }

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -186,7 +186,13 @@ std::string PathwayEntry::GetBodySourceCode() const
 		declaration +=
 			StringHelper::Sprintf("%i, %i, %i, %s", numPoints, unk1, unk2, listName.c_str());
 	else
-		declaration += StringHelper::Sprintf("ARRAY_COUNT(%s), %s", listName.c_str(), listName.c_str());
+	{
+		if (numPoints > 0)
+		declaration +=
+			StringHelper::Sprintf("ARRAY_COUNT(%s), %s", listName.c_str(), listName.c_str());
+		else
+			declaration += StringHelper::Sprintf("%i, %s", numPoints, listName.c_str());
+	}
 
 	return declaration;
 }


### PR DESCRIPTION
This PR addresses issue #183. It uses `ARRAY_COUNT` for Paths and Collision Headers instead of a hardcoded size.