### PR TITLE
Use Enum names for Ocarina Actions and Sequence IDs

### DIFF
--- a/ZAPD/GameConfig.cpp
+++ b/ZAPD/GameConfig.cpp
@@ -214,6 +214,12 @@ void GameConfig::ConfigFunc_EnumData(const tinyxml2::XMLElement& element)
 			else if (enumKey == "naviQuestHintType")
 				enumData.naviQuestHintType[itemIndex] = itemID;
 
+			else if (enumKey == "ocarinaSongActionId")
+				enumData.ocarinaSongActionId[itemIndex] = itemID;
+
+			else if (enumKey == "seqId")
+				enumData.seqId[itemIndex] = itemID;
+
 			// MM
 			else if (enumKey == "modifySeqType")
 				enumData.modifySeqType[itemIndex] = itemID;

--- a/ZAPD/GameConfig.h
+++ b/ZAPD/GameConfig.h
@@ -31,6 +31,8 @@ public:
 	std::map<uint16_t, std::string> fadeOutSeqPlayer;
 	std::map<uint16_t, std::string> transitionType;
 	std::map<uint16_t, std::string> naviQuestHintType;
+	std::map<uint16_t, std::string> ocarinaSongActionId;
+	std::map<uint16_t, std::string> seqId;
 
 	// OoT
 	std::map<uint16_t, std::string> textType;

--- a/ZAPD/OtherStructs/CutsceneMM_Commands.cpp
+++ b/ZAPD/OtherStructs/CutsceneMM_Commands.cpp
@@ -73,14 +73,16 @@ std::string CutsceneMMSubCommandEntry_GenericCmd::GetBodySourceCode() const
 	         enumData->chooseCreditsSceneType.find(base) != enumData->chooseCreditsSceneType.end())
 		type = enumData->chooseCreditsSceneType[base];
 
-	else if (commandId == CutsceneMM_CommandType::CS_CMD_START_SEQ) {
+	else if (commandId == CutsceneMM_CommandType::CS_CMD_START_SEQ)
+	{
 		if (isIndexInSeqId)
 			type = enumData->seqId[base - 1];
 		else
 			entryFmt = "CS_START_SEQ(0x%04X, %i, %i)";
 	}
 
-	else if (commandId == CutsceneMM_CommandType::CS_CMD_STOP_SEQ) {
+	else if (commandId == CutsceneMM_CommandType::CS_CMD_STOP_SEQ)
+	{
 		if (isIndexInSeqId)
 			type = enumData->seqId[base - 1];
 		else
@@ -364,11 +366,12 @@ std::string CutsceneMMSubCommandEntry_Text::GetBodySourceCode() const
 	if (type == 2)
 	{
 		if (enumData->ocarinaSongActionId.find(base) != enumData->ocarinaSongActionId.end())
-			return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%s, %i, %i, 0x%X)", enumData->ocarinaSongActionId[base].c_str(), startFrame,
-										endFrame, textId1);
+			return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%s, %i, %i, 0x%X)",
+			                             enumData->ocarinaSongActionId[base].c_str(), startFrame,
+			                             endFrame, textId1);
 		else
-			return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%i, %i, %i, 0x%X)", base, startFrame,
-										endFrame, textId1);
+			return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%i, %i, %i, 0x%X)", base,
+			                             startFrame, endFrame, textId1);
 	}
 
 	switch (type)

--- a/ZAPD/OtherStructs/CutsceneMM_Commands.cpp
+++ b/ZAPD/OtherStructs/CutsceneMM_Commands.cpp
@@ -14,13 +14,13 @@ const std::unordered_map<CutsceneMM_CommandType, CsCommandListDescriptor> csComm
 	{CutsceneMM_CommandType::CS_CMD_TRANSITION, {"CS_TRANSITION", "(%s, %i, %i)"}},
 	{CutsceneMM_CommandType::CS_CMD_MOTION_BLUR, {"CS_MOTION_BLUR", "(%s, %i, %i)"}},
 	{CutsceneMM_CommandType::CS_CMD_GIVE_TATL, {"CS_GIVE_TATL", "(%s, %i, %i)"}},
