### PR TITLE
Use address instead of offset to detect unaligned textures

### DIFF
--- a/ZAPD/ZTexture.cpp
+++ b/ZAPD/ZTexture.cpp
@@ -131,7 +131,7 @@ void ZTexture::ParseXML(tinyxml2::XMLElement* reader)
 
 void ZTexture::ParseRawData()
 {
-	if (rawDataIndex % 8 != 0)
+	if ((parent->baseAddress + rawDataIndex) % 8 != 0)
 		dWordAligned = false;
 
 	switch (format)


### PR DESCRIPTION
OoT iQue ovl_En_Mag contains a texture at offset 0x5C from the data section, but it's at offset 0x0 from the part of the file we actually want to extract (note that since #322 we specify offsets from the start of the assets, not the start of the file). ZAPD currently thinks this texture should use `u64` instead of `u32`.