### PR TITLE
Some cleanup and refactoring

### DIFF
--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -419,6 +419,8 @@ int HandleExtract(ZFileMode fileMode, ExporterSet* exporterSet)
 		if (!parseSuccessful)
 			return 1;
 	}
+
+	return 0;
 }
 
 void BuildAssetTexture(const fs::path& pngFilePath, TextureType texType, const fs::path& outPath)

--- a/ZAPD/ZArray.cpp
+++ b/ZAPD/ZArray.cpp
@@ -56,7 +56,7 @@ void ZArray::ParseXML(tinyxml2::XMLElement* reader)
 		}
 		res->parent = parent;
 		res->SetInnerNode(true);
-		res->ExtractFromXML(child, childIndex);
+		res->ExtractWithXML(child, childIndex);
 
 		childIndex += res->GetRawDataSize();
 		resList.push_back(res);

--- a/ZAPD/ZDisplayList.cpp
+++ b/ZAPD/ZDisplayList.cpp
@@ -40,7 +40,7 @@ ZDisplayList::~ZDisplayList()
 }
 
 // EXTRACT MODE
-void ZDisplayList::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
+void ZDisplayList::ExtractWithXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
 	rawDataIndex = nRawDataIndex;
 	ParseXML(reader);

--- a/ZAPD/ZDisplayList.h
+++ b/ZAPD/ZDisplayList.h
@@ -346,7 +346,7 @@ public:
 	ZDisplayList(ZFile* nParent);
 	~ZDisplayList();
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
+	void ExtractWithXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
 	void ExtractFromBinary(uint32_t nRawDataIndex, int32_t rawDataSize);
 
 	void ParseRawData() override;

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -272,7 +272,7 @@ void ZFile::ParseXML(tinyxml2::XMLElement* reader, const std::string& filename)
 			ZResource* nRes = nodeMap[nodeName](this);
 
 			if (mode == ZFileMode::Extract || mode == ZFileMode::ExternalFile)
