### PR TITLE
Add option to extract cutscene floats as hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ ZAPD also accepts the following list of extra parameters:
 - `-us` / `--unaccounted-static` : Mark unaccounted data as `static` 
 - `-s` / `--static` : Mark every asset as `static`.
   - This behaviour can be overridden per asset using `Static=` in the respective XML node.
+- `--cs-float` : How cutscene floats should be extracted. 
+- Valid values:
+  - `hex`
+  - `float`
+  - `both`
 - `-W...`: warning flags, see below
 
 Additionally, you can pass the flag `--version` to see the current ZAPD version. If that flag is passed, ZAPD will ignore any other parameter passed.

--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -16,6 +16,13 @@ enum class VerbosityLevel
 	VERBOSITY_DEBUG
 };
 
+enum class CsFloatType
+{
+	HexOnly,
+	FloatOnly,
+	HexAndFloat,
+};
+
 class Globals
 {
 public:
@@ -31,6 +38,7 @@ public:
 	ZFileMode fileMode;
 	fs::path baseRomPath, inputPath, outputPath, sourceOutputPath, cfgPath;
 	TextureType texType;
+	CsFloatType floatType = CsFloatType::FloatOnly;
 	ZGame game;
 	GameConfig cfg;
 	bool verboseUnaccounted = false;

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -36,6 +36,7 @@ void Arg_SetExporter(int& i, char* argv[]);
 void Arg_EnableGCCCompat(int& i, char* argv[]);
 void Arg_ForceStatic(int& i, char* argv[]);
 void Arg_ForceUnaccountedStatic(int& i, char* argv[]);
+void Arg_CsFloatMode(int& i, char* argv[]);
 
 int main(int argc, char* argv[]);
 
@@ -252,6 +253,7 @@ void ParseArgs(int& argc, char* argv[])
 		{"--static", &Arg_ForceStatic},
 		{"-us", &Arg_ForceUnaccountedStatic},
 		{"--unaccounted-static", &Arg_ForceUnaccountedStatic},
+		{"--cs-float", &Arg_CsFloatMode},
 	};
 
 	for (int32_t i = 2; i < argc; i++)
@@ -390,6 +392,36 @@ void Arg_ForceStatic([[maybe_unused]] int& i, [[maybe_unused]] char* argv[])
 void Arg_ForceUnaccountedStatic([[maybe_unused]] int& i, [[maybe_unused]] char* argv[])
 {
 	Globals::Instance->forceUnaccountedStatic = true;
+}
+
+void Arg_CsFloatMode([[maybe_unused]] int& i, [[maybe_unused]] char* argv[])
+{
+	i++;
+	if (std::strcmp(argv[i], "hex") == 0)
+	{
+		printf("HEX\n");
+		Globals::Instance->floatType = CsFloatType::HexOnly;
+	}
+	else if (std::strcmp(argv[i], "float") == 0)
+	{
+		printf("FLOAT\n");
+		Globals::Instance->floatType = CsFloatType::FloatOnly;
+	}
+	else if (std::strcmp(argv[i], "both") == 0)
+	{
+		printf("BOTH\n");
+		Globals::Instance->floatType = CsFloatType::HexAndFloat;
+	}
+	else
+	{
+		printf("ERR\n");
+		Globals::Instance->floatType = CsFloatType::FloatOnly;
+		HANDLE_WARNING(
+			WarningType::Always, "Invalid CS Float Type",
+			StringHelper::Sprintf("Invalid CS float type entered. Expected \"hex\", \"float\", or "
+		                          "\"both\". Got %s.\n Defaulting to \"float\".",
+		                          argv[i]));
+	}
 }
 
 int HandleExtract(ZFileMode fileMode, ExporterSet* exporterSet)

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -399,22 +399,18 @@ void Arg_CsFloatMode([[maybe_unused]] int& i, [[maybe_unused]] char* argv[])
 	i++;
 	if (std::strcmp(argv[i], "hex") == 0)
 	{
-		printf("HEX\n");
 		Globals::Instance->floatType = CsFloatType::HexOnly;
 	}
 	else if (std::strcmp(argv[i], "float") == 0)
 	{
-		printf("FLOAT\n");
 		Globals::Instance->floatType = CsFloatType::FloatOnly;
 	}
 	else if (std::strcmp(argv[i], "both") == 0)
 	{
-		printf("BOTH\n");
 		Globals::Instance->floatType = CsFloatType::HexAndFloat;
 	}
 	else
 	{
-		printf("ERR\n");
 		Globals::Instance->floatType = CsFloatType::FloatOnly;
 		HANDLE_WARNING(
 			WarningType::Always, "Invalid CS Float Type",

--- a/ZAPD/OtherStructs/CutsceneMM_Commands.cpp
+++ b/ZAPD/OtherStructs/CutsceneMM_Commands.cpp
@@ -6,6 +6,8 @@
 #include "Utils/StringHelper.h"
 #include "WarningHandler.h"
 
+#include "ZCutscene.h"
+
 /**** GENERIC ****/
 
 // Specific for command lists where each entry has size 8 bytes
@@ -556,22 +558,29 @@ CutsceneMMSubCommandEntry_ActorCue::CutsceneMMSubCommandEntry_ActorCue(
 std::string CutsceneMMSubCommandEntry_ActorCue::GetBodySourceCode() const
 {
 	EnumData* enumData = &Globals::Instance->cfg.enumData;
+	std::string normalXStr =
+		ZCutscene::GetCsEncodedFloat(normalX, Globals::Instance->floatType, true);
+	std::string normalYStr =
+		ZCutscene::GetCsEncodedFloat(normalY, Globals::Instance->floatType, true);
+	std::string normalZStr =
+		ZCutscene::GetCsEncodedFloat(normalZ, Globals::Instance->floatType, true);
 
 	if (static_cast<CutsceneMM_CommandType>(commandID) == CutsceneMM_CommandType::CS_CMD_PLAYER_CUE)
 	{
 		return StringHelper::Sprintf("CS_PLAYER_CUE(%s, %i, %i, 0x%04X, 0x%04X, 0x%04X, %i, %i, "
-		                             "%i, %i, %i, %i, %.8ef, %.8ef, %.8ef)",
+		                             "%i, %i, %i, %i, %s, %s, %s)",
 		                             enumData->playerCueId[base].c_str(), startFrame, endFrame,
 		                             rotX, rotY, rotZ, startPosX, startPosY, startPosZ, endPosX,
-		                             endPosY, endPosZ, normalX, normalY, normalZ);
+		                             endPosY, endPosZ, normalXStr.c_str(), normalYStr.c_str(),
+		                             normalZStr.c_str());
 	}
 	else
 	{
 		return StringHelper::Sprintf("CS_ACTOR_CUE(%i, %i, %i, 0x%04X, 0x%04X, 0x%04X, %i, %i, "
-		                             "%i, %i, %i, %i, %.8ef, %.8ef, %.8ef)",
+		                             "%i, %i, %i, %i, %s, %s, %s)",
 		                             base, startFrame, endFrame, rotX, rotY, rotZ, startPosX,
-		                             startPosY, startPosZ, endPosX, endPosY, endPosZ, normalX,
-		                             normalY, normalZ);
+		                             startPosY, startPosZ, endPosX, endPosY, endPosZ,
+		                             normalXStr.c_str(), normalYStr.c_str(), normalZStr.c_str());
 	}
 }
 

--- a/ZAPD/OtherStructs/CutsceneOoT_Commands.cpp
+++ b/ZAPD/OtherStructs/CutsceneOoT_Commands.cpp
@@ -6,6 +6,8 @@
 #include "Utils/BitConverter.h"
 #include "Utils/StringHelper.h"
 
+#include "ZCutscene.h"
+
 /**** GENERIC ****/
 
 // Specific for command lists where each entry has size 0x30 bytes
@@ -139,9 +141,11 @@ std::string CutsceneOoTCommand_CameraPoint::GetBodySourceCode() const
 	if (continueFlag != 0)
 		continueMacro = "CS_CAM_STOP";
 
-	return StringHelper::Sprintf("CS_CAM_POINT(%s, 0x%02X, %i, %ff, %i, %i, %i, 0x%04X)",
-	                             continueMacro.c_str(), cameraRoll, nextPointFrame, viewAngle, posX,
-	                             posY, posZ, unused);
+	return StringHelper::Sprintf(
+		"CS_CAM_POINT(%s, 0x%02X, %i, %s, %i, %i, %i, 0x%04X)", continueMacro.c_str(), cameraRoll,
+		nextPointFrame,
+		ZCutscene::GetCsEncodedFloat(viewAngle, Globals::Instance->floatType, false).c_str(), posX,
+		posY, posZ, unused);
 }
 
 size_t CutsceneOoTCommand_CameraPoint::GetRawSize() const
@@ -334,27 +338,34 @@ CutsceneOoTSubCommandEntry_ActorCue::CutsceneOoTSubCommandEntry_ActorCue(
 	normalY = BitConverter::ToFloatBE(rawData, rawDataIndex + 0x28);
 	normalZ = BitConverter::ToFloatBE(rawData, rawDataIndex + 0x2C);
 }
-
 std::string CutsceneOoTSubCommandEntry_ActorCue::GetBodySourceCode() const
 {
 	EnumData* enumData = &Globals::Instance->cfg.enumData;
+
+	std::string normalXStr =
+		ZCutscene::GetCsEncodedFloat(normalX, Globals::Instance->floatType, true);
+	std::string normalYStr =
+		ZCutscene::GetCsEncodedFloat(normalY, Globals::Instance->floatType, true);
+	std::string normalZStr =
+		ZCutscene::GetCsEncodedFloat(normalZ, Globals::Instance->floatType, true);
 
 	if (static_cast<CutsceneOoT_CommandType>(commandID) ==
 	    CutsceneOoT_CommandType::CS_CMD_PLAYER_CUE)
 	{
 		return StringHelper::Sprintf("CS_PLAYER_CUE(%s, %i, %i, 0x%04X, 0x%04X, 0x%04X, %i, %i, "
-		                             "%i, %i, %i, %i, %.8ef, %.8ef, %.8ef)",
+		                             "%i, %i, %i, %i, %s, %s, %s)",
 		                             enumData->playerCueId[base].c_str(), startFrame, endFrame,
 		                             rotX, rotY, rotZ, startPosX, startPosY, startPosZ, endPosX,
-		                             endPosY, endPosZ, normalX, normalY, normalZ);
+		                             endPosY, endPosZ, normalXStr.c_str(), normalYStr.c_str(),
+		                             normalZStr.c_str());
 	}
 	else
 	{
 		return StringHelper::Sprintf("CS_ACTOR_CUE(%i, %i, %i, 0x%04X, 0x%04X, 0x%04X, %i, %i, "
-		                             "%i, %i, %i, %i, %.8ef, %.8ef, %.8ef)",
+		                             "%i, %i, %i, %i, %s, %s, %s)",
 		                             base, startFrame, endFrame, rotX, rotY, rotZ, startPosX,
-		                             startPosY, startPosZ, endPosX, endPosY, endPosZ, normalX,
-		                             normalY, normalZ);
+		                             startPosY, startPosZ, endPosX, endPosY, endPosZ,
+		                             normalXStr.c_str(), normalYStr.c_str(), normalZStr.c_str());
 	}
 }
 

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -377,6 +377,8 @@ std::string ZCutscene::GetCsEncodedFloat(float f, CsFloatType type, bool useSciN
 {
 	switch (type)
 	{
+	default:
+	// This default case will NEVER be reached, but GCC still gives a warning.
 	case CsFloatType::HexOnly:
 	{
 		uint32_t i;

--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -372,3 +372,34 @@ ZResourceType ZCutscene::GetResourceType() const
 {
 	return ZResourceType::Cutscene;
 }
+
+std::string ZCutscene::GetCsEncodedFloat(float f, CsFloatType type, bool useSciNotation)
+{
+	switch (type)
+	{
+	case CsFloatType::HexOnly:
+	{
+		uint32_t i;
+		std::memcpy(&i, &f, sizeof(i));
+		return StringHelper::Sprintf("0x%08X", i);
+	}
+	case CsFloatType::FloatOnly:
+	{
+		if (useSciNotation)
+		{
+			return StringHelper::Sprintf("%.8ef", f);
+		}
+		return StringHelper::Sprintf("%ff", f);
+	}
+	case CsFloatType::HexAndFloat:
+	{
+		uint32_t i;
+		std::memcpy(&i, &f, sizeof(i));
+		if (useSciNotation)
+		{
+			return StringHelper::Sprintf("CS_FLOAT(0x%08X, %.8ef)", i, f);
+		}
+		return StringHelper::Sprintf("CS_FLOAT(0x%08X, %ff)", i, f);
+	}
+	}
+}

--- a/ZAPD/ZCutscene.h
+++ b/ZAPD/ZCutscene.h
@@ -10,6 +10,8 @@
 #include "ZFile.h"
 #include "ZResource.h"
 
+enum class CsFloatType;
+
 class ZCutscene : public ZResource
 {
 public:
@@ -26,6 +28,8 @@ public:
 
 	std::string GetSourceTypeName() const override;
 	ZResourceType GetResourceType() const override;
+
+	static std::string GetCsEncodedFloat(float f, CsFloatType type, bool useSciNotation);
 
 	int32_t numCommands;
 	int32_t endFrame;


### PR DESCRIPTION
As the title says. `float` data in cutscene commands can be extracted as only hex, only float, or both. This removes the requirement to build assets with the asm-processor.
Related issues:
#316
zeldaret/oot#1719