-	{CutsceneMM_CommandType::CS_CMD_START_SEQ, {"CS_START_SEQ", "(0x%04X, %i, %i)"}},
+	{CutsceneMM_CommandType::CS_CMD_START_SEQ, {"CS_START_SEQ", "(%s, %i, %i)"}},
 	{CutsceneMM_CommandType::CS_CMD_SFX_REVERB_INDEX_2,
      {"CS_SFX_REVERB_INDEX_2", "(0x%04X, %i, %i)"}},
 	{CutsceneMM_CommandType::CS_CMD_SFX_REVERB_INDEX_1,
      {"CS_SFX_REVERB_INDEX_1", "(0x%04X, %i, %i)"}},
 	{CutsceneMM_CommandType::CS_CMD_MODIFY_SEQ, {"CS_MODIFY_SEQ", "(%s, %i, %i)"}},
-	{CutsceneMM_CommandType::CS_CMD_STOP_SEQ, {"CS_STOP_SEQ", "(0x%04X, %i, %i, %i)"}},
+	{CutsceneMM_CommandType::CS_CMD_STOP_SEQ, {"CS_STOP_SEQ", "(%s, %i, %i, %i)"}},
 	{CutsceneMM_CommandType::CS_CMD_START_AMBIENCE, {"CS_START_AMBIENCE", "(0x%04X, %i, %i)"}},
 	{CutsceneMM_CommandType::CS_CMD_FADE_OUT_AMBIENCE,
      {"CS_FADE_OUT_AMBIENCE", "(0x%04X, %i, %i)"}},
@@ -41,6 +41,7 @@ std::string CutsceneMMSubCommandEntry_GenericCmd::GetBodySourceCode() const
 	const auto& element = csCommandsDescMM.find(commandId);
 	std::string entryFmt = "CS_UNK_DATA(0x%02X, %i, %i, %i)";
 	std::string type = "";
+	bool isIndexInSeqId = enumData->seqId.find(base - 1) != enumData->seqId.end();
 
 	if (element != csCommandsDescMM.end())
 	{
@@ -71,6 +72,20 @@ std::string CutsceneMMSubCommandEntry_GenericCmd::GetBodySourceCode() const
 	else if (commandId == CutsceneMM_CommandType::CS_CMD_CHOOSE_CREDITS_SCENES &&
 	         enumData->chooseCreditsSceneType.find(base) != enumData->chooseCreditsSceneType.end())
 		type = enumData->chooseCreditsSceneType[base];
+
+	else if (commandId == CutsceneMM_CommandType::CS_CMD_START_SEQ) {
+		if (isIndexInSeqId)
+			type = enumData->seqId[base - 1];
+		else
+			entryFmt = "CS_START_SEQ(0x%04X, %i, %i)";
+	}
+
+	else if (commandId == CutsceneMM_CommandType::CS_CMD_STOP_SEQ) {
+		if (isIndexInSeqId)
+			type = enumData->seqId[base - 1];
+		else
+			entryFmt = "CS_STOP_SEQ(0x%04X, %i, %i, %i)";
+	}
 
 	else if (commandId == CutsceneMM_CommandType::CS_CMD_GIVE_TATL)
 		type = base ? "true" : "false";
@@ -339,6 +354,8 @@ CutsceneMMSubCommandEntry_Text::CutsceneMMSubCommandEntry_Text(const std::vector
 
 std::string CutsceneMMSubCommandEntry_Text::GetBodySourceCode() const
 {
+	EnumData* enumData = &Globals::Instance->cfg.enumData;
+
 	if (type == 0xFFFF)
 	{
 		return StringHelper::Sprintf("CS_TEXT_NONE(%i, %i)", startFrame, endFrame);
@@ -346,10 +363,12 @@ std::string CutsceneMMSubCommandEntry_Text::GetBodySourceCode() const
 
 	if (type == 2)
 	{
-		// TODO: set the enum name when it will be documented
-		// (https://github.com/Decompollaborate/mm/blob/3e1c568c084671c17836ced904714ea49d989621/include/z64ocarina.h#L35-L118)
-		return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%i, %i, %i, 0x%X)", base, startFrame,
-		                             endFrame, textId1);
+		if (enumData->ocarinaSongActionId.find(base) != enumData->ocarinaSongActionId.end())
+			return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%s, %i, %i, 0x%X)", enumData->ocarinaSongActionId[base].c_str(), startFrame,
+										endFrame, textId1);
+		else
+			return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%i, %i, %i, 0x%X)", base, startFrame,
+										endFrame, textId1);
 	}
 
 	switch (type)

