### PR TITLE
Ignore warning args in ParseArgs

### DIFF
--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -258,6 +258,12 @@ void ParseArgs(int& argc, char* argv[])
 	{
 		std::string arg = argv[i];
 
+		// Ignore warning args as they have already been parsed
+		if (arg[0] == '-' && arg[1] == 'W' && arg[2] != '\0')
+		{
+			continue;
+		}
+
 		auto it = ArgFuncDictionary.find(arg);
 		if (it == ArgFuncDictionary.end())
 		{

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -259,7 +259,7 @@ void ParseArgs(int& argc, char* argv[])
 		std::string arg = argv[i];
 
 		// Ignore warning args as they have already been parsed
-		if (arg[0] == '-' && arg[1] == 'W' && arg[2] != '\0')
+		if (arg.length() > 2 && arg[0] == '-' && arg[1] == 'W' && arg[2] != '\0')
 		{
 			continue;
 		}


### PR DESCRIPTION
Passing warning args would always result in Unsupported argument errors as the args map did not include them. They are instead handled separately by the WarningsHandler.