### PR TITLE
Write numCommands instead of commands.size() in CS_BEGIN_CUTSCENE

### DIFF
--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -24,7 +24,7 @@ std::string ZCutscene::GetBodySourceCode() const
 {
 	std::string output = "";
 
-	output += StringHelper::Sprintf("    CS_BEGIN_CUTSCENE(%i, %i),\n", commands.size(), endFrame);
+	output += StringHelper::Sprintf("    CS_BEGIN_CUTSCENE(%i, %i),\n", numCommands, endFrame);
 
 	for (size_t i = 0; i < commands.size(); i++)
 	{
@@ -32,7 +32,7 @@ std::string ZCutscene::GetBodySourceCode() const
 		output += "    " + cmd->GenerateSourceCode();
 	}
 
-	output += StringHelper::Sprintf("    CS_END(),", commands.size(), endFrame);
+	output += StringHelper::Sprintf("    CS_END(),");
 
 	return output;
 }


### PR DESCRIPTION
These aren't the same for some unused cutscenes in OoT