--- a/ZAPD/OtherStructs/CutsceneMM_Commands.cpp
+++ b/ZAPD/OtherStructs/CutsceneMM_Commands.cpp
@@ -73,21 +73,10 @@ std::string CutsceneMMSubCommandEntry_GenericCmd::GetBodySourceCode() const
 	         enumData->chooseCreditsSceneType.find(base) != enumData->chooseCreditsSceneType.end())
 		type = enumData->chooseCreditsSceneType[base];
 
-	else if (commandId == CutsceneMM_CommandType::CS_CMD_START_SEQ)
-	{
-		if (isIndexInSeqId)
-			type = enumData->seqId[base - 1];
-		else
-			entryFmt = "CS_START_SEQ(0x%04X, %i, %i)";
-	}
-
-	else if (commandId == CutsceneMM_CommandType::CS_CMD_STOP_SEQ)
-	{
-		if (isIndexInSeqId)
-			type = enumData->seqId[base - 1];
-		else
-			entryFmt = "CS_STOP_SEQ(0x%04X, %i, %i, %i)";
-	}
+	else if ((commandId == CutsceneMM_CommandType::CS_CMD_START_SEQ ||
+	          commandId == CutsceneMM_CommandType::CS_CMD_STOP_SEQ) &&
+	         isIndexInSeqId)
+		type = enumData->seqId[base - 1];
 
 	else if (commandId == CutsceneMM_CommandType::CS_CMD_GIVE_TATL)
 		type = base ? "true" : "false";
@@ -363,15 +352,12 @@ std::string CutsceneMMSubCommandEntry_Text::GetBodySourceCode() const
 		return StringHelper::Sprintf("CS_TEXT_NONE(%i, %i)", startFrame, endFrame);
 	}
 
-	if (type == 2)
+	if (type == 2 &&
+	    enumData->ocarinaSongActionId.find(base) != enumData->ocarinaSongActionId.end())
 	{
-		if (enumData->ocarinaSongActionId.find(base) != enumData->ocarinaSongActionId.end())
-			return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%s, %i, %i, 0x%X)",
-			                             enumData->ocarinaSongActionId[base].c_str(), startFrame,
-			                             endFrame, textId1);
-		else
-			return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%i, %i, %i, 0x%X)", base,
-			                             startFrame, endFrame, textId1);
+		return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%s, %i, %i, 0x%X)",
+		                             enumData->ocarinaSongActionId[base].c_str(), startFrame,
+		                             endFrame, textId1);
 	}
 
 	switch (type)

--- a/ZAPD/OtherStructs/CutsceneOoT_Commands.cpp
+++ b/ZAPD/OtherStructs/CutsceneOoT_Commands.cpp
@@ -51,8 +51,7 @@ std::string CutsceneOoTSubCommandEntry_GenericCmd::GetBodySourceCode() const
 		bool isIndexInMisc = enumData->miscType.find(base) != enumData->miscType.end();
 		bool isIndexInFade =
 			enumData->fadeOutSeqPlayer.find(base) != enumData->fadeOutSeqPlayer.end();
-		bool isIndexInSeqId =
-			enumData->seqId.find(base - 1) != enumData->seqId.end();
+		bool isIndexInSeqId = enumData->seqId.find(base - 1) != enumData->seqId.end();
 		std::string entryFmt = element->second.cmdMacro;
 		std::string firstArg;
 		entryFmt += element->second.args;
