### PR TITLE
Refactor - Clean up and document declaration class.

### DIFF
--- a/ZAPD/Declaration.cpp
+++ b/ZAPD/Declaration.cpp
@@ -4,69 +4,81 @@
 #include "Utils/StringHelper.h"
 
 Declaration::Declaration(offset_t nAddress, DeclarationAlignment nAlignment, size_t nSize,
-                         const std::string& nText)
+                         const std::string& nBody)
 {
 	address = nAddress;
 	alignment = nAlignment;
 	size = nSize;
-	text = nText;
+	declBody = nBody;
 }
 
-Declaration::Declaration(offset_t nAddress, DeclarationAlignment nAlignment, size_t nSize,
-                         const std::string& nVarType, const std::string& nVarName, bool nIsArray,
-                         const std::string& nText)
-	: Declaration(nAddress, nAlignment, nSize, nText)
+Declaration* Declaration::Create(offset_t declAddr, DeclarationAlignment declAlign, size_t declSize,
+                                 const std::string& declType, const std::string& declName, const std::string& declBody)
 {
-	varType = nVarType;
-	varName = nVarName;
-	isArray = nIsArray;
+	Declaration* decl = new Declaration(declAddr, declAlign, declSize, declBody);
+
+	decl->declType = declType;
+	decl->declName = declName;
+	decl->declBody = declBody;
+
+	return decl;
 }
 
-Declaration::Declaration(offset_t nAddress, DeclarationAlignment nAlignment, size_t nSize,
-                         const std::string& nVarType, const std::string& nVarName, bool nIsArray,
-                         size_t nArrayItemCnt, const std::string& nText)
-	: Declaration(nAddress, nAlignment, nSize, nText)
+Declaration* Declaration::CreateArray(offset_t declAddr, DeclarationAlignment declAlign,
+                                      size_t declSize, const std::string& declType, const std::string& declName,
+                                      const std::string& declBody, size_t declArrayItemCnt,
+                                      bool isDeclExternal)
 {
-	varType = nVarType;
-	varName = nVarName;
-	isArray = nIsArray;
-	arrayItemCnt = nArrayItemCnt;
+	Declaration* decl = new Declaration(declAddr, declAlign, declSize, declBody);
+
+
+	decl->declName = declName;
+	decl->declType = declType;
+	decl->arrayItemCnt = declArrayItemCnt;
+	decl->isExternal = isDeclExternal;
+	decl->isArray = true;
+
+	return decl;
 }
 
-Declaration::Declaration(offset_t nAddress, DeclarationAlignment nAlignment, size_t nSize,
-                         const std::string& nVarType, const std::string& nVarName, bool nIsArray,
-                         const std::string& nArrayItemCntStr, const std::string& nText)
-	: Declaration(nAddress, nAlignment, nSize, nText)
+Declaration* Declaration::CreateArray(offset_t declAddr, DeclarationAlignment declAlign,
+                                      size_t declSize, const std::string& declType, const std::string& declName,
+                                      const std::string& declBody, const std::string& declArrayItemCntStr,
+                                      bool isDeclExternal)
 {
-	varType = nVarType;
-	varName = nVarName;
-	isArray = nIsArray;
-	arrayItemCntStr = nArrayItemCntStr;
+	Declaration* decl = new Declaration(declAddr, declAlign, declSize, declBody);
+
+	decl->declName = declName;
+	decl->declType = declType;
+	decl->arrayItemCntStr = declArrayItemCntStr;
+	decl->isExternal = isDeclExternal;
+	decl->isArray = true;
+
+	return decl;
 }
 
-Declaration::Declaration(offset_t nAddress, DeclarationAlignment nAlignment, size_t nSize,
-                         const std::string& nVarType, const std::string& nVarName, bool nIsArray,
-                         size_t nArrayItemCnt, const std::string& nText, bool nIsExternal)
-	: Declaration(nAddress, nAlignment, nSize, nVarType, nVarName, nIsArray, nArrayItemCnt, nText)
+Declaration* Declaration::CreateInclude(offset_t declAddr, const std::string& includePath, size_t declSize,
+                                        const std::string& declType, const std::string& declName,
+                                        const std::string& defines)
 {
-	isExternal = nIsExternal;
+	Declaration* decl = new Declaration(declAddr, DeclarationAlignment::Align4, declSize, "");
+	decl->includePath = includePath;
+	decl->declType = declType;
+	decl->declName = declName;
+	decl->defines = defines;
+
+
+	return decl;
 }
 
-Declaration::Declaration(offset_t nAddress, const std::string& nIncludePath, size_t nSize,
-                         const std::string& nVarType, const std::string& nVarName)
-	: Declaration(nAddress, DeclarationAlignment::Align4, nSize, "")
+Declaration* Declaration::CreatePlaceholder(offset_t declAddr, const std::string& declName)
 {
-	includePath = nIncludePath;
-	varType = nVarType;
-	varName = nVarName;
-}
+	Declaration* decl =
+		new Declaration(declAddr, DeclarationAlignment::Align4, 0, "");
+	decl->declName = declName;
+	decl->isPlaceholder = true;
 
-Declaration::Declaration(offset_t nAddress, const std::string& nIncludePath, size_t nSize,
-                         const std::string& nVarType, const std::string& nVarName,
-                         const std::string& nDefines)
-	: Declaration(nAddress, nIncludePath, nSize, nVarType, nVarName)
-{
-	defines = nDefines;
+	return decl;
 }
 
 bool Declaration::IsStatic() const
