### PR TITLE
Pass more arguments to OoT CS_LIGHT_SETTING

### DIFF
--- a/ZAPD/OtherStructs/CutsceneOoT_Commands.cpp
+++ b/ZAPD/OtherStructs/CutsceneOoT_Commands.cpp
@@ -15,7 +15,7 @@ const std::unordered_map<CutsceneOoT_CommandType, CsCommandListDescriptor> csCom
 	{CutsceneOoT_CommandType::CS_CMD_MISC,
      {"CS_MISC", "(%s, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i)"}},
 	{CutsceneOoT_CommandType::CS_CMD_LIGHT_SETTING,
-     {"CS_LIGHT_SETTING", "(0x%02X, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i)"}},
+     {"CS_LIGHT_SETTING", "(0x%02X, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i)"}},
 	{CutsceneOoT_CommandType::CS_CMD_START_SEQ,
      {"CS_START_SEQ", "(%s, %i, %i, %i, %i, %i, %i, %i, %i, %i, %i)"}},
 	{CutsceneOoT_CommandType::CS_CMD_STOP_SEQ,


### PR DESCRIPTION
For some unused cutscenes this data might not be 0 so it needs to be preserved for matching