### PR TITLE
rename CS_BEGIN_CUTSCENE and CS_END

### DIFF
--- a/ZAPD/ZCutscene.cpp
+++ b/ZAPD/ZCutscene.cpp
@@ -24,7 +24,7 @@ std::string ZCutscene::GetBodySourceCode() const
 {
 	std::string output = "";
 
-	output += StringHelper::Sprintf("    CS_BEGIN_CUTSCENE(%i, %i),\n", numCommands, endFrame);
+	output += StringHelper::Sprintf("    CS_HEADER(%i, %i),\n", numCommands, endFrame);
 
 	for (size_t i = 0; i < commands.size(); i++)
 	{
@@ -32,7 +32,7 @@ std::string ZCutscene::GetBodySourceCode() const
 		output += "    " + cmd->GenerateSourceCode();
 	}
 
-	output += StringHelper::Sprintf("    CS_END(),");
+	output += StringHelper::Sprintf("    CS_END_OF_SCRIPT(),");
 
 	return output;
 }


### PR DESCRIPTION
Opening as draft pending concurrence between MM and OoT projects. Ref: https://github.com/zeldaret/oot/pull/2311

Change `CS_BEGIN_CUTSCENE` and `CS_END` macros to `CS_HEADER` and `CS_END_OF_SCRIPT`, respectively. Previous names could be misinterpreted as controlling cutscene behavior when they are only used internally by the cutscene script parser.