@@ -67,9 +66,9 @@ std::string CutsceneOoTSubCommandEntry_GenericCmd::GetBodySourceCode() const
 			firstArg = enumData->seqId[base - 1];
 		else
 		{
-			return StringHelper::Sprintf(entryFmt.c_str(), base - 1, startFrame,
-			                             endFrame, pad, unused1, unused2, unused3, unused4, unused5,
-			                             unused6, unused7, unused8, unused9, unused10);
+			return StringHelper::Sprintf(entryFmt.c_str(), base - 1, startFrame, endFrame, pad,
+			                             unused1, unused2, unused3, unused4, unused5, unused6,
+			                             unused7, unused8, unused9, unused10);
 		}
 		return StringHelper::Sprintf(entryFmt.c_str(), firstArg.c_str(), startFrame, endFrame, pad,
 		                             unused1, unused2, unused3, unused4, unused5, unused6, unused7,
@@ -273,9 +272,11 @@ std::string CutsceneOoTSubCommandEntry_Text::GetBodySourceCode() const
 	{
 		return StringHelper::Sprintf("CS_TEXT_NONE(%i, %i)", startFrame, endFrame);
 	}
-	if (type == 2 && enumData->ocarinaSongActionId.find(base) != enumData->ocarinaSongActionId.end())
+	if (type == 2 &&
+	    enumData->ocarinaSongActionId.find(base) != enumData->ocarinaSongActionId.end())
 	{
-		return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%s, %i, %i, 0x%X)", enumData->ocarinaSongActionId[base].c_str(), startFrame,
+		return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%s, %i, %i, 0x%X)",
+		                             enumData->ocarinaSongActionId[base].c_str(), startFrame,
 		                             endFrame, textId1);
 	}
 

--- a/ZAPD/OtherStructs/CutsceneOoT_Commands.cpp
+++ b/ZAPD/OtherStructs/CutsceneOoT_Commands.cpp
@@ -52,7 +52,7 @@ std::string CutsceneOoTSubCommandEntry_GenericCmd::GetBodySourceCode() const
 		bool isIndexInFade =
 			enumData->fadeOutSeqPlayer.find(base) != enumData->fadeOutSeqPlayer.end();
 		bool isIndexInSeqId =
-			enumData->seqId.find(base) != enumData->seqId.end();
+			enumData->seqId.find(base - 1) != enumData->seqId.end();
 		std::string entryFmt = element->second.cmdMacro;
 		std::string firstArg;
 		entryFmt += element->second.args;

--- a/ZAPD/OtherStructs/CutsceneOoT_Commands.cpp
+++ b/ZAPD/OtherStructs/CutsceneOoT_Commands.cpp
@@ -15,9 +15,9 @@ const std::unordered_map<CutsceneOoT_CommandType, CsCommandListDescriptor> csCom
 	{CutsceneOoT_CommandType::CS_CMD_LIGHT_SETTING,
      {"CS_LIGHT_SETTING", "(0x%02X, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i)"}},
 	{CutsceneOoT_CommandType::CS_CMD_START_SEQ,
-     {"CS_START_SEQ", "(%i, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i)"}},
+     {"CS_START_SEQ", "(%s, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i)"}},
 	{CutsceneOoT_CommandType::CS_CMD_STOP_SEQ,
-     {"CS_STOP_SEQ", "(%i, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i)"}},
+     {"CS_STOP_SEQ", "(%s, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i)"}},
 	{CutsceneOoT_CommandType::CS_CMD_FADE_OUT_SEQ,
      {"CS_FADE_OUT_SEQ", "(%s, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i)"}},
 };
@@ -51,6 +51,8 @@ std::string CutsceneOoTSubCommandEntry_GenericCmd::GetBodySourceCode() const
 		bool isIndexInMisc = enumData->miscType.find(base) != enumData->miscType.end();
 		bool isIndexInFade =
 			enumData->fadeOutSeqPlayer.find(base) != enumData->fadeOutSeqPlayer.end();
+		bool isIndexInSeqId =
+			enumData->seqId.find(base) != enumData->seqId.end();
 		std::string entryFmt = element->second.cmdMacro;
 		std::string firstArg;
 		entryFmt += element->second.args;
@@ -59,12 +61,13 @@ std::string CutsceneOoTSubCommandEntry_GenericCmd::GetBodySourceCode() const
 			firstArg = enumData->miscType[base];
 		else if (commandId == CutsceneOoT_CommandType::CS_CMD_FADE_OUT_SEQ && isIndexInFade)
 			firstArg = enumData->fadeOutSeqPlayer[base];
