### PR TITLE
Support for compiling on MacOS 10.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,18 @@ COPYCHECK_ARGS ?=
 LLD ?= 0
 WERROR ?= 0
 
+# On MacOS 10.14, use boost::filesystem, because
+# the system doesn't supply std::filesystem.
+ifneq ($(OS),Windows_NT)
+    ifeq ($(shell uname -s),Darwin)
+        MACOS_VERSION := $(shell sw_vers -productVersion | cut -d . -f 1,2)
+        ifeq ($(MACOS_VERSION),10.14)
+            USE_BOOST_FS ?= 1
+        endif
+    endif
+endif
+USE_BOOST_FS ?= 0
+
 # Use clang++ if available, else use g++
 ifeq ($(shell command -v clang++ >/dev/null 2>&1; echo $$?),0)
   CXX := clang++
@@ -45,6 +57,11 @@ endif
 # CXXFLAGS += -DTEXTURE_DEBUG
 
 LDFLAGS := -lm -ldl -lpng
+
+ifneq ($(USE_BOOST_FS),0)
+  CXXFLAGS += -DUSE_BOOST_FS
+  LDFLAGS += -lboost_filesystem
+endif
 
 # Use LLD if available. Set LLD=0 to not use it
 ifeq ($(shell command -v ld.lld >/dev/null 2>&1; echo $$?),0)

--- a/ZAPDUtils/Utils/Directory.h
+++ b/ZAPDUtils/Utils/Directory.h
@@ -4,7 +4,10 @@
 #include <string>
 #include <vector>
 
-#if __has_include(<filesystem>)
+#ifdef USE_BOOST_FS
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+#elif __has_include(<filesystem>)
 #include <filesystem>
 namespace fs = std::filesystem;
 #else
@@ -17,7 +20,11 @@ namespace fs = std::experimental::filesystem;
 class Directory
 {
 public:
+#ifdef USE_BOOST_FS
+	static std::string GetCurrentDirectory() { return fs::current_path().string(); }
+#else
 	static std::string GetCurrentDirectory() { return fs::current_path().u8string(); }
+#endif
 
 	static bool Exists(const fs::path& path) { return fs::exists(path); }
 

--- a/ZAPDUtils/Utils/File.h
+++ b/ZAPDUtils/Utils/File.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#ifdef USE_BOOST_FS
+#include <boost/filesystem/fstream.hpp>
+#else
 #include <fstream>
+#endif
+
 #include <string>
 #include <vector>
 #include "Directory.h"
@@ -8,16 +13,24 @@
 
 class File
 {
+#ifdef USE_BOOST_FS
+	typedef fs::ifstream ifstream;
+	typedef fs::ofstream ofstream;
+#else
+	typedef std::ifstream ifstream;
+	typedef std::ofstream ofstream;
+#endif
+
 public:
 	static bool Exists(const fs::path& filePath)
 	{
-		std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
+		ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
 		return file.good();
 	}
 
 	static std::vector<uint8_t> ReadAllBytes(const fs::path& filePath)
 	{
-		std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
+		ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
 		int32_t fileSize = (int32_t)file.tellg();
 		file.seekg(0);
 		char* data = new char[fileSize];
@@ -31,7 +44,7 @@ public:
 
 	static std::string ReadAllText(const fs::path& filePath)
 	{
-		std::ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
+		ifstream file(filePath, std::ios::in | std::ios::binary | std::ios::ate);
 		if (!file.is_open())
 			return "";
 		int32_t fileSize = (int32_t)file.tellg();
@@ -56,28 +69,28 @@ public:
 
 	static void WriteAllBytes(const fs::path& filePath, const std::vector<uint8_t>& data)
 	{
-		std::ofstream file(filePath, std::ios::binary);
+		ofstream file(filePath, std::ios::binary);
 		file.write((char*)data.data(), data.size());
 		file.close();
 	};
 
 	static void WriteAllBytes(const std::string& filePath, const std::vector<char>& data)
 	{
-		std::ofstream file(filePath, std::ios::binary);
+		ofstream file(filePath, std::ios::binary);
 		file.write((char*)data.data(), data.size());
 		file.close();
 	};
 
 	static void WriteAllBytes(const std::string& filePath, const char* data, int dataSize)
 	{
-		std::ofstream file(filePath, std::ios::binary);
+		ofstream file(filePath, std::ios::binary);
 		file.write((char*)data, dataSize);
 		file.close();
 	};
 
 	static void WriteAllText(const fs::path& filePath, const std::string& text)
 	{
-		std::ofstream file(filePath, std::ios::out);
+		ofstream file(filePath, std::ios::out);
 		file.write(text.c_str(), text.size());
 		file.close();
 	}

--- a/ZAPDUtils/Utils/Path.h
+++ b/ZAPDUtils/Utils/Path.h
@@ -4,7 +4,10 @@
 #include <string>
 #include "Utils/StringHelper.h"
 
-#if __has_include(<filesystem>)
+#ifdef USE_BOOST_FS
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+#elif __has_include(<filesystem>)
 #include <filesystem>
 namespace fs = std::filesystem;
 #else


### PR DESCRIPTION
This adds an option to use `boost::filesystem` instead of `std::filesystem`, and uses it by default if MacOS 10.14 is detected.

The APIs aren't exactly the same, so this did need some small changes in ZAPDUtils, all conditional on `USE_BOOST_FS` being defined:

* `string()` instead of `u8string()`.
* `fstream` constructors that take `path`s are defined in the `fs` namespace, not `std`.
* Include `<boost/filesystem.hpp>` instead of `<filesystem>`.

With this patch, ZAPD compiles without issue on MacOS 10.14.