### PR TITLE
GCC 13 Fixes

### DIFF
--- a/ZAPD/CrashHandler.cpp
+++ b/ZAPD/CrashHandler.cpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <cstdio>
 #include <cstdlib>
+#include <cstdint>
 #include <ctime>
 
 #if HAS_POSIX == 1

--- a/ZAPD/Declaration.h
+++ b/ZAPD/Declaration.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 // TODO: should we drop the `_t` suffix because of UNIX compliance?
 typedef uint32_t segptr_t;

--- a/ZAPD/OutputFormatter.h
+++ b/ZAPD/OutputFormatter.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 class OutputFormatter
 {


### PR DESCRIPTION
GCC/G++ 13 restructured header files. This is the fix. [Porting to GCC 13](https://gcc.gnu.org/gcc-13/porting_to.html).