-				nRes->ExtractFromXML(child, rawDataIndex);
+				nRes->ExtractWithXML(child, rawDataIndex);
 
 			switch (nRes->GetResourceType())
 			{
@@ -887,13 +887,9 @@ std::string ZFile::GetExternalFileHeaderInclude() const
 		{
 			fs::path outputFolderPath = externalFile->GetSourceOutputFolderPath();
 			if (outputFolderPath == this->GetSourceOutputFolderPath())
-			{
 				outputFolderPath = externalFile->outName.stem();
-			}
 			else
-			{
 				outputFolderPath /= externalFile->outName.stem();
-			}
 
 			externalFilesIncludes +=
 				StringHelper::Sprintf("#include \"%s.h\"\n", outputFolderPath.string().c_str());

--- a/ZAPD/ZFile.cpp
+++ b/ZAPD/ZFile.cpp
@@ -772,6 +772,21 @@ bool ZFile::HasDeclaration(offset_t address)
 	return declarations.find(address) != declarations.end();
 }
 
+
+size_t ZFile::GetDeclarationSizeFromNeighbor(uint32_t declarationAddress)
+{
+	auto currentDecl = declarations.find(declarationAddress);
+	if (currentDecl == declarations.end())
+		return 0;
+
+	auto nextDecl = currentDecl;
+	std::advance(nextDecl, 1);
+	if (nextDecl == declarations.end())
+		return GetRawData().size() - currentDecl->first;
+
+	return nextDecl->first - currentDecl->first;
+}
+
 void ZFile::GenerateSourceFiles()
 {
 	std::string sourceOutput;

--- a/ZAPD/ZFile.h
+++ b/ZAPD/ZFile.h
@@ -89,6 +89,7 @@ public:
 	Declaration* GetDeclaration(offset_t address) const;
 	Declaration* GetDeclarationRanged(offset_t address) const;
 	bool HasDeclaration(offset_t address);
+	size_t GetDeclarationSizeFromNeighbor(uint32_t declarationAddress);
 
 	std::string GetHeaderInclude() const;
 	std::string GetZRoomHeaderInclude() const;

--- a/ZAPD/ZResource.cpp
+++ b/ZAPD/ZResource.cpp
@@ -24,7 +24,7 @@ ZResource::ZResource(ZFile* nParent)
 	RegisterOptionalAttribute("Static", "Global");
 }
 
-void ZResource::ExtractFromXML(tinyxml2::XMLElement* reader, offset_t nRawDataIndex)
+void ZResource::ExtractWithXML(tinyxml2::XMLElement* reader, offset_t nRawDataIndex)
 {
 	rawDataIndex = nRawDataIndex;
 	declaredInXml = true;

--- a/ZAPD/ZResource.h
+++ b/ZAPD/ZResource.h
@@ -80,8 +80,18 @@ public:
 	ZResource(ZFile* nParent);
 	virtual ~ZResource() = default;
 
-	// Parsing from File
-	virtual void ExtractFromXML(tinyxml2::XMLElement* reader, offset_t nRawDataIndex);
+
+	/// <summary>
+	/// Extracts/Parsees data from binary file using an XML to provide the needed metadata.
+	/// </summary>
+	/// <param name="reader">XML Node we wish to parse from.</param>
+	/// <param name="nRawDataIndex">The offset within the binary file we are going to parse from as indicated by the "Offset" parameter in the XML.</param>
+	virtual void ExtractWithXML(tinyxml2::XMLElement* reader, offset_t nRawDataIndex);
+
+	/// <summary>
+	/// Extracts/Parses the needed data straight from a binary without the use of an XML.
+	/// </summary>
+	/// <param name="nRawDataIndex">The offset within the binary file we wish to parse from.</param>
 	virtual void ExtractFromFile(offset_t nRawDataIndex);
 
 	// Misc

--- a/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
+++ b/ZAPD/ZRoom/Commands/SetAlternateHeaders.cpp
@@ -21,7 +21,7 @@ void SetAlternateHeaders::DeclareReferences([[maybe_unused]] const std::string& 
 
 void SetAlternateHeaders::ParseRawDataLate()
 {
-	size_t numHeaders = zRoom->GetDeclarationSizeFromNeighbor(segmentOffset) / 4;
+	size_t numHeaders = zRoom->parent->GetDeclarationSizeFromNeighbor(segmentOffset) / 4;
 
 	headers.reserve(numHeaders);
 	for (uint32_t i = 0; i < numHeaders; i++)

--- a/ZAPD/ZRoom/Commands/SetEntranceList.cpp
+++ b/ZAPD/ZRoom/Commands/SetEntranceList.cpp
@@ -24,7 +24,7 @@ void SetEntranceList::DeclareReferences([[maybe_unused]] const std::string& pref
 void SetEntranceList::ParseRawDataLate()
 {
 	// Parse Entrances and Generate Declaration
-	uint32_t numEntrances = zRoom->GetDeclarationSizeFromNeighbor(segmentOffset) / 2;
+	uint32_t numEntrances = zRoom->parent->GetDeclarationSizeFromNeighbor(segmentOffset) / 2;
 	uint32_t currentPtr = segmentOffset;
 
 	entrances.reserve(numEntrances);

--- a/ZAPD/ZRoom/Commands/SetExitList.cpp
+++ b/ZAPD/ZRoom/Commands/SetExitList.cpp
@@ -24,7 +24,7 @@ void SetExitList::DeclareReferences([[maybe_unused]] const std::string& prefix)
 void SetExitList::ParseRawDataLate()
 {
 	// Parse Entrances and Generate Declaration
-	uint32_t numEntrances = zRoom->GetDeclarationSizeFromNeighbor(segmentOffset) / 2;
+	uint32_t numEntrances = zRoom->parent->GetDeclarationSizeFromNeighbor(segmentOffset) / 2;
 	uint32_t currentPtr = segmentOffset;
 
 	exits.reserve(numEntrances);

--- a/ZAPD/ZRoom/Commands/SetPathways.cpp
+++ b/ZAPD/ZRoom/Commands/SetPathways.cpp
@@ -24,7 +24,7 @@ void SetPathways::ParseRawDataLate()
 {
 	if (Globals::Instance->game == ZGame::MM_RETAIL)
 	{
-		auto numPaths = zRoom->GetDeclarationSizeFromNeighbor(segmentOffset) / 8;
+		auto numPaths = zRoom->parent->GetDeclarationSizeFromNeighbor(segmentOffset) / 8;
 		pathwayList.SetNumPaths(numPaths);
 	}
 

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -356,20 +356,6 @@ ZRoomCommand* ZRoom::FindCommandOfType(RoomCommand cmdType)
 	return nullptr;
 }
 
-size_t ZRoom::GetDeclarationSizeFromNeighbor(uint32_t declarationAddress)
-{
-	auto currentDecl = parent->declarations.find(declarationAddress);
-	if (currentDecl == parent->declarations.end())
-		return 0;
-
-	auto nextDecl = currentDecl;
-	std::advance(nextDecl, 1);
-	if (nextDecl == parent->declarations.end())
-		return parent->GetRawData().size() - currentDecl->first;
-
-	return nextDecl->first - currentDecl->first;
-}
-
 size_t ZRoom::GetCommandSizeFromNeighbor(ZRoomCommand* cmd)
 {
 	int32_t cmdIndex = -1;

--- a/ZAPD/ZRoom/ZRoom.cpp
+++ b/ZAPD/ZRoom/ZRoom.cpp
@@ -64,9 +64,9 @@ ZRoom::~ZRoom()
 		delete cmd;
 }
 
-void ZRoom::ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
+void ZRoom::ExtractWithXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex)
 {
-	ZResource::ExtractFromXML(reader, nRawDataIndex);
+	ZResource::ExtractWithXML(reader, nRawDataIndex);
 
 	if (hackMode == "syotes_room")
 		SyotesRoomFix();

--- a/ZAPD/ZRoom/ZRoom.h
+++ b/ZAPD/ZRoom/ZRoom.h
@@ -22,7 +22,7 @@ public:
 	ZRoom(ZFile* nParent);
 	virtual ~ZRoom();
 
-	void ExtractFromXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
+	void ExtractWithXML(tinyxml2::XMLElement* reader, uint32_t nRawDataIndex) override;
 	void ExtractFromBinary(uint32_t nRawDataIndex, ZResourceType parentType);
 
 	void ParseXML(tinyxml2::XMLElement* reader) override;

--- a/ZAPD/ZRoom/ZRoom.h
+++ b/ZAPD/ZRoom/ZRoom.h
@@ -37,7 +37,6 @@ public:
 	void GetSourceOutputCode(const std::string& prefix) override;
 
 	std::string GetDefaultName(const std::string& prefix) const override;
-	size_t GetDeclarationSizeFromNeighbor(uint32_t declarationAddress);
 	size_t GetCommandSizeFromNeighbor(ZRoomCommand* cmd);
 	ZRoomCommand* FindCommandOfType(RoomCommand cmdType);
 


### PR DESCRIPTION
- Main is divided up into sub functions to reduce clutter.
- `ZResource::ExtractWithXML` is renamed to `ZResource::ExtractFromXML` to avoid confusion. Some documentation on how it works has also been added.
- ZRoom's `GetDeclarationSizeFromNeighbor` was moved into `ZFile` since nothing about it is exclusive to rooms and it can be useful elsewhere.