+		else if (commandId == CutsceneOoT_CommandType::CS_CMD_START_SEQ && isIndexInSeqId)
+			firstArg = enumData->seqId[base - 1];
+		else if (commandId == CutsceneOoT_CommandType::CS_CMD_STOP_SEQ && isIndexInSeqId)
+			firstArg = enumData->seqId[base - 1];
 		else
 		{
-			bool baseOne = (commandId == CutsceneOoT_CommandType::CS_CMD_LIGHT_SETTING ||
-			                commandId == CutsceneOoT_CommandType::CS_CMD_START_SEQ ||
-			                commandId == CutsceneOoT_CommandType::CS_CMD_STOP_SEQ);
-			return StringHelper::Sprintf(entryFmt.c_str(), baseOne ? base - 1 : base, startFrame,
+			return StringHelper::Sprintf(entryFmt.c_str(), base - 1, startFrame,
 			                             endFrame, pad, unused1, unused2, unused3, unused4, unused5,
 			                             unused6, unused7, unused8, unused9, unused10);
 		}
@@ -270,9 +273,9 @@ std::string CutsceneOoTSubCommandEntry_Text::GetBodySourceCode() const
 	{
 		return StringHelper::Sprintf("CS_TEXT_NONE(%i, %i)", startFrame, endFrame);
 	}
-	if (type == 2)
+	if (type == 2 && enumData->ocarinaSongActionId.find(base) != enumData->ocarinaSongActionId.end())
 	{
-		return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%i, %i, %i, 0x%X)", base, startFrame,
+		return StringHelper::Sprintf("CS_TEXT_OCARINA_ACTION(%s, %i, %i, 0x%X)", enumData->ocarinaSongActionId[base].c_str(), startFrame,
 		                             endFrame, textId1);
 	}
 

--- a/ZAPD/OtherStructs/SkinLimbStructs.h
+++ b/ZAPD/OtherStructs/SkinLimbStructs.h
@@ -8,9 +8,9 @@
 
 enum class ZLimbSkinType
 {
-	SkinType_Null,			// SkinLimb segment = NULL
-	SkinType_Animated = 4,	// SkinLimb segment = SkinAnimatedLimbData*
-	SkinType_Normal = 11,	// SkinLimb segment = Gfx*
+	SkinType_Null,          // SkinLimb segment = NULL
+	SkinType_Animated = 4,  // SkinLimb segment = SkinAnimatedLimbData*
+	SkinType_Normal = 11,   // SkinLimb segment = Gfx*
 };
 
 class SkinVertex : public ZResource
@@ -75,11 +75,11 @@ public:
 	size_t GetRawDataSize() const override;
 
 protected:
-	uint16_t vtxCount;				// Number of vertices in this modif entry
-	uint16_t transformCount;		// Length of limbTransformations
-	uint16_t unk_4;					// 0 or 1, used as an index for limbTransformations
-	segptr_t skinVertices;			// SkinVertex*
-	segptr_t limbTransformations;	// SkinTransformation*
+	uint16_t vtxCount;             // Number of vertices in this modif entry
+	uint16_t transformCount;       // Length of limbTransformations
+	uint16_t unk_4;                // 0 or 1, used as an index for limbTransformations
+	segptr_t skinVertices;         // SkinVertex*
+	segptr_t limbTransformations;  // SkinTransformation*
 
 	std::vector<SkinVertex> skinVertices_arr;
 	std::vector<SkinTransformation> limbTransformations_arr;
@@ -102,9 +102,9 @@ public:
 
 protected:
 	uint16_t totalVtxCount;
-	uint16_t limbModifCount;	// Length of limbModifications
-	segptr_t limbModifications;	// SkinLimbModif*
-	segptr_t dlist;				// Gfx*
+	uint16_t limbModifCount;     // Length of limbModifications
+	segptr_t limbModifications;  // SkinLimbModif*
+	segptr_t dlist;              // Gfx*
 
 	std::vector<SkinLimbModif> limbModifications_arr;
 	// ZDisplayList* unk_8_dlist = nullptr;


### PR DESCRIPTION
forgot to include that in the previous PR, both games match on my side, both gists are updated ([oot](https://gist.github.com/Yanis42/b9c0480459b46d1b88d8efe1d341a881), [mm](https://gist.github.com/Yanis42/bfc87af02429fb98343c99cdcdbce8f0))