### PR TITLE
Add support for skybox settings, sound settings and room behavior enums values

### DIFF
--- a/ZAPD/GameConfig.cpp
+++ b/ZAPD/GameConfig.cpp
@@ -223,6 +223,27 @@ void GameConfig::ConfigFunc_EnumData(const tinyxml2::XMLElement& element)
 			else if (enumKey == "playerCueId")
 				enumData.playerCueId[itemIndex] = itemID;
 
+			else if (enumKey == "ambienceId")
+				enumData.ambienceId[itemIndex] = itemID;
+
+			else if (enumKey == "seqId")
+				enumData.seqId[itemIndex] = itemID;
+
+			else if (enumKey == "skyboxId")
+				enumData.skyboxId[itemIndex] = itemID;
+
+			else if (enumKey == "skyboxConfig")
+				enumData.skyboxConfig[itemIndex] = itemID;
+
+			else if (enumKey == "roomType")
+				enumData.roomType[itemIndex] = itemID;
+
+			else if (enumKey == "environmentType")
+				enumData.environmentType[itemIndex] = itemID;
+
+			else if (enumKey == "lensMode")
+				enumData.lensMode[itemIndex] = itemID;
+
 			// MM
 			else if (enumKey == "modifySeqType")
 				enumData.modifySeqType[itemIndex] = itemID;
@@ -247,6 +268,9 @@ void GameConfig::ConfigFunc_EnumData(const tinyxml2::XMLElement& element)
 
 			else if (enumKey == "endSfx")
 				enumData.endSfx[itemIndex] = itemID;
+
+			else if (enumKey == "stormState")
+				enumData.stormState[itemIndex] = itemID;
 
 			else if (enumKey == "csSplineInterpType")
 				enumData.interpType[itemIndex] = itemID;

--- a/ZAPD/GameConfig.h
+++ b/ZAPD/GameConfig.h
@@ -32,7 +32,13 @@ public:
 	std::map<uint16_t, std::string> transitionType;
 	std::map<uint16_t, std::string> naviQuestHintType;
 	std::map<uint16_t, std::string> ocarinaSongActionId;
+	std::map<uint16_t, std::string> ambienceId;
 	std::map<uint16_t, std::string> seqId;
+	std::map<uint16_t, std::string> skyboxId;
+	std::map<uint16_t, std::string> skyboxConfig;
+	std::map<uint16_t, std::string> roomType;
+	std::map<uint16_t, std::string> environmentType;
+	std::map<uint16_t, std::string> lensMode;
 
 	// OoT
 	std::map<uint16_t, std::string> textType;
@@ -48,6 +54,7 @@ public:
 	std::map<uint16_t, std::string> rumbleType;
 	std::map<uint8_t, std::string> spawnFlag;
 	std::map<uint8_t, std::string> endSfx;
+	std::map<uint8_t, std::string> stormState;
 	std::map<uint8_t, std::string> interpType;
 	std::map<uint16_t, std::string> relTo;
 };

--- a/ZAPD/ZRoom/Commands/SetRoomBehavior.cpp
+++ b/ZAPD/ZRoom/Commands/SetRoomBehavior.cpp
@@ -26,17 +26,25 @@ void SetRoomBehavior::ParseRawData()
 
 std::string SetRoomBehavior::GetBodySourceCode() const
 {
+	EnumData* enumData = &Globals::Instance->cfg.enumData;
+
 	if (Globals::Instance->game == ZGame::MM_RETAIL)
 	{
 		std::string enableLights = StringHelper::BoolStr(enablePosLights);
-		return StringHelper::Sprintf("SCENE_CMD_ROOM_BEHAVIOR(0x%02X, 0x%02X, %i, %i, %s, %i)",
-		                             gameplayFlags, currRoomUnk2, currRoomUnk5, msgCtxUnk,
-		                             enableLights.c_str(), kankyoContextUnkE2);
+		return StringHelper::Sprintf("SCENE_CMD_ROOM_BEHAVIOR(%s, %s, %s, %i, %s, %s)",
+		                             enumData->roomType[gameplayFlags].c_str(),
+		                             enumData->environmentType[currRoomUnk2].c_str(),
+		                             enumData->lensMode[currRoomUnk5].c_str(), msgCtxUnk,
+		                             enableLights.c_str(),
+		                             enumData->stormState[kankyoContextUnkE2].c_str());
 	}
-	std::string showInvisible = StringHelper::BoolStr(showInvisActors);
+
 	std::string disableWarps = StringHelper::BoolStr(msgCtxUnk);
-	return StringHelper::Sprintf("SCENE_CMD_ROOM_BEHAVIOR(0x%02X, 0x%02X, %s, %s)", gameplayFlags,
-	                             currRoomUnk2, showInvisible.c_str(), disableWarps.c_str());
+
+	return StringHelper::Sprintf("SCENE_CMD_ROOM_BEHAVIOR(%s, %s, %s, %s)",
+	                             enumData->roomType[gameplayFlags].c_str(),
+	                             enumData->environmentType[currRoomUnk2].c_str(),
+	                             enumData->lensMode[showInvisActors].c_str(), disableWarps.c_str());
 }
 
 std::string SetRoomBehavior::GetCommandCName() const

--- a/ZAPD/ZRoom/Commands/SetSkyboxSettings.cpp
+++ b/ZAPD/ZRoom/Commands/SetSkyboxSettings.cpp
@@ -17,12 +17,17 @@ void SetSkyboxSettings::ParseRawData()
 
 std::string SetSkyboxSettings::GetBodySourceCode() const
 {
+	EnumData* enumData = &Globals::Instance->cfg.enumData;
 	std::string indoors = StringHelper::BoolStr(isIndoors);
+
 	if (Globals::Instance->game == ZGame::MM_RETAIL)
-		return StringHelper::Sprintf("SCENE_CMD_SKYBOX_SETTINGS(0x%02X, %i, %i, %s)", unk1,
-		                             skyboxNumber, cloudsType, indoors.c_str());
-	return StringHelper::Sprintf("SCENE_CMD_SKYBOX_SETTINGS(%i, %i, %s)", skyboxNumber, cloudsType,
-	                             indoors.c_str());
+		return StringHelper::Sprintf("SCENE_CMD_SKYBOX_SETTINGS(0x%02X, %s, %s, %s)", unk1,
+		                             enumData->skyboxId[skyboxNumber].c_str(),
+		                             enumData->skyboxConfig[cloudsType].c_str(), indoors.c_str());
+
+	return StringHelper::Sprintf("SCENE_CMD_SKYBOX_SETTINGS(%s, %s, %s)",
+	                             enumData->skyboxId[skyboxNumber].c_str(),
+	                             enumData->skyboxConfig[cloudsType].c_str(), indoors.c_str());
 }
 
 std::string SetSkyboxSettings::GetCommandCName() const

--- a/ZAPD/ZRoom/Commands/SetSoundSettings.cpp
+++ b/ZAPD/ZRoom/Commands/SetSoundSettings.cpp
@@ -1,3 +1,4 @@
+#include "Globals.h"
 #include "SetSoundSettings.h"
 #include "Utils/StringHelper.h"
 
@@ -15,8 +16,11 @@ void SetSoundSettings::ParseRawData()
 
 std::string SetSoundSettings::GetBodySourceCode() const
 {
-	return StringHelper::Sprintf("SCENE_CMD_SOUND_SETTINGS(%i, %i, %i)", reverb, nightTimeSFX,
-	                             musicSequence);
+	EnumData* enumData = &Globals::Instance->cfg.enumData;
+
+	return StringHelper::Sprintf("SCENE_CMD_SOUND_SETTINGS(%i, %s, %s)", reverb,
+	                             enumData->ambienceId[nightTimeSFX].c_str(),
+	                             enumData->seqId[musicSequence].c_str());
 }
 
 std::string SetSoundSettings::GetCommandCName() const


### PR DESCRIPTION
this adds support for the different values of skybox settings, sound settings and room behavior commands, builds OK for both games (note: on OoT the `SkyboxConfig` enum doesn't exist but I decided to add the values in the xml data instead, this way whenever this is documented ZAPD won't need an extra update there)

I'm not sure if a ZAPD update is planned on both repos so I was thinking of opening PRs to add the new enums in the xml, though let me know if it's fine to make the update in code too

---
oot: https://github.com/Yanis002/oot/tree/more_enums
mm: https://github.com/Yanis002/mm/tree/more_enums