@@ -90,9 +102,6 @@ std::string Declaration::GetNormalDeclarationStr() const
 {
 	std::string output;
 
-	if (preText != "")
-		output += preText + "\n";
-
 	if (IsStatic())
 	{
 		output += "static ";
@@ -100,27 +109,28 @@ std::string Declaration::GetNormalDeclarationStr() const
 
 	if (isArray)
 	{
-		if (arrayItemCntStr != "" && (IsStatic() || forceArrayCnt))
+		bool includeArraySize = (IsStatic() || forceArrayCnt);
+
+		if (includeArraySize)
 		{
-			output += StringHelper::Sprintf("%s %s[%s];\n", varType.c_str(), varName.c_str(),
-			                                arrayItemCntStr.c_str());
-		}
-		else if (arrayItemCnt != 0 && (IsStatic() || forceArrayCnt))
-		{
-			output += StringHelper::Sprintf("%s %s[%i] = {\n", varType.c_str(), varName.c_str(),
-			                                arrayItemCnt);
+			if (arrayItemCntStr != "")
+				output += StringHelper::Sprintf("%s %s[%s];\n", declType.c_str(), declName.c_str(),
+				                                arrayItemCntStr.c_str());
+			else
+				output += StringHelper::Sprintf("%s %s[%i] = {\n", declType.c_str(), declName.c_str(),
+				                                arrayItemCnt);
 		}
 		else
 		{
-			output += StringHelper::Sprintf("%s %s[] = {\n", varType.c_str(), varName.c_str());
+			output += StringHelper::Sprintf("%s %s[] = {\n", declType.c_str(), declName.c_str());
 		}
 
-		output += text + "\n";
+		output += declBody + "\n";
 	}
 	else
 	{
-		output += StringHelper::Sprintf("%s %s = { ", varType.c_str(), varName.c_str());
-		output += text;
+		output += StringHelper::Sprintf("%s %s = { ", declType.c_str(), declName.c_str());
+		output += declBody;
 	}
 
 	if (output.back() == '\n')
@@ -128,13 +138,7 @@ std::string Declaration::GetNormalDeclarationStr() const
 	else
 		output += " };";
 
-	if (rightText != "")
-		output += " " + rightText + "";
-
 	output += "\n";
-
-	if (postText != "")
-		output += postText + "\n";
 
 	output += "\n";
 
@@ -145,41 +149,34 @@ std::string Declaration::GetExternalDeclarationStr() const
 {
 	std::string output;
 
-	if (preText != "")
-		output += preText + "\n";
-
 	if (IsStatic())
-	{
 		output += "static ";
+
+	bool includeArraySize = (IsStatic() || forceArrayCnt);
+
+	if (includeArraySize)
+	{
+		if (arrayItemCntStr != "")
+			output += StringHelper::Sprintf("%s %s[%s] = ", declType.c_str(), declName.c_str(),
+			                                arrayItemCntStr.c_str());
+		else
+			output += StringHelper::Sprintf("%s %s[%i] = ", declType.c_str(), declName.c_str(),
+			                                arrayItemCnt);
+	}
+	else
+	{
+		output += StringHelper::Sprintf("%s %s[] = ", declType.c_str(), declName.c_str());
 	}
 
-	if (arrayItemCntStr != "" && (IsStatic() || forceArrayCnt))
-		output += StringHelper::Sprintf("%s %s[%s] = ", varType.c_str(), varName.c_str(),
-		                                arrayItemCntStr.c_str());
-	else if (arrayItemCnt != 0 && (IsStatic() || forceArrayCnt))
-		output +=
-			StringHelper::Sprintf("%s %s[%i] = ", varType.c_str(), varName.c_str(), arrayItemCnt);
-	else
-		output += StringHelper::Sprintf("%s %s[] = ", varType.c_str(), varName.c_str());
-
 	output += StringHelper::Sprintf("{\n#include \"%s\"\n};", includePath.c_str());
-
-	if (rightText != "")
-		output += " " + rightText + "";
-
-	output += "\n";
-
-	if (postText != "")
-		output += postText + "\n";
-
-	output += "\n";
+	output += "\n\n";
 
 	return output;
 }
 
 std::string Declaration::GetExternStr() const
 {
-	if (IsStatic() || varType == "" || isUnaccounted)
+	if (IsStatic() || declType == "" || isUnaccounted)
 	{
 		return "";
 	}
@@ -188,24 +185,24 @@ std::string Declaration::GetExternStr() const
 	{
 		if (arrayItemCntStr != "" && (IsStatic() || forceArrayCnt))
 		{
-			return StringHelper::Sprintf("extern %s %s[%s];\n", varType.c_str(), varName.c_str(),
+			return StringHelper::Sprintf("extern %s %s[%s];\n", declType.c_str(), declName.c_str(),
 			                             arrayItemCntStr.c_str());
 		}
 		else if (arrayItemCnt != 0 && (IsStatic() || forceArrayCnt))
 		{
-			return StringHelper::Sprintf("extern %s %s[%i];\n", varType.c_str(), varName.c_str(),
+			return StringHelper::Sprintf("extern %s %s[%i];\n", declType.c_str(), declName.c_str(),
 			                             arrayItemCnt);
 		}
 		else
-			return StringHelper::Sprintf("extern %s %s[];\n", varType.c_str(), varName.c_str());
+			return StringHelper::Sprintf("extern %s %s[];\n", declType.c_str(), declName.c_str());
 	}
 
-	return StringHelper::Sprintf("extern %s %s;\n", varType.c_str(), varName.c_str());
+	return StringHelper::Sprintf("extern %s %s;\n", declType.c_str(), declName.c_str());
 }
 
 std::string Declaration::GetDefinesStr() const
 {
-	if (IsStatic() || (varType == ""))
+	if (IsStatic() || (declType == ""))
 	{
 		return "";
 	}
@@ -227,15 +224,15 @@ std::string Declaration::GetStaticForwardDeclarationStr() const
 
 		if (arrayItemCntStr != "")
 		{
-			return StringHelper::Sprintf("static %s %s[%s];\n", varType.c_str(), varName.c_str(),
+			return StringHelper::Sprintf("static %s %s[%s];\n", declType.c_str(), declName.c_str(),
 			                             arrayItemCntStr.c_str());
 		}
 		else
 		{
-			return StringHelper::Sprintf("static %s %s[%i];\n", varType.c_str(), varName.c_str(),
+			return StringHelper::Sprintf("static %s %s[%i];\n", declType.c_str(), declName.c_str(),
 			                             arrayItemCnt);
 		}
 	}
 
-	return StringHelper::Sprintf("static %s %s;\n", varType.c_str(), varName.c_str());
+	return StringHelper::Sprintf("static %s %s;\n", declType.c_str(), declName.c_str());
 }

--- a/ZAPD/Declaration.h
+++ b/ZAPD/Declaration.h
@@ -22,65 +22,154 @@ enum class StaticConfig
 	On
 };
 
+/// <summary>
+/// A declaration is contains the C contents of a symbol for a file. 
+/// It contains at a minimum the address where the symbol would be in the binary file, alignment settings, the size of the binary data, and the C code that makes it up.
+/// Optionally it can also contain comments.
+/// </summary>
 class Declaration
 {
 public:
-	offset_t address;
-	DeclarationAlignment alignment;
-	size_t size;
-	std::string preText;
-	std::string text;
-	std::string rightText;
-	std::string postText;
-	std::string preComment;
-	std::string postComment;
-	std::string varType;
-	std::string varName;
-	std::string defines = "";  // Defines to be included in the header
-	std::string includePath;
+	// Where in the binary file (segment) will this C code end up being?
+	offset_t address = 0; 
 
+	// How is this C code aligned?
+	DeclarationAlignment alignment = DeclarationAlignment::Align4;
+
+	// How many bytes will this C code take up in the resulting binary when compiled?
+	size_t size = 0;
+
+	// The C type of this declaration
+	std::string declType = "";
+
+	// The C variable name of this declaration
+	std::string declName = "";
+
+	// The body of the declaration containing the data.
+	// In "int j = 7;", "7" would be text.
+	std::string declBody = "";
+
+	 // #define's to be included in the header
+	std::string defines = ""; 
+
+	std::string includePath = "";
+
+	// Is this declaration in an external file? (ie. a gameplay_keep reference being found in another file that wishes to use its data)
 	bool isExternal = false;
+
 	bool isArray = false;
+
+	// If true, will ensure that the arrays size is included in the declaration
 	bool forceArrayCnt = false;
+
+	// If this declaration is an array, how many items make it up?
 	size_t arrayItemCnt = 0;
-	std::string arrayItemCntStr = ""; // Can be used to put a specific string inside an array declaration's brackets
+
+	// Overrides the brackets for the arrays size with a custom string
+	std::string arrayItemCntStr = "";
+
 	std::vector<segptr_t> references;
+
+	// If true, this declaration represents data inside the file which we do not understand it's purpose for.
+	// It will be outputted as just a byte array.
 	bool isUnaccounted = false;
+
+	// Is this declaration a placeholder that will be replaced later?
 	bool isPlaceholder = false;
+
+
+	// Does this declaration come straight from the XML?
+	// If false, this means that the declaration was created by ZAPD when it was parsing the resources.
 	bool declaredInXml = false;
+
 	StaticConfig staticConf = StaticConfig::Global;
 
-	Declaration(offset_t nAddress, DeclarationAlignment nAlignment, size_t nSize,
-	            const std::string& nVarType, const std::string& nVarName, bool nIsArray,
-	            const std::string& nText);
-	Declaration(offset_t nAddress, DeclarationAlignment nAlignment, size_t nSize,
-	            const std::string& nVarType, const std::string& nVarName, bool nIsArray,
-	            size_t nArrayItemCnt, const std::string& nText);
-	Declaration(offset_t nAddress, DeclarationAlignment nAlignment, size_t nSize,
-	            const std::string& nVarType, const std::string& nVarName, bool nIsArray,
-	            const std::string& nArrayItemCntStr, const std::string& nText);
-	Declaration(offset_t nAddress, DeclarationAlignment nAlignment, size_t nSize,
-	            const std::string& nVarType, const std::string& nVarName, bool nIsArray,
-	            size_t nArrayItemCnt, const std::string& nText, bool nIsExternal);
+	/// <summary>
+	/// Creates a regular declaration.
+	/// </summary>
+	/// <param name="declAddr">The address inside a binary file this declaration will be in when compiled.</param>
+	/// <param name="declAlign">The alignment of this declaration in the compiled binary file.</param>
+	/// <param name="declSize">The size of this declaration when it is compiled to binary data.</param>
+	/// <param name="declType">The C variable type this declaration will be declared as.</param>
+	/// <param name="declName">The C variable name this declaration will be declared as.</param>
+	/// <param name="declBody">The contents of the C variable declaration.</param>
+	/// <returns></returns>
+	static Declaration* Create(offset_t declAddr, DeclarationAlignment declAlign, size_t declSize,
+	                           const std::string& declType, const std::string& declName, const std::string& declBody);
 
-	Declaration(offset_t nAddress, const std::string& nIncludePath, size_t nSize,
-	            const std::string& nVarType, const std::string& nVarName);
+	/// <summary>
+	/// Creates an array declaration.
+	/// </summary>
+	/// <param name="declAddr">The address inside a binary file this declaration will be in when compiled.</param>
+	/// <param name="declAlign">The alignment of this declaration in the compiled binary file.</param>
+	/// <param name="declSize">The size of this declaration when it is compiled to binary data.</param>
+	/// <param name="declType">The C variable type this declaration will be declared as.</param>
+	/// <param name="declName">The C variable name this declaration will be declared as.</param>
+	/// <param name="declBody">The contents of the C variable declaration.</param>
+	/// <param name="declArrayItemCnt">The number of items in the array.</param>
+	/// <param name="isDeclExternal">(Optional) Is this declaration from another segment?</param>
+	/// <returns></returns>
+	static Declaration* CreateArray(offset_t declAddr, DeclarationAlignment declAlign,
+	                                size_t declSize, const std::string& declType, const std::string& declName,
+	                                const std::string& declBody, size_t declArrayItemCnt = 0,
+	                                bool isDeclExternal = false);
 
-	Declaration(offset_t nAddress, const std::string& nIncludePath, size_t nSize,
-	            const std::string& nVarType, const std::string& nVarName,
-	            const std::string& nDefines);
+	/// <summary>
+	/// Creates an array declaration who's size in the C code uses a custom string.
+	/// </summary>
+	/// <param name="declAddr">The address inside a binary file this declaration will be in when compiled.</param>
+	/// <param name="declAlign">The alignment of this declaration in the compiled binary file.</param>
+	/// <param name="declSize">The size of this declaration when it is compiled to binary data.</param>
+	/// <param name="declType">The C variable type this declaration will be declared as.</param>
+	/// <param name="declName">The C variable name this declaration will be declared as.</param>
+	/// <param name="declBody">The contents of the C variable declaration.</param>
+	/// <param name="declArrayItemCntStr">The string to be put in the C array's size inbetween the brackets.</param>
+	/// <param name="isDeclExternal">(Optional) Is this declaration from another segment?</param>
+	/// <returns></returns>
+	static Declaration* CreateArray(offset_t declAddr, DeclarationAlignment declAlign,
+	                                size_t declSize, const std::string& declType, const std::string& declName,
+	                                const std::string& declBody, const std::string& declArrayItemCntStr,
+	                                bool isDeclExternal = false);
+
+	/// <summary>
+	/// Creates a declaration who's body uses a #include to include another file
+	/// </summary>
+	/// <param name="declAddr">The address inside a binary file this declaration will be in when compiled.</param>
+	/// <param name="includePath">The path to the file this declaration will be #including.</param>
+	/// <param name="declSize">The size of this declaration when it is compiled to binary data.</param>
+	/// <param name="declType">The C variable type this declaration will be declared as.</param>
+	/// <param name="declName">The C variable name this declaration will be declared as.</param>
+	/// <param name="defines">(Optional) Any #define's we want to have outputted by this declaration.</param>
+	/// <returns></returns>
+	static Declaration* CreateInclude(offset_t declAddr, const std::string& includePath, size_t declSize,
+	                                  const std::string& declType, const std::string& declName,
+	                                  const std::string& defines = "");
+
+	/// <summary>
+	/// Creates a placeholder declaration to be replaced later.
+	/// </summary>
+	/// <param name="declAddr">The address inside a binary file this declaration will be in when compiled.</param>
+	/// <param name="declName">The C variable name this declaration will be declared as.</param>
+	/// <returns></returns>
+	static Declaration* CreatePlaceholder(offset_t declAddr, const std::string& declName);
 
 	bool IsStatic() const;
 
+	// Returns the declaration as C code as it would be in the code file when the body contains the needed data
 	std::string GetNormalDeclarationStr() const;
+
+	// Returns the declaration as C code as it would be in the code file when the body #include's another file
 	std::string GetExternalDeclarationStr() const;
 
+	// Generates the extern for this item to be placed in header files.
 	std::string GetExternStr() const;
+
+	// Generates any #define's needed
 	std::string GetDefinesStr() const;
 
 	std::string GetStaticForwardDeclarationStr() const;
 
 protected:
 	Declaration(offset_t nAddress, DeclarationAlignment nAlignment, size_t nSize,
-	            const std::string& nText);
+	            const std::string& nBody);
 };

--- a/ZAPD/OtherStructs/SkinLimbStructs.cpp
+++ b/ZAPD/OtherStructs/SkinLimbStructs.cpp
@@ -165,7 +165,7 @@ void Struct_800A598C::DeclareReferences(const std::string& prefix)
 			                            res.GetSourceTypeName(), unk_8_Str, arrayItemCnt, entryStr);
 		}
 		else
-			decl->text = entryStr;
+			decl->declBody = entryStr;
 	}
 
 	if (unk_C != 0 && GETSEGNUM(unk_C) == parent->segment)
@@ -195,7 +195,7 @@ void Struct_800A598C::DeclareReferences(const std::string& prefix)
 			                            res.GetSourceTypeName(), unk_C_Str, arrayItemCnt, entryStr);
 		}
 		else
-			decl->text = entryStr;
+			decl->declBody = entryStr;
 	}
 }
 
@@ -296,7 +296,7 @@ void Struct_800A5E28::DeclareReferences(const std::string& prefix)
 			                            res.GetSourceTypeName(), unk_4_Str, arrayItemCnt, entryStr);
 		}
 		else
-			decl->text = entryStr;
+			decl->declBody = entryStr;
 	}
 
 	if (unk_8 != SEGMENTED_NULL && GETSEGNUM(unk_8) == parent->segment)

--- a/ZAPD/ZAnimation.cpp
+++ b/ZAPD/ZAnimation.cpp
@@ -300,7 +300,7 @@ void ZCurveAnimation::DeclareReferences(const std::string& prefix)
 		}
 		else
 		{
-			decl->text = entryStr;
+			decl->declBody = entryStr;
 		}
 	}
 
@@ -331,7 +331,7 @@ void ZCurveAnimation::DeclareReferences(const std::string& prefix)
 		}
 		else
 		{
-			decl->text = entryStr;
+			decl->declBody = entryStr;
 		}
 	}
 
@@ -359,7 +359,7 @@ void ZCurveAnimation::DeclareReferences(const std::string& prefix)
 		}
 		else
 		{
-			decl->text = entryStr;
+			decl->declBody = entryStr;
 		}
 	}
 }

--- a/ZAPD/ZArray.cpp
+++ b/ZAPD/ZArray.cpp
@@ -79,7 +79,7 @@ Declaration* ZArray::DeclareVar(const std::string& prefix, const std::string& bo
 		                                                res->GetExternalExtension().c_str());
 		decl = parent->AddDeclarationIncludeArray(rawDataIndex, includePath, GetRawDataSize(),
 		                                          GetSourceTypeName(), name, arrayCnt);
-		decl->text = bodyStr;
+		decl->declBody = bodyStr;
 		decl->isExternal = true;
 	}
 	else

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -708,7 +708,7 @@ void ZDisplayList::Opcode_G_DL(uint64_t data, const std::string& prefix, char* l
 		if (!Globals::Instance->HasSegment(segNum))
 			sprintf(line, "gsSPBranchList(0x%08" PRIX64 "),", data & 0xFFFFFFFF);
 		else if (dListDecl != nullptr)
-			sprintf(line, "gsSPBranchList(%s),", dListDecl->varName.c_str());
+			sprintf(line, "gsSPBranchList(%s),", dListDecl->declName.c_str());
 		else
 			sprintf(line, "gsSPBranchList(%sDlist0x%06" PRIX64 "),", prefix.c_str(),
 			        GETSEGOFFSET(data));
@@ -718,7 +718,7 @@ void ZDisplayList::Opcode_G_DL(uint64_t data, const std::string& prefix, char* l
 		if (!Globals::Instance->HasSegment(segNum))
 			sprintf(line, "gsSPDisplayList(0x%08" PRIX64 "),", data & 0xFFFFFFFF);
 		else if (dListDecl != nullptr)
-			sprintf(line, "gsSPDisplayList(%s),", dListDecl->varName.c_str());
+			sprintf(line, "gsSPDisplayList(%s),", dListDecl->declName.c_str());
 		else
 			sprintf(line, "gsSPDisplayList(%sDlist0x%06" PRIX64 "),", prefix.c_str(),
 			        GETSEGOFFSET(data));
@@ -958,7 +958,7 @@ void ZDisplayList::Opcode_G_SETTIMG(uint64_t data, const std::string& prefix, ch
 		}
 
 		if (texDecl != nullptr)
-			sprintf(texStr, "%s", texDecl->varName.c_str());
+			sprintf(texStr, "%s", texDecl->declName.c_str());
 		else if (data != 0 && Globals::Instance->HasSegment(segmentNumber))
 			sprintf(texStr, "%sTex_%06X", prefix.c_str(), texAddress);
 		else

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -446,24 +446,25 @@ Declaration* ZFile::AddDeclaration(offset_t address, DeclarationAlignment alignm
                                    const std::string& varType, const std::string& varName,
                                    const std::string& body)
 {
-	bool validOffset = AddDeclarationChecks(address, varName);
+	bool validOffset = DeclarationSanityChecks(address, varName);
 	if (!validOffset)
 		return nullptr;
 
 	Declaration* decl = GetDeclaration(address);
 	if (decl == nullptr)
 	{
-		decl = new Declaration(address, alignment, size, varType, varName, false, body);
+		decl = Declaration::Create(address, alignment, size, varType, varName, body);
 		declarations[address] = decl;
 	}
 	else
 	{
 		decl->alignment = alignment;
 		decl->size = size;
-		decl->varType = varType;
-		decl->varName = varName;
-		decl->text = body;
+		decl->declType = varType;
+		decl->declName = varName;
+		decl->declBody = body;
 	}
+
 	return decl;
 }
 
@@ -472,27 +473,29 @@ Declaration* ZFile::AddDeclarationArray(offset_t address, DeclarationAlignment a
                                         const std::string& varName, size_t arrayItemCnt,
                                         const std::string& body)
 {
-	bool validOffset = AddDeclarationChecks(address, varName);
+	bool validOffset = DeclarationSanityChecks(address, varName);
 	if (!validOffset)
 		return nullptr;
 
 	Declaration* decl = GetDeclaration(address);
 	if (decl == nullptr)
 	{
-		decl =
-			new Declaration(address, alignment, size, varType, varName, true, arrayItemCnt, body);
+		decl = Declaration::CreateArray(address, alignment, size, varType, varName, body,
+		                                arrayItemCnt);
+
 		declarations[address] = decl;
 	}
 	else
 	{
 		if (decl->isPlaceholder)
-			decl->varName = varName;
+			decl->declName = varName;
+
 		decl->alignment = alignment;
 		decl->size = size;
-		decl->varType = varType;
+		decl->declType = varType;
 		decl->isArray = true;
 		decl->arrayItemCnt = arrayItemCnt;
-		decl->text = body;
+		decl->declBody = body;
 	}
 
 	return decl;
@@ -503,41 +506,41 @@ Declaration* ZFile::AddDeclarationArray(offset_t address, DeclarationAlignment a
                                         const std::string& varName,
                                         const std::string& arrayItemCntStr, const std::string& body)
 {
-	bool validOffset = AddDeclarationChecks(address, varName);
+	bool validOffset = DeclarationSanityChecks(address, varName);
 	if (!validOffset)
 		return nullptr;
 
 	Declaration* decl = GetDeclaration(address);
 	if (decl == nullptr)
 	{
-		decl = new Declaration(address, alignment, size, varType, varName, true, arrayItemCntStr,
-		                       body);
+		decl = Declaration::CreateArray(address, alignment, size, varType, varName,
+		                                body, arrayItemCntStr);
+
 		declarations[address] = decl;
 	}
 	else
 	{
 		decl->alignment = alignment;
 		decl->size = size;
-		decl->varType = varType;
-		decl->varName = varName;
+		decl->declType = varType;
+		decl->declName = varName;
 		decl->isArray = true;
 		decl->arrayItemCntStr = arrayItemCntStr;
-		decl->text = body;
+		decl->declBody = body;
 	}
 	return decl;
 }
 
 Declaration* ZFile::AddDeclarationPlaceholder(offset_t address, const std::string& varName)
 {
-	bool validOffset = AddDeclarationChecks(address, varName);
+	bool validOffset = DeclarationSanityChecks(address, varName);
 	if (!validOffset)
 		return nullptr;
 
 	Declaration* decl;
 	if (declarations.find(address) == declarations.end())
 	{
-		decl = new Declaration(address, DeclarationAlignment::Align4, 0, "", varName, false, "");
-		decl->isPlaceholder = true;
+		decl = Declaration::CreatePlaceholder(address, varName);
 		declarations[address] = decl;
 	}
 	else
@@ -550,22 +553,22 @@ Declaration* ZFile::AddDeclarationInclude(offset_t address, const std::string& i
                                           size_t size, const std::string& varType,
                                           const std::string& varName)
 {
-	bool validOffset = AddDeclarationChecks(address, varName);
+	bool validOffset = DeclarationSanityChecks(address, varName);
 	if (!validOffset)
 		return nullptr;
 
 	Declaration* decl = GetDeclaration(address);
 	if (decl == nullptr)
 	{
-		decl = new Declaration(address, includePath, size, varType, varName);
+		decl = Declaration::CreateInclude(address, includePath, size, varType, varName);
 		declarations[address] = decl;
 	}
 	else
 	{
 		decl->includePath = includePath;
 		decl->size = size;
-		decl->varType = varType;
-		decl->varName = varName;
+		decl->declType = varType;
+		decl->declName = varName;
 	}
 	return decl;
 }
@@ -574,7 +577,7 @@ Declaration* ZFile::AddDeclarationIncludeArray(offset_t address, std::string& in
                                                size_t size, const std::string& varType,
                                                const std::string& varName, size_t arrayItemCnt)
 {
-	bool validOffset = AddDeclarationChecks(address, varName);
+	bool validOffset = DeclarationSanityChecks(address, varName);
 	if (!validOffset)
 		return nullptr;
 
@@ -586,7 +589,7 @@ Declaration* ZFile::AddDeclarationIncludeArray(offset_t address, std::string& in
 	Declaration* decl = GetDeclaration(address);
 	if (decl == nullptr)
 	{
-		decl = new Declaration(address, includePath, size, varType, varName);
+		decl = Declaration::CreateInclude(address, includePath, size, varType, varName);
 
 		decl->isArray = true;
 		decl->arrayItemCnt = arrayItemCnt;
@@ -596,8 +599,8 @@ Declaration* ZFile::AddDeclarationIncludeArray(offset_t address, std::string& in
 	else
 	{
 		decl->includePath = includePath;
-		decl->varType = varType;
-		decl->varName = varName;
+		decl->declType = varType;
+		decl->declName = varName;
 		decl->size = size;
 		decl->isArray = true;
 		decl->arrayItemCnt = arrayItemCnt;
@@ -610,7 +613,7 @@ Declaration* ZFile::AddDeclarationIncludeArray(offset_t address, std::string& in
                                                const std::string& varName,
                                                const std::string& defines, size_t arrayItemCnt)
 {
-	bool validOffset = AddDeclarationChecks(address, varName);
+	bool validOffset = DeclarationSanityChecks(address, varName);
 	if (!validOffset)
 		return nullptr;
 
@@ -622,7 +625,7 @@ Declaration* ZFile::AddDeclarationIncludeArray(offset_t address, std::string& in
 	Declaration* decl = GetDeclaration(address);
 	if (decl == nullptr)
 	{
-		decl = new Declaration(address, includePath, size, varType, varName, defines);
+		decl = Declaration::CreateInclude(address, includePath, size, varType, varName, defines);
 
 		decl->isArray = true;
 		decl->arrayItemCnt = arrayItemCnt;
@@ -632,8 +635,8 @@ Declaration* ZFile::AddDeclarationIncludeArray(offset_t address, std::string& in
 	else
 	{
 		decl->includePath = includePath;
-		decl->varType = varType;
-		decl->varName = varName;
+		decl->declType = varType;
+		decl->declName = varName;
 		decl->defines = defines;
 		decl->size = size;
 		decl->isArray = true;
@@ -642,7 +645,7 @@ Declaration* ZFile::AddDeclarationIncludeArray(offset_t address, std::string& in
 	return decl;
 }
 
-bool ZFile::AddDeclarationChecks(uint32_t address, const std::string& varName)
+bool ZFile::DeclarationSanityChecks(uint32_t address, const std::string& varName)
 {
 	assert(GETSEGNUM(address) == 0);
 	assert(varName != "");
@@ -686,7 +689,7 @@ bool ZFile::GetDeclarationPtrName(segptr_t segAddress, const std::string& expect
 
 	if (expectedType != "" && expectedType != "void*")
 	{
-		if (expectedType != decl->varType && "static " + expectedType != decl->varType)
+		if (expectedType != decl->declType && "static " + expectedType != decl->declType)
 		{
 			declName = StringHelper::Sprintf("0x%08X", segAddress);
 			return false;
@@ -694,9 +697,9 @@ bool ZFile::GetDeclarationPtrName(segptr_t segAddress, const std::string& expect
 	}
 
 	if (!decl->isArray)
-		declName = "&" + decl->varName;
+		declName = "&" + decl->declName;
 	else
-		declName = decl->varName;
+		declName = decl->declName;
 	return true;
 }
 
@@ -720,7 +723,7 @@ bool ZFile::GetDeclarationArrayIndexedName(segptr_t segAddress, size_t elementSi
 
 	if (expectedType != "" && expectedType != "void*")
 	{
-		if (expectedType != decl->varType && "static " + expectedType != decl->varType)
+		if (expectedType != decl->declType && "static " + expectedType != decl->declType)
 		{
 			declName = StringHelper::Sprintf("0x%08X", segAddress);
 			return false;
@@ -729,7 +732,7 @@ bool ZFile::GetDeclarationArrayIndexedName(segptr_t segAddress, size_t elementSi
 
 	if (decl->address == address)
 	{
-		declName = decl->varName;
+		declName = decl->declName;
 		return true;
 	}
 
@@ -740,7 +743,7 @@ bool ZFile::GetDeclarationArrayIndexedName(segptr_t segAddress, size_t elementSi
 	}
 
 	uint32_t index = (address - decl->address) / elementSize;
-	declName = StringHelper::Sprintf("&%s[%u]", decl->varName.c_str(), index);
+	declName = StringHelper::Sprintf("&%s[%u]", decl->declName.c_str(), index);
 	return true;
 }
 
@@ -1020,12 +1023,12 @@ std::string ZFile::ProcessDeclarations()
 
 		if (curItem.second->isArray && lastItem.second->isArray)
 		{
-			if (curItem.second->varType == lastItem.second->varType)
+			if (curItem.second->declType == lastItem.second->declType)
 			{
 				if (!curItem.second->declaredInXml && !lastItem.second->declaredInXml)
 				{
 					// TEST: For now just do Vtx declarations...
-					if (lastItem.second->varType == "Vtx")
+					if (lastItem.second->declType == "Vtx")
 					{
 						int32_t sizeDiff = curItem.first - (lastItem.first + lastItem.second->size);
 
@@ -1034,7 +1037,7 @@ std::string ZFile::ProcessDeclarations()
 						{
 							lastItem.second->size += curItem.second->size;
 							lastItem.second->arrayItemCnt += curItem.second->arrayItemCnt;
-							lastItem.second->text += "\n" + curItem.second->text;
+							lastItem.second->declBody += "\n" + curItem.second->declBody;
 							declarations.erase(curItem.first);
 							declarationKeys.erase(declarationKeys.begin() + i);
 							delete curItem.second;
@@ -1082,20 +1085,20 @@ std::string ZFile::ProcessDeclarations()
 				// HACK
 				std::string extType;
 
-				if (item.second->varType == "Gfx")
+				if (item.second->declType == "Gfx")
 					extType = "dlist";
-				else if (item.second->varType == "Vtx")
+				else if (item.second->declType == "Vtx")
 					extType = "vtx";
 
-				auto filepath = outputPath / item.second->varName;
+				auto filepath = outputPath / item.second->declName;
 				File::WriteAllText(
 					StringHelper::Sprintf("%s.%s.inc", filepath.string().c_str(), extType.c_str()),
-					item.second->text);
+					item.second->declBody);
 			}
 
 			output += item.second->GetExternalDeclarationStr();
 		}
-		else if (item.second->varType != "")
+		else if (item.second->declType != "")
 		{
 			output += item.second->GetNormalDeclarationStr();
 		}
@@ -1111,17 +1114,17 @@ void ZFile::ProcessDeclarationText(Declaration* decl)
 	if (!(decl->references.size() > 0))
 		return;
 
-	for (size_t i = 0; i < decl->text.size() - 1; i++)
+	for (size_t i = 0; i < decl->declBody.size() - 1; i++)
 	{
-		char c = decl->text[i];
-		char c2 = decl->text[i + 1];
+		char c = decl->declBody[i];
+		char c2 = decl->declBody[i + 1];
 
 		if (c == '@' && c2 == 'r')
 		{
 			std::string vtxName;
 			Globals::Instance->GetSegmentedArrayIndexedName(decl->references[refIndex], 0x10, this,
 			                                                "Vtx", vtxName);
-			decl->text.replace(i, 2, vtxName);
+			decl->declBody.replace(i, 2, vtxName);
 
 			refIndex++;
 
@@ -1206,7 +1209,7 @@ std::string ZFile::ProcessTextureIntersections([[maybe_unused]] const std::strin
 				if (nextDecl == nullptr)
 					texNextName = texturesResources.at(nextOffset)->GetName();
 				else
-					texNextName = nextDecl->varName;
+					texNextName = nextDecl->declName;
 
 				defines += StringHelper::Sprintf("#define %s ((u32)%s + 0x%06X)\n",
 				                                 texNextName.c_str(), texName.c_str(), offsetDiff);
@@ -1279,8 +1282,8 @@ bool ZFile::HandleUnaccountedAddress(offset_t currentAddress, offset_t lastAddr,
 
 			std::string intersectionInfo = StringHelper::Sprintf(
 				"Resource from 0x%06X:0x%06X (%s) conflicts with 0x%06X (%s).", lastAddr,
-				lastAddr + lastSize, lastDecl->varName.c_str(), currentAddress,
-				currentDecl->varName.c_str());
+				lastAddr + lastSize, lastDecl->declName.c_str(), currentAddress,
+				currentDecl->declName.c_str());
 			HANDLE_WARNING_RESOURCE(WarningType::Intersection, this, nullptr, currentAddress,
 			                        "intersection detected", intersectionInfo);
 		}

--- a/ZAPD/ZFile.h
+++ b/ZAPD/ZFile.h
@@ -131,7 +131,7 @@ protected:
 	void DeclareResourceSubReferences();
 	void GenerateSourceFiles();
 	void GenerateSourceHeaderFiles();
-	bool AddDeclarationChecks(uint32_t address, const std::string& varName);
+	bool DeclarationSanityChecks(uint32_t address, const std::string& varName);
 	std::string ProcessDeclarations();
 	void ProcessDeclarationText(Declaration* decl);
 	std::string ProcessExterns();

--- a/ZAPD/ZPath.cpp
+++ b/ZAPD/ZPath.cpp
@@ -173,7 +173,7 @@ void PathwayEntry::DeclareReferences(const std::string& prefix)
 		                            points.size(), declaration);
 	}
 	else
-		decl->text = declaration;
+		decl->declBody = declaration;
 }
 
 std::string PathwayEntry::GetBodySourceCode() const

--- a/ZAPD/ZResource.cpp
+++ b/ZAPD/ZResource.cpp
@@ -274,7 +274,7 @@ void ZResource::GetSourceOutputCode([[maybe_unused]] const std::string& prefix)
 		if (decl == nullptr || decl->isPlaceholder)
 			decl = DeclareVar(prefix, bodyStr);
 		else
-			decl->text = bodyStr;
+			decl->declBody = bodyStr;
 
 		decl->staticConf = staticConf;
 	}

--- a/ZAPD/ZRoom/Commands/SetMesh.cpp
+++ b/ZAPD/ZRoom/Commands/SetMesh.cpp
@@ -151,7 +151,7 @@ void PolygonDlist::GetSourceOutputCode(const std::string& prefix)
 	if (decl == nullptr)
 		DeclareVar(prefix, bodyStr);
 	else
-		decl->text = bodyStr;
+		decl->declBody = bodyStr;
 }
 
 std::string PolygonDlist::GetSourceTypeName() const
@@ -371,7 +371,7 @@ void PolygonTypeBase::DeclareAndGenerateOutputCode(const std::string& prefix)
 	}
 	else
 	{
-		decl->text = bodyStr;
+		decl->declBody = bodyStr;
 	}
 }
 


### PR DESCRIPTION
This PR makes several changes to Declaration.cpp/Declaration.h and code which uses it.

To summarize:
- Variables which were not being used such as `preText`, `postText, etc were removed.
- Variables were renamed to make their purpose clearer - `text` being changed to `declBody`, as one example.
- Each variable is given a description explaining its purpose.
- Instead of having a bunch of different constructors for `Declaration` with varying parameters (which was causing some confusion), static functions are created which return a Declaration. Each one includes a descriptive name and an explanation of its purpose and the purpose of its arguments. Examples include `Declaration::Create`, `Declaration::CreateArray`, `Declaration::CreateInclude`, etc.
- A few functions were adjusted to simplify the logic. 