### PR TITLE
Emit different keyframe skeleton struct based on limb type

### DIFF
--- a/ZAPD/ZCKeyFrame.cpp
+++ b/ZAPD/ZCKeyFrame.cpp
@@ -130,7 +130,17 @@ size_t ZKeyFrameSkel::GetRawDataSize() const
 
 std::string ZKeyFrameSkel::GetSourceTypeName() const
 {
-	return "KeyFrameSkeleton";
+	switch (limbType)
+	{
+		case ZKeyframeSkelType::Normal:
+			return "KeyFrameSkeleton";
+
+		case ZKeyframeSkelType::Flex:
+			return "KeyFrameFlexSkeleton";
+
+		default:
+			return "KeyFrameSkeleton";
+	}
 }
 
 ZResourceType ZKeyFrameSkel::GetResourceType() const


### PR DESCRIPTION
MM main currently splits `KeyFrameSkeleton` and `KeyFrameFlexSkeleton` with different pointer types to the limbs. This changes keyframe extraction to choose the correct struct based on